### PR TITLE
Remove 'fork' method and use 'from' as an implicit fork call.

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -172,7 +172,6 @@ func (a *AlertNode) runAlert() error {
 			}
 		}
 	}
-	a.logger.Println("I! alert node done")
 	return nil
 }
 
@@ -279,7 +278,6 @@ func (a *AlertNode) handleLog(ad AlertData) {
 	if n != 1 || err != nil {
 		a.logger.Println("E! failed to write to file", err)
 	}
-	a.logger.Println("I! handled Log")
 }
 
 func (a *AlertNode) handleExec(ad AlertData) {

--- a/expr.go
+++ b/expr.go
@@ -20,16 +20,16 @@ func EvalPredicate(se *tick.StatefulExpr, fields models.Fields, tags map[string]
 	return b, nil
 }
 
-func mergeFieldsAndTags(fields models.Fields, tags map[string]string) (tick.Vars, error) {
-	vars := make(tick.Vars)
+func mergeFieldsAndTags(fields models.Fields, tags map[string]string) (*tick.Scope, error) {
+	scope := tick.NewScope()
 	for k, v := range fields {
 		if _, ok := tags[k]; ok {
 			return nil, fmt.Errorf("cannot have field and tags with same name %q", k)
 		}
-		vars[k] = v
+		scope.Set(k, v)
 	}
 	for k, v := range tags {
-		vars[k] = v
+		scope.Set(k, v)
 	}
-	return vars, nil
+	return scope, nil
 }

--- a/http_out.go
+++ b/http_out.go
@@ -118,6 +118,7 @@ func (h *HTTPOutNode) updateResultWithBatch(b models.Batch) {
 		h.result.Series[idx] = row
 	}
 }
+
 func (h *HTTPOutNode) stopOut() {
 	h.et.tm.HTTPDService.DelRoutes(h.routes)
 }

--- a/integrations/batcher_test.go
+++ b/integrations/batcher_test.go
@@ -105,7 +105,7 @@ func testBatcher(t *testing.T, name, script string) (clock.Setter, *kapacitor.Ex
 	}
 
 	// Create task
-	task, err := kapacitor.NewBatcher(name, script)
+	task, err := kapacitor.NewBatcher(name, script, dbrps)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -22,6 +22,13 @@ import (
 
 var httpService *httpd.Service
 
+var dbrps = []kapacitor.DBRP{
+	{
+		Database:        "dbname",
+		RetentionPolicy: "rpname",
+	},
+}
+
 func init() {
 	wlog.LogLevel = wlog.OFF
 	// create API server
@@ -249,7 +256,6 @@ func TestStream_Join(t *testing.T) {
 
 	var script = `
 var errorCounts = stream
-			.fork()
 			.from('errors')
 			.groupBy('service')
 			.window()
@@ -258,7 +264,6 @@ var errorCounts = stream
 			.mapReduce(influxql.sum('value'))
 
 var viewCounts = stream
-			.fork()
 			.from('views')
 			.groupBy('service')
 			.window()
@@ -348,15 +353,12 @@ func TestStream_Union(t *testing.T) {
 
 	var script = `
 var cpu = stream
-			.fork()
 			.from('cpu')
 			.where(lambda: "cpu" == 'total')
 var mem = stream
-			.fork()
 			.from('memory')
 			.where(lambda: "type" == 'free')
 var disk = stream
-			.fork()
 			.from('disk')
 			.where(lambda: "device" == 'sda')
 
@@ -1028,7 +1030,7 @@ func testStreamer(t *testing.T, name, script string) (clock.Setter, *kapacitor.E
 	}
 
 	//Create the task
-	task, err := kapacitor.NewStreamer(name, script)
+	task, err := kapacitor.NewStreamer(name, script, dbrps)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node.go
+++ b/node.go
@@ -3,11 +3,9 @@ package kapacitor
 import (
 	"fmt"
 	"log"
-	"os"
 	"runtime"
 
 	"github.com/influxdb/kapacitor/pipeline"
-	"github.com/influxdb/kapacitor/wlog"
 )
 
 // A node that can be  in an executor.
@@ -19,6 +17,9 @@ type Node interface {
 	// start the node and its children
 	start()
 	stop()
+
+	// set the logger
+	setLogger(logger *log.Logger)
 
 	// wait for the node to finish processing and return any errors
 	Err() error
@@ -55,8 +56,11 @@ func (n *node) closeParentEdges() {
 	}
 }
 
+func (n *node) setLogger(l *log.Logger) {
+	n.logger = l
+}
+
 func (n *node) start() {
-	n.logger = wlog.New(os.Stderr, fmt.Sprintf("[%s] ", n.Name()), log.LstdFlags)
 	n.errCh = make(chan error, 1)
 	go func() {
 		var err error

--- a/pipeline/join.go
+++ b/pipeline/join.go
@@ -6,8 +6,8 @@ package pipeline
 // Aliases are used to prefix all fields from the respective nodes.
 //
 // Example:
-//    var errors = stream.fork().from('errors')
-//    var requests = stream.fork().from('requests')
+//    var errors = stream.from('errors')
+//    var requests = stream.from('requests')
 //    // Join the errors and requests streams
 //    errors.join(requests)
 //            // Provide prefix names for the fields of the data points.

--- a/pipeline/union.go
+++ b/pipeline/union.go
@@ -6,9 +6,9 @@ package pipeline
 // without modification.
 //
 // Example:
-//    var logins = stream.fork().from('logins')
-//    var logouts = stream.fork().from('logouts')
-//    var frontpage = stream.fork().from('frontpage')
+//    var logins = stream.from('logins')
+//    var logouts = stream.from('logouts')
+//    var frontpage = stream.from('frontpage')
 //    // Union all user actions into a single stream
 //    logins.union(logouts, frontpage)
 //            .rename('user_actions')

--- a/query.go
+++ b/query.go
@@ -61,6 +61,22 @@ func NewQuery(q string) (*Query, error) {
 	return query, nil
 }
 
+// Return the db rp pairs of the query
+func (q *Query) DBRPs() ([]DBRP, error) {
+	dbrps := make([]DBRP, len(q.q.Sources))
+	for i, s := range q.q.Sources {
+		m, ok := s.(*influxql.Measurement)
+		if !ok {
+			return nil, fmt.Errorf("unknown query source %T", s)
+		}
+		dbrps[i] = DBRP{
+			Database:        m.Database,
+			RetentionPolicy: m.RetentionPolicy,
+		}
+	}
+	return dbrps, nil
+}
+
 // Set the start time of the query
 func (q *Query) Start(s time.Time) {
 	q.startTL.Val = s

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -179,7 +179,7 @@ func (h *Handler) DelRoutes(routes []Route) {
 func (h *Handler) DelRoute(r Route) {
 	mux, ok := h.methodMux[r.Method]
 	if ok {
-		mux.Deregister(r.Pattern)
+		mux.Deregister(APIRoot + r.Pattern)
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -26,10 +26,10 @@ func newStreamNode(et *ExecutingTask, n *pipeline.StreamNode) (*StreamNode, erro
 	}
 	sn.node.runF = sn.runStream
 	var err error
-	if sn.s.From != "" {
-		sn.db, sn.rp, sn.name, err = parseFromClause(sn.s.From)
+	if sn.s.FromSelector != "" {
+		sn.db, sn.rp, sn.name, err = parseFromClause(sn.s.FromSelector)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing FROM clause %q %v", sn.s.From, err)
+			return nil, fmt.Errorf("error parsing FROM clause %q %v", sn.s.FromSelector, err)
 		}
 	}
 	if n.Expression != nil {

--- a/tick/eval.go
+++ b/tick/eval.go
@@ -194,7 +194,7 @@ func evalFunc(f *FunctionNode, scope *Scope, stck *stack, args []reflect.Value) 
 		e := recover()
 		if e != nil {
 			*errp = fmt.Errorf("error calling func %q on obj %T: %v", f.Func, obj, e)
-			if strings.Contains((*errp).Error(), "value of type *tick.ReferenceNode is not assignable to type string") {
+			if strings.Contains((*errp).Error(), "*tick.ReferenceNode") && strings.Contains((*errp).Error(), "type string") {
 				*errp = fmt.Errorf("cannot assign *tick.ReferenceNode to type string, did you use double quotes instead of single quotes?")
 			}
 

--- a/tick/scope.go
+++ b/tick/scope.go
@@ -26,5 +26,5 @@ func (s *Scope) Get(name string) (interface{}, error) {
 	if v, ok := s.variables[name]; ok {
 		return v, nil
 	}
-	return nil, fmt.Errorf("name %s is undefined", name)
+	return nil, fmt.Errorf("name %q is undefined", name)
 }


### PR DESCRIPTION
With this change tasks (stream and batch) are now scoped to their defined DBRP pairs. 

Stream taskd will not be able to receive anything outside of their scope.
Batch tasks will not be able to query any other DBs or RPs.
