### PR TITLE
Adds reporting service for sending stats to Enterprise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*.swp
 dist/*
 /build/*
+/kapacitor.conf
 kapacitor_linux*
 kapacitord_linux*
 *~

--- a/cmd/kapacitord/run/config.go
+++ b/cmd/kapacitord/run/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdb/kapacitor/services/influxdb"
 	"github.com/influxdb/kapacitor/services/logging"
 	"github.com/influxdb/kapacitor/services/replay"
+	"github.com/influxdb/kapacitor/services/reporting"
 	"github.com/influxdb/kapacitor/services/smtp"
 	"github.com/influxdb/kapacitor/services/task_store"
 	"github.com/influxdb/kapacitor/services/udp"
@@ -29,18 +30,18 @@ type Config struct {
 	Replay   replay.Config     `toml:"replay"`
 	Task     task_store.Config `toml:"task"`
 	InfluxDB influxdb.Config   `toml:"influxdb"`
-	Logging  logging.Config
+	Logging  logging.Config    `toml:"logging"`
 
 	Graphites []graphite.Config `toml:"graphite"`
 	Collectd  collectd.Config   `toml:"collectd"`
 	OpenTSDB  opentsdb.Config   `toml:"opentsdb"`
 	UDPs      []udp.Config      `toml:"udp"`
 	SMTP      smtp.Config       `toml:"smtp"`
+	Reporting reporting.Config  `toml:"reporting"`
 
 	Hostname string `toml:"hostname"`
-
-	// Server reporting
-	ReportingDisabled bool `toml:"reporting-disabled"`
+	DataDir  string `toml:"data_dir"`
+	Token    string `toml:"token"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.
@@ -57,6 +58,7 @@ func NewConfig() *Config {
 	c.Collectd = collectd.NewConfig()
 	c.OpenTSDB = opentsdb.NewConfig()
 	c.SMTP = smtp.NewConfig()
+	c.Reporting = reporting.NewConfig()
 
 	return c
 }
@@ -79,6 +81,7 @@ func NewDemoConfig() (*Config, error) {
 	c.Replay.Dir = filepath.Join(homeDir, ".kapacitor", c.Replay.Dir)
 	c.Task.Dir = filepath.Join(homeDir, ".kapacitor", c.Task.Dir)
 
+	c.DataDir = filepath.Join(homeDir, ".kapacitor", c.DataDir)
 	return c, nil
 }
 
@@ -86,6 +89,9 @@ func NewDemoConfig() (*Config, error) {
 func (c *Config) Validate() error {
 	if c.Hostname == "" {
 		return fmt.Errorf("must configure valid hostname")
+	}
+	if c.DataDir == "" {
+		return fmt.Errorf("must configure valid data dir")
 	}
 	err := c.Replay.Validate()
 	if err != nil {

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -1,13 +1,20 @@
 # The hostname of this node.
 # Must be resolvable by any configured InfluxDB hosts.
 hostname = "localhost"
-reporting-disabled = false
+# Directory for storing a small amount of metadata about the server.
+data_dir = "/var/lib/kapacitor"
+# Your Enterprise token. By using Enterprise you can
+# send all internal statistics to the Enterprise
+# endpoints which will store and report on the
+# activity of your instances.
+token = ""
 
 [http]
   # HTTP API Server for Kapacitor
   # This server is always on,
-  # it servers both a write endpoint
-  # and all other Kapacitor API calls
+  # it servers both as a write endpoint
+  # and as the API endpoint for all other
+  # Kapacitor calls.
   bind-address = ":9092"
   auth-enabled = false
   log-enabled = true
@@ -18,14 +25,14 @@ reporting-disabled = false
 
 [logging]
     # Destination for logs
-    # Can be a path to a file or STDOUT, STDERR
+    # Can be a path to a file or 'STDOUT', 'STDERR'.
     file = "/var/log/kapacitor/kapacitor.log"
     # Logging level can be one of:
     # DEBUG, INFO, WARN, ERROR, or OFF
     level = "INFO"
 
 [replay]
-  # Where to store replay files
+  # Where to store replay files, aka recordings.
   dir = "/var/lib/kapacitor/replay"
 
 [task]
@@ -35,7 +42,7 @@ reporting-disabled = false
 [influxdb]
   # Connect to an InfluxDB cluster
   # Kapacitor can subscribe, query and write to this cluster.
-  # Not required.
+  # Using InfluxDB is not required and can be disabled.
   enabled = true
   urls = ["http://localhost:8086"]
   username = ""
@@ -49,7 +56,7 @@ reporting-disabled = false
     # db_name = <list of retention policies>
     #
     # Example:
-    my_database = [ "default", "longterm" ]
+    # my_database = [ "default", "longterm" ]
 
 [smtp]
   # Configure an SMTP email server
@@ -63,7 +70,16 @@ reporting-disabled = false
   # Close idle connections after timeout
   idle-timeout = "30s"
 
-
+[reporting]
+  # Send anonymous usage statistics
+  # every 12 hours to Enterprise.
+  enabled = true
+  enterprise-url = "https://enterprise.influxdata.com"
+  # The interval at which to send all
+  # internal statistics to Enterprise.
+  # If no token is specified this
+  # setting has no effect.
+  stats-interval = "1m0s"
 
 ##################################
 # Input Methods, same as InfluxDB

--- a/services/influxdb/config.go
+++ b/services/influxdb/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Config struct {
-	Enabled       bool
+	Enabled       bool                `toml:"enabled"`
 	URLs          []string            `toml:"urls"`
 	Username      string              `toml:"username"`
 	Password      string              `toml:"password"`

--- a/services/reporting/config.go
+++ b/services/reporting/config.go
@@ -1,0 +1,22 @@
+package reporting
+
+import (
+	"time"
+
+	"github.com/influxdb/enterprise-client/v1"
+	"github.com/influxdb/influxdb/toml"
+)
+
+type Config struct {
+	Enabled       bool          `toml:"enabled"`
+	EnterpriseURL string        `toml:"enterprise-url"`
+	StatsInterval toml.Duration `toml:"stats-interval"`
+}
+
+func NewConfig() Config {
+	return Config{
+		Enabled:       true,
+		EnterpriseURL: client.URL,
+		StatsInterval: toml.Duration(time.Minute),
+	}
+}

--- a/services/reporting/service.go
+++ b/services/reporting/service.go
@@ -1,0 +1,313 @@
+// Sends anonymous reports to InfluxData
+package reporting
+
+import (
+	"expvar"
+	"log"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/influxdb/enterprise-client/v1"
+	"github.com/influxdb/kapacitor"
+)
+
+const reportingInterval = time.Hour * 12
+
+// Sends periodic information to Enterprise.
+// If not registered with Enterprise just
+// registers the server on startup and sends anonymous
+// stats every 12 hours.
+//
+// If registered with Enterprise also sends
+// all expvar statistics at the Config.StatsInterval.
+type Service struct {
+	tags client.Tags
+
+	client *client.Client
+
+	clusterID string
+	serverID  string
+	hostname  string
+	version   string
+	product   string
+
+	statsInterval time.Duration
+	statsTicker   *time.Ticker
+	usageTicker   *time.Ticker
+	closing       chan struct{}
+	logger        *log.Logger
+	wg            sync.WaitGroup
+}
+
+func NewService(c Config, token string, l *log.Logger) *Service {
+	client := client.New(token)
+	client.URL = c.EnterpriseURL
+	return &Service{
+		client:        client,
+		logger:        l,
+		statsInterval: time.Duration(c.StatsInterval),
+	}
+}
+
+func (s *Service) Open() error {
+	if s.closing == nil {
+		s.closing = make(chan struct{})
+	}
+
+	// Populate published vars
+	s.clusterID = kapacitor.GetStringVar(kapacitor.ClusterIDVarName)
+	s.serverID = kapacitor.GetStringVar(kapacitor.ServerIDVarName)
+	s.hostname = kapacitor.GetStringVar(kapacitor.HostVarName)
+	s.version = kapacitor.GetStringVar(kapacitor.VersionVarName)
+	s.product = kapacitor.Product
+
+	// Populate anonymous tags
+	s.tags = make(client.Tags)
+	s.tags["version"] = s.version
+	s.tags["arch"] = runtime.GOARCH
+	s.tags["os"] = runtime.GOOS
+
+	// Check for enterprise token
+	if s.client.Token == "" {
+		r := client.Registration{
+			ClusterID: s.clusterID,
+			Product:   s.product,
+		}
+		u, _ := s.client.RegistrationURL(r)
+		s.logger.Println("E! No Enterprise token configured, please register at", u)
+	} else {
+		// Send periodic stats
+		s.statsTicker = time.NewTicker(s.statsInterval)
+		s.wg.Add(1)
+		go s.stats()
+	}
+
+	// Register server on startup
+	err := s.registerServer()
+	if err != nil {
+		s.logger.Println("E! error registering server:", err)
+	}
+
+	// Send anonymous usage stats on startup
+	s.usageTicker = time.NewTicker(reportingInterval)
+	err = s.sendUsageReport()
+	if err != nil {
+		s.logger.Println("E! error sending usage stats:", err)
+	}
+
+	// Send periodic anonymous usage stats
+	s.wg.Add(1)
+	go s.usage()
+	return nil
+}
+
+func (s *Service) Close() error {
+	if s.usageTicker != nil {
+		s.usageTicker.Stop()
+	}
+	if s.statsTicker != nil {
+		s.statsTicker.Stop()
+	}
+	if s.closing != nil {
+		close(s.closing)
+	}
+	s.wg.Wait()
+	return nil
+}
+
+func (s *Service) usage() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.closing:
+			return
+		case <-s.usageTicker.C:
+			err := s.sendUsageReport()
+			if err != nil {
+				s.logger.Println("E! error while sending usage report:", err)
+			}
+		}
+	}
+}
+
+func (s *Service) stats() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.closing:
+			return
+		case <-s.statsTicker.C:
+			err := s.sendStatsReport()
+			if err != nil {
+				s.logger.Println("E! error while sending stats report:", err)
+			}
+		}
+	}
+}
+
+// Register this server with Enterprise.
+func (s *Service) registerServer() error {
+	server := client.Server{
+		ClusterID: s.clusterID,
+		ServerID:  s.serverID,
+		Host:      s.hostname,
+		Version:   s.version,
+		Product:   s.product,
+	}
+	_, err := s.client.Save(server)
+	return err
+}
+
+// Send anonymous usage report.
+func (s *Service) sendUsageReport() error {
+	data := client.UsageData{
+		Tags:   s.tags,
+		Values: make(client.Values),
+	}
+	// Add values
+	data.Values[kapacitor.ClusterIDVarName] = s.clusterID
+	data.Values[kapacitor.ServerIDVarName] = s.serverID
+	data.Values[kapacitor.NumTasksVarName] = kapacitor.GetIntVar(kapacitor.NumTasksVarName)
+	data.Values[kapacitor.NumEnabledTasksVarName] = kapacitor.GetIntVar(kapacitor.NumEnabledTasksVarName)
+	data.Values[kapacitor.NumSubscriptionsVarName] = kapacitor.GetIntVar(kapacitor.NumSubscriptionsVarName)
+
+	usage := client.Usage{
+		Product: kapacitor.Product,
+		Data:    []client.UsageData{data},
+	}
+
+	_, err := s.client.Save(usage)
+	return err
+}
+
+// Send all internal stats.
+func (s *Service) sendStatsReport() error {
+	data, err := s.getStatsData()
+	if err != nil {
+		return err
+	}
+	stats := client.Stats{
+		ClusterID: s.clusterID,
+		ServerID:  s.serverID,
+		Product:   s.product,
+		Data:      data,
+	}
+	_, err = s.client.Save(stats)
+
+	return err
+}
+
+// Return all stats data from the expvars.
+func (s *Service) getStatsData() ([]client.StatsData, error) {
+	allData := make([]client.StatsData, 0)
+	// Add Global expvars
+	globalData := client.StatsData{
+		Name:   "kapacitor",
+		Values: make(client.Values),
+	}
+
+	allData = append(allData, globalData)
+
+	expvar.Do(func(kv expvar.KeyValue) {
+		var f interface{}
+		var err error
+		switch v := kv.Value.(type) {
+		case *expvar.Float:
+			f, err = strconv.ParseFloat(v.String(), 64)
+			if err == nil {
+				globalData.Values[kv.Key] = f
+			}
+		case *expvar.Int:
+			f, err = strconv.ParseInt(v.String(), 10, 64)
+			if err == nil {
+				globalData.Values[kv.Key] = f
+			}
+		case *expvar.Map:
+			data := client.StatsData{
+				Tags:   make(client.Tags),
+				Values: make(client.Values),
+			}
+
+			v.Do(func(subKV expvar.KeyValue) {
+				switch subKV.Key {
+				case "name":
+					// straight to string name.
+					u, err := strconv.Unquote(subKV.Value.String())
+					if err != nil {
+						return
+					}
+					data.Name = u
+				case "tags":
+					// string-string tags map.
+					n := subKV.Value.(*expvar.Map)
+					n.Do(func(t expvar.KeyValue) {
+						u, err := strconv.Unquote(t.Value.String())
+						if err != nil {
+							return
+						}
+						data.Tags[t.Key] = u
+					})
+				case "values":
+					// string-interface map.
+					n := subKV.Value.(*expvar.Map)
+					n.Do(func(kv expvar.KeyValue) {
+						var f interface{}
+						var err error
+						switch v := kv.Value.(type) {
+						case *expvar.Float:
+							f, err = strconv.ParseFloat(v.String(), 64)
+							if err != nil {
+								return
+							}
+						case *expvar.Int:
+							f, err = strconv.ParseInt(v.String(), 10, 64)
+							if err != nil {
+								return
+							}
+						default:
+							return
+						}
+						data.Values[kv.Key] = f
+					})
+				}
+			})
+
+			// If a registered client has no field data, don't include it in the results
+			if len(data.Values) == 0 {
+				return
+			}
+
+			allData = append(allData, data)
+		}
+	})
+
+	// Add Go memstats.
+	data := client.StatsData{
+		Name: "runtime",
+	}
+
+	var rt runtime.MemStats
+	runtime.ReadMemStats(&rt)
+	data.Values = client.Values{
+		"Alloc":        int64(rt.Alloc),
+		"TotalAlloc":   int64(rt.TotalAlloc),
+		"Sys":          int64(rt.Sys),
+		"Lookups":      int64(rt.Lookups),
+		"Mallocs":      int64(rt.Mallocs),
+		"Frees":        int64(rt.Frees),
+		"HeapAlloc":    int64(rt.HeapAlloc),
+		"HeapSys":      int64(rt.HeapSys),
+		"HeapIdle":     int64(rt.HeapIdle),
+		"HeapInUse":    int64(rt.HeapInuse),
+		"HeapReleased": int64(rt.HeapReleased),
+		"HeapObjects":  int64(rt.HeapObjects),
+		"PauseTotalNs": int64(rt.PauseTotalNs),
+		"NumGC":        int64(rt.NumGC),
+		"NumGoroutine": int64(runtime.NumGoroutine()),
+	}
+	allData = append(allData, data)
+
+	return allData, nil
+}

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,62 @@
+package kapacitor
+
+import (
+	"expvar"
+	"strconv"
+)
+
+const (
+	// List of names for top-level exported vars
+	ClusterIDVarName = "cluster_id"
+	ServerIDVarName  = "server_id"
+	HostVarName      = "host"
+	ProductVarName   = "product"
+	VersionVarName   = "version"
+
+	NumTasksVarName         = "num_tasks"
+	NumEnabledTasksVarName  = "num_enabled_tasks"
+	NumSubscriptionsVarName = "num_subscriptions"
+
+	// The name of the product
+	Product = "kapacitor"
+)
+
+var (
+	// Global expvars
+	NumTasks         = &expvar.Int{}
+	NumEnabledTasks  = &expvar.Int{}
+	NumSubscriptions = &expvar.Int{}
+)
+
+func init() {
+	expvar.Publish(NumTasksVarName, NumTasks)
+	expvar.Publish(NumEnabledTasksVarName, NumEnabledTasks)
+	expvar.Publish(NumSubscriptionsVarName, NumSubscriptions)
+}
+
+// Gets an exported var and returns its unquoted string contents
+func GetStringVar(name string) string {
+	s, err := strconv.Unquote(expvar.Get(name).String())
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// Gets an exported var and returns its int value
+func GetIntVar(name string) int64 {
+	i, err := strconv.ParseInt(expvar.Get(name).String(), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+// Gets an exported var and returns its float value
+func GetFloatVar(name string) float64 {
+	f, err := strconv.ParseFloat(expvar.Get(name).String(), 64)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}


### PR DESCRIPTION
If the new reporting service is enabled (the default) then Kapacitor will:
- Always on startup hit the `/api/v1/servers` endpoint and register the current server with cluster and server IDs.
- Always send anon stats every 12hrs.

If a token is also configured then Kapacitor will also send all internal stats to Enterprise.
Both the Enterprise host and stats interval are configurable.

If no token is configured a message shows in the logs at startup with a link to register with Enterprise.

If the reporting service is disabled then none of this occurs.

@pauldix @markbates Did I get that right?
