### PR TITLE
Several Usability improvements:

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -135,7 +135,7 @@ func (a *AlertNode) runAlert() error {
 					Name:   p.Name,
 					Group:  p.Group,
 					Tags:   p.Tags,
-					Points: []models.TimeFields{{Time: p.Time, Fields: p.Fields}},
+					Points: []models.BatchPoint{models.BatchPointFromPoint(p)},
 				}
 
 				ad := AlertData{
@@ -151,7 +151,7 @@ func (a *AlertNode) runAlert() error {
 		for b, ok := a.ins[0].NextBatch(); ok; b, ok = a.ins[0].NextBatch() {
 			triggered := false
 			for _, p := range b.Points {
-				l := a.determineLevel(p.Fields, b.Tags)
+				l := a.determineLevel(p.Fields, p.Tags)
 				if l > NoAlert {
 					triggered = true
 					if a.a.UseFlapping {

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/influxdb/kapacitor"
 	"github.com/influxdb/kapacitor/services/replay"
+	"github.com/influxdb/kapacitor/services/task_store"
 )
 
 // These variables are populated via the Go linker.
@@ -618,29 +619,21 @@ func doShow(args []string) error {
 		return err
 	}
 	defer r.Body.Close()
-	// Decode valid response
-	type resp struct {
-		Error      string
-		Name       string
-		Type       kapacitor.TaskType
-		DBRPs      []kapacitor.DBRP
-		TICKscript string
-		Dot        string
-		Enabled    bool
-	}
 	d := json.NewDecoder(r.Body)
-	rp := resp{}
-	d.Decode(&rp)
-	if rp.Error != "" {
-		return errors.New(rp.Error)
+	ti := task_store.TaskInfo{}
+	d.Decode(&ti)
+
+	if ti.Name == "" && ti.Error != "" {
+		return errors.New(ti.Error)
 	}
 
-	fmt.Println("Name:", rp.Name)
-	fmt.Println("Type:", rp.Type)
-	fmt.Println("Enabled:", rp.Enabled)
-	fmt.Println("Databases Retention Policies:", rp.DBRPs)
-	fmt.Printf("TICKscript:\n%s\n\n", rp.TICKscript)
-	fmt.Printf("DOT:\n%s\n", rp.Dot)
+	fmt.Println("Name:", ti.Name)
+	fmt.Println("Error:", ti.Error)
+	fmt.Println("Type:", ti.Type)
+	fmt.Println("Enabled:", ti.Enabled)
+	fmt.Println("Databases Retention Policies:", ti.DBRPs)
+	fmt.Printf("TICKscript:\n%s\n\n", ti.TICKscript)
+	fmt.Printf("DOT:\n%s\n", ti.Dot)
 	return nil
 }
 

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -184,7 +184,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 }
 
 func (s *Server) appendTaskStoreService(c task_store.Config) {
-	l := s.LogService.NewLogger("[task] ", log.LstdFlags)
+	l := s.LogService.NewLogger("[task_store] ", log.LstdFlags)
 	srv := task_store.NewService(c, l)
 	srv.HTTPDService = s.HTTPDService
 	srv.TaskMaster = s.TaskMaster

--- a/group_by.go
+++ b/group_by.go
@@ -41,17 +41,11 @@ func (g *GroupByNode) runGroupBy() error {
 	switch g.Wants() {
 	case pipeline.StreamEdge:
 		for pt, ok := g.ins[0].NextPoint(); ok; pt, ok = g.ins[0].NextPoint() {
-			var tags map[string]string
 			if g.allDimensions {
-				tags = pt.Tags
-			} else {
-				tags = make(map[string]string, len(g.dimensions))
-				for _, dim := range g.dimensions {
-					tags[dim] = pt.Tags[dim]
-				}
+				g.dimensions = models.SortedKeys(pt.Tags)
 			}
-			pt.Tags = tags
 			pt.Group = models.TagsToGroupID(g.dimensions, pt.Tags)
+			pt.Dimensions = g.dimensions
 			for _, child := range g.outs {
 				err := child.CollectPoint(pt)
 				if err != nil {
@@ -59,6 +53,8 @@ func (g *GroupByNode) runGroupBy() error {
 				}
 			}
 		}
+	default:
+		panic("not implemented")
 	}
 	return nil
 }

--- a/integrations/batcher_test.go
+++ b/integrations/batcher_test.go
@@ -41,7 +41,7 @@ batch
 				Tags:    map[string]string{"cpu": "cpu-total"},
 				Columns: []string{"time", "sum"},
 				Values: [][]interface{}{[]interface{}{
-					time.Date(1970, 1, 1, 0, 0, 18, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 28, 0, time.UTC),
 					10.0,
 				}},
 			},
@@ -50,7 +50,7 @@ batch
 				Tags:    map[string]string{"cpu": "cpu0"},
 				Columns: []string{"time", "sum"},
 				Values: [][]interface{}{[]interface{}{
-					time.Date(1970, 1, 1, 0, 0, 18, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 28, 0, time.UTC),
 					10.0,
 				}},
 			},
@@ -59,7 +59,7 @@ batch
 				Tags:    map[string]string{"cpu": "cpu1"},
 				Columns: []string{"time", "sum"},
 				Values: [][]interface{}{[]interface{}{
-					time.Date(1970, 1, 1, 0, 0, 18, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 28, 0, time.UTC),
 					10.0,
 				}},
 			},
@@ -93,7 +93,6 @@ batch
 
 	// Assert we got the expected result
 	result := kapacitor.ResultFromJSON(resp.Body)
-	t.Log(result.Series[0])
 	if eq, msg := compareResults(er, result); !eq {
 		t.Error(msg)
 	}

--- a/integrations/data/TestStream_Aggregations.srpl
+++ b/integrations/data/TestStream_Aggregations.srpl
@@ -9,10 +9,10 @@ rpname
 disk,type=sda,host=serverB value=39 0000000001
 dbname
 rpname
-cpu,type=idle,host=serverA value=92 0000000002
+cpu,type=idle,host=serverA value=91 0000000002
 dbname
 rpname
-cpu,type=idle,host=serverB value=92 0000000002
+cpu,type=idle,host=serverB value=91 0000000002
 dbname
 rpname
 cpu,type=idle,host=serverA value=95 0000000003

--- a/integrations/data/TestStream_Join.srpl
+++ b/integrations/data/TestStream_Join.srpl
@@ -15,7 +15,7 @@ rpname
 disk,service=sda,dc=B value=39   0000000001
 dbname
 rpname
-errors,service=front,dc=A value=2 0000000002
+errors,service=front,dc=A value=2 0000000001
 dbname
 rpname
 views,service=front,dc=A value=200 0000000002

--- a/integrations/data/TestStream_TopSelector.srpl
+++ b/integrations/data/TestStream_TopSelector.srpl
@@ -1,0 +1,621 @@
+dbname
+rpname
+scores,game=g0,player=p0 value=434 1447114137
+dbname
+rpname
+scores,game=g0,player=p1 value=967 1447114137
+dbname
+rpname
+scores,game=g0,player=p2 value=534 1447114137
+dbname
+rpname
+scores,game=g0,player=p3 value=669 1447114137
+dbname
+rpname
+scores,game=g0,player=p4 value=173 1447114137
+dbname
+rpname
+scores,game=g0,player=p5 value=88 1447114137
+dbname
+rpname
+scores,game=g0,player=p6 value=848 1447114137
+dbname
+rpname
+scores,game=g0,player=p7 value=340 1447114137
+dbname
+rpname
+scores,game=g0,player=p8 value=775 1447114137
+dbname
+rpname
+scores,game=g0,player=p9 value=817 1447114137
+dbname
+rpname
+scores,game=g0,player=p10 value=542 1447114137
+dbname
+rpname
+scores,game=g0,player=p11 value=598 1447114137
+dbname
+rpname
+scores,game=g0,player=p12 value=300 1447114137
+dbname
+rpname
+scores,game=g0,player=p13 value=750 1447114137
+dbname
+rpname
+scores,game=g0,player=p14 value=875 1447114137
+dbname
+rpname
+scores,game=g0,player=p15 value=519 1447114137
+dbname
+rpname
+scores,game=g0,player=p16 value=432 1447114137
+dbname
+rpname
+scores,game=g0,player=p17 value=157 1447114137
+dbname
+rpname
+scores,game=g0,player=p18 value=128 1447114137
+dbname
+rpname
+scores,game=g0,player=p19 value=70 1447114137
+dbname
+rpname
+scores,game=g1,player=p0 value=50 1447114137
+dbname
+rpname
+scores,game=g1,player=p1 value=671 1447114137
+dbname
+rpname
+scores,game=g1,player=p2 value=328 1447114137
+dbname
+rpname
+scores,game=g1,player=p3 value=836 1447114137
+dbname
+rpname
+scores,game=g1,player=p4 value=866 1447114137
+dbname
+rpname
+scores,game=g1,player=p5 value=884 1447114137
+dbname
+rpname
+scores,game=g1,player=p6 value=989 1447114137
+dbname
+rpname
+scores,game=g1,player=p7 value=42 1447114137
+dbname
+rpname
+scores,game=g1,player=p8 value=919 1447114137
+dbname
+rpname
+scores,game=g1,player=p9 value=561 1447114137
+dbname
+rpname
+scores,game=g1,player=p10 value=959 1447114137
+dbname
+rpname
+scores,game=g1,player=p11 value=220 1447114137
+dbname
+rpname
+scores,game=g1,player=p12 value=91 1447114137
+dbname
+rpname
+scores,game=g1,player=p13 value=123 1447114137
+dbname
+rpname
+scores,game=g1,player=p14 value=737 1447114137
+dbname
+rpname
+scores,game=g1,player=p15 value=909 1447114137
+dbname
+rpname
+scores,game=g1,player=p16 value=786 1447114137
+dbname
+rpname
+scores,game=g1,player=p17 value=471 1447114137
+dbname
+rpname
+scores,game=g1,player=p18 value=152 1447114137
+dbname
+rpname
+scores,game=g1,player=p19 value=254 1447114137
+dbname
+rpname
+scores,game=g0,player=p0 value=347 1447114138
+dbname
+rpname
+scores,game=g0,player=p1 value=623 1447114138
+dbname
+rpname
+scores,game=g0,player=p2 value=872 1447114138
+dbname
+rpname
+scores,game=g0,player=p3 value=798 1447114138
+dbname
+rpname
+scores,game=g0,player=p4 value=840 1447114138
+dbname
+rpname
+scores,game=g0,player=p5 value=584 1447114138
+dbname
+rpname
+scores,game=g0,player=p6 value=843 1447114138
+dbname
+rpname
+scores,game=g0,player=p7 value=16 1447114138
+dbname
+rpname
+scores,game=g0,player=p8 value=269 1447114138
+dbname
+rpname
+scores,game=g0,player=p9 value=538 1447114138
+dbname
+rpname
+scores,game=g0,player=p10 value=224 1447114138
+dbname
+rpname
+scores,game=g0,player=p11 value=931 1447114138
+dbname
+rpname
+scores,game=g0,player=p12 value=196 1447114138
+dbname
+rpname
+scores,game=g0,player=p13 value=894 1447114138
+dbname
+rpname
+scores,game=g0,player=p14 value=159 1447114138
+dbname
+rpname
+scores,game=g0,player=p15 value=69 1447114138
+dbname
+rpname
+scores,game=g0,player=p16 value=789 1447114138
+dbname
+rpname
+scores,game=g0,player=p17 value=518 1447114138
+dbname
+rpname
+scores,game=g0,player=p18 value=73 1447114138
+dbname
+rpname
+scores,game=g0,player=p19 value=116 1447114138
+dbname
+rpname
+scores,game=g1,player=p0 value=965 1447114138
+dbname
+rpname
+scores,game=g1,player=p1 value=553 1447114138
+dbname
+rpname
+scores,game=g1,player=p2 value=599 1447114138
+dbname
+rpname
+scores,game=g1,player=p3 value=594 1447114138
+dbname
+rpname
+scores,game=g1,player=p4 value=213 1447114138
+dbname
+rpname
+scores,game=g1,player=p5 value=392 1447114138
+dbname
+rpname
+scores,game=g1,player=p6 value=466 1447114138
+dbname
+rpname
+scores,game=g1,player=p7 value=63 1447114138
+dbname
+rpname
+scores,game=g1,player=p8 value=953 1447114138
+dbname
+rpname
+scores,game=g1,player=p9 value=660 1447114138
+dbname
+rpname
+scores,game=g1,player=p10 value=466 1447114138
+dbname
+rpname
+scores,game=g1,player=p11 value=261 1447114138
+dbname
+rpname
+scores,game=g1,player=p12 value=833 1447114138
+dbname
+rpname
+scores,game=g1,player=p13 value=734 1447114138
+dbname
+rpname
+scores,game=g1,player=p14 value=73 1447114138
+dbname
+rpname
+scores,game=g1,player=p15 value=277 1447114138
+dbname
+rpname
+scores,game=g1,player=p16 value=188 1447114138
+dbname
+rpname
+scores,game=g1,player=p17 value=463 1447114138
+dbname
+rpname
+scores,game=g1,player=p18 value=813 1447114138
+dbname
+rpname
+scores,game=g1,player=p19 value=370 1447114138
+dbname
+rpname
+scores,game=g0,player=p0 value=209 1447114139
+dbname
+rpname
+scores,game=g0,player=p1 value=104 1447114139
+dbname
+rpname
+scores,game=g0,player=p2 value=905 1447114139
+dbname
+rpname
+scores,game=g0,player=p3 value=881 1447114139
+dbname
+rpname
+scores,game=g0,player=p4 value=306 1447114139
+dbname
+rpname
+scores,game=g0,player=p5 value=907 1447114139
+dbname
+rpname
+scores,game=g0,player=p6 value=817 1447114139
+dbname
+rpname
+scores,game=g0,player=p7 value=124 1447114139
+dbname
+rpname
+scores,game=g0,player=p8 value=285 1447114139
+dbname
+rpname
+scores,game=g0,player=p9 value=467 1447114139
+dbname
+rpname
+scores,game=g0,player=p10 value=499 1447114139
+dbname
+rpname
+scores,game=g0,player=p11 value=855 1447114139
+dbname
+rpname
+scores,game=g0,player=p12 value=616 1447114139
+dbname
+rpname
+scores,game=g0,player=p13 value=391 1447114139
+dbname
+rpname
+scores,game=g0,player=p14 value=218 1447114139
+dbname
+rpname
+scores,game=g0,player=p15 value=66 1447114139
+dbname
+rpname
+scores,game=g0,player=p16 value=644 1447114139
+dbname
+rpname
+scores,game=g0,player=p17 value=336 1447114139
+dbname
+rpname
+scores,game=g0,player=p18 value=938 1447114139
+dbname
+rpname
+scores,game=g0,player=p19 value=972 1447114139
+dbname
+rpname
+scores,game=g1,player=p0 value=487 1447114139
+dbname
+rpname
+scores,game=g1,player=p1 value=265 1447114139
+dbname
+rpname
+scores,game=g1,player=p2 value=602 1447114139
+dbname
+rpname
+scores,game=g1,player=p3 value=511 1447114139
+dbname
+rpname
+scores,game=g1,player=p4 value=848 1447114139
+dbname
+rpname
+scores,game=g1,player=p5 value=734 1447114139
+dbname
+rpname
+scores,game=g1,player=p6 value=857 1447114139
+dbname
+rpname
+scores,game=g1,player=p7 value=140 1447114139
+dbname
+rpname
+scores,game=g1,player=p8 value=247 1447114139
+dbname
+rpname
+scores,game=g1,player=p9 value=981 1447114139
+dbname
+rpname
+scores,game=g1,player=p10 value=640 1447114139
+dbname
+rpname
+scores,game=g1,player=p11 value=485 1447114139
+dbname
+rpname
+scores,game=g1,player=p12 value=681 1447114139
+dbname
+rpname
+scores,game=g1,player=p13 value=109 1447114139
+dbname
+rpname
+scores,game=g1,player=p14 value=55 1447114139
+dbname
+rpname
+scores,game=g1,player=p15 value=184 1447114139
+dbname
+rpname
+scores,game=g1,player=p16 value=659 1447114139
+dbname
+rpname
+scores,game=g1,player=p17 value=784 1447114139
+dbname
+rpname
+scores,game=g1,player=p18 value=452 1447114139
+dbname
+rpname
+scores,game=g1,player=p19 value=986 1447114139
+dbname
+rpname
+scores,game=g0,player=p0 value=248 1447114140
+dbname
+rpname
+scores,game=g0,player=p1 value=539 1447114140
+dbname
+rpname
+scores,game=g0,player=p2 value=347 1447114140
+dbname
+rpname
+scores,game=g0,player=p3 value=114 1447114140
+dbname
+rpname
+scores,game=g0,player=p4 value=328 1447114140
+dbname
+rpname
+scores,game=g0,player=p5 value=877 1447114140
+dbname
+rpname
+top_scores_gap,game=g0 gap=145,topFirst=918,topLast=773 1447114070
+dbname
+rpname
+scores,game=g0,player=p6 value=708 1447114140
+dbname
+rpname
+scores,game=g0,player=p7 value=978 1447114140
+dbname
+rpname
+scores,game=g0,player=p8 value=454 1447114140
+dbname
+rpname
+scores,game=g0,player=p9 value=878 1447114140
+dbname
+rpname
+scores,game=g0,player=p10 value=957 1447114140
+dbname
+rpname
+scores,game=g0,player=p11 value=356 1447114140
+dbname
+rpname
+scores,game=g0,player=p12 value=539 1447114140
+dbname
+rpname
+scores,game=g0,player=p13 value=623 1447114140
+dbname
+rpname
+scores,game=g0,player=p14 value=627 1447114140
+dbname
+rpname
+scores,game=g0,player=p15 value=791 1447114140
+dbname
+rpname
+scores,game=g0,player=p16 value=247 1447114140
+dbname
+rpname
+scores,game=g0,player=p17 value=780 1447114140
+dbname
+rpname
+scores,game=g0,player=p18 value=138 1447114140
+dbname
+rpname
+scores,game=g0,player=p19 value=491 1447114140
+dbname
+rpname
+scores,game=g1,player=p0 value=879 1447114140
+dbname
+rpname
+scores,game=g1,player=p1 value=617 1447114140
+dbname
+rpname
+scores,game=g1,player=p2 value=265 1447114140
+dbname
+rpname
+scores,game=g1,player=p3 value=788 1447114140
+dbname
+rpname
+scores,game=g1,player=p4 value=685 1447114140
+dbname
+rpname
+scores,game=g1,player=p5 value=383 1447114140
+dbname
+rpname
+scores,game=g1,player=p6 value=180 1447114140
+dbname
+rpname
+scores,game=g1,player=p7 value=770 1447114140
+dbname
+rpname
+scores,game=g1,player=p8 value=344 1447114140
+dbname
+rpname
+scores,game=g1,player=p9 value=809 1447114140
+dbname
+rpname
+scores,game=g1,player=p10 value=97 1447114140
+dbname
+rpname
+scores,game=g1,player=p11 value=534 1447114140
+dbname
+rpname
+scores,game=g1,player=p12 value=887 1447114140
+dbname
+rpname
+scores,game=g1,player=p13 value=272 1447114140
+dbname
+rpname
+scores,game=g1,player=p14 value=277 1447114140
+dbname
+rpname
+scores,game=g1,player=p15 value=872 1447114140
+dbname
+rpname
+scores,game=g1,player=p16 value=863 1447114140
+dbname
+rpname
+scores,game=g1,player=p17 value=311 1447114140
+dbname
+rpname
+scores,game=g1,player=p18 value=749 1447114140
+dbname
+rpname
+scores,game=g1,player=p19 value=926 1447114140
+dbname
+rpname
+top_scores_gap,game=g1 gap=142,topFirst=998,topLast=856 1447114070
+dbname
+rpname
+top_scores,game=g1,player=p14 top=998 1447114070
+dbname
+rpname
+top_scores,game=g1,player=p8 top=940 1447114070
+dbname
+rpname
+top_scores,game=g1,player=p17 top=926 1447114070
+dbname
+rpname
+top_scores,game=g1,player=p4 top=861 1447114070
+dbname
+rpname
+top_scores,game=g1,player=p9 top=856 1447114070
+dbname
+rpname
+scores,game=g0,player=p0 value=971 1447114141
+dbname
+rpname
+scores,game=g0,player=p1 value=244 1447114141
+dbname
+rpname
+scores,game=g0,player=p2 value=599 1447114141
+dbname
+rpname
+scores,game=g0,player=p3 value=172 1447114141
+dbname
+rpname
+scores,game=g0,player=p4 value=985 1447114141
+dbname
+rpname
+scores,game=g0,player=p5 value=494 1447114141
+dbname
+rpname
+scores,game=g0,player=p6 value=897 1447114141
+dbname
+rpname
+scores,game=g0,player=p7 value=338 1447114141
+dbname
+rpname
+scores,game=g0,player=p8 value=90 1447114141
+dbname
+rpname
+scores,game=g0,player=p9 value=765 1447114141
+dbname
+rpname
+scores,game=g0,player=p10 value=665 1447114141
+dbname
+rpname
+scores,game=g0,player=p11 value=215 1447114141
+dbname
+rpname
+scores,game=g0,player=p12 value=929 1447114141
+dbname
+rpname
+scores,game=g0,player=p13 value=186 1447114141
+dbname
+rpname
+scores,game=g0,player=p14 value=631 1447114141
+dbname
+rpname
+scores,game=g0,player=p15 value=489 1447114141
+dbname
+rpname
+scores,game=g0,player=p16 value=97 1447114141
+dbname
+rpname
+scores,game=g0,player=p17 value=725 1447114141
+dbname
+rpname
+scores,game=g0,player=p18 value=432 1447114141
+dbname
+rpname
+scores,game=g0,player=p19 value=806 1447114141
+dbname
+rpname
+scores,game=g1,player=p0 value=431 1447114141
+dbname
+rpname
+scores,game=g1,player=p1 value=473 1447114141
+dbname
+rpname
+scores,game=g1,player=p2 value=495 1447114141
+dbname
+rpname
+scores,game=g1,player=p3 value=853 1447114141
+dbname
+rpname
+scores,game=g1,player=p4 value=558 1447114141
+dbname
+rpname
+scores,game=g1,player=p5 value=345 1447114141
+dbname
+rpname
+scores,game=g1,player=p6 value=988 1447114141
+dbname
+rpname
+scores,game=g1,player=p7 value=726 1447114141
+dbname
+rpname
+scores,game=g1,player=p8 value=639 1447114141
+dbname
+rpname
+scores,game=g1,player=p9 value=266 1447114141
+dbname
+rpname
+scores,game=g1,player=p10 value=613 1447114141
+dbname
+rpname
+scores,game=g1,player=p11 value=382 1447114141
+dbname
+rpname
+scores,game=g1,player=p12 value=596 1447114141
+dbname
+rpname
+scores,game=g1,player=p13 value=138 1447114141
+dbname
+rpname
+scores,game=g1,player=p14 value=480 1447114141
+dbname
+rpname
+scores,game=g1,player=p15 value=53 1447114141
+dbname
+rpname
+scores,game=g1,player=p16 value=748 1447114141
+dbname
+rpname
+scores,game=g1,player=p17 value=434 1447114141
+dbname
+rpname
+scores,game=g1,player=p18 value=739 1447114141
+dbname
+rpname
+scores,game=g1,player=p19 value=861 1447114141

--- a/join.go
+++ b/join.go
@@ -132,7 +132,7 @@ func (j *JoinNode) joinBatches(rename string) error {
 			return fmt.Errorf("batches are different lengths cannot join. Use groupBy time and fill to ensure batches match")
 		}
 		// Rename fields
-		newPoints := make([]models.TimeFields, len(bn.Points))
+		newPoints := make([]models.BatchPoint, len(bn.Points))
 		for i, pn := range bn.Points {
 			pm := bm.Points[i]
 			if pn.Time.Equal(pm.Time) {
@@ -143,9 +143,10 @@ func (j *JoinNode) joinBatches(rename string) error {
 				for k, v := range pm.Fields {
 					fields[j.j.Names[m]+"."+k] = v
 				}
-				newPoints[i] = models.TimeFields{
+				newPoints[i] = models.BatchPoint{
 					Time:   pn.Time,
 					Fields: fields,
+					Tags:   bn.Tags,
 				}
 			}
 		}
@@ -153,6 +154,7 @@ func (j *JoinNode) joinBatches(rename string) error {
 			Name:   rename,
 			Group:  bn.Group,
 			Tags:   bn.Tags,
+			TMax:   bn.TMax,
 			Points: newPoints,
 		}
 

--- a/models/point.go
+++ b/models/point.go
@@ -21,7 +21,8 @@ type Point struct {
 	Database        string
 	RetentionPolicy string
 
-	Group GroupID
+	Group      GroupID
+	Dimensions []string
 
 	Tags map[string]string
 

--- a/pipeline/eval.go
+++ b/pipeline/eval.go
@@ -4,7 +4,10 @@ import (
 	"github.com/influxdb/kapacitor/tick"
 )
 
-// Evaluates a transformation on each data point it receives.
+// Evaluates expressions on each data point it receives.
+// A list of expressions may be provided and will be evaluated in the order they are given
+// and results of previous expressions are made available to later expressions.
+// See the property 'As' for details on how to reference the results.
 //
 // Example:
 //    stream
@@ -14,31 +17,58 @@ import (
 // The above example will add a new field `error_percent` to each
 // data point with the result of `error_count / total_count` where
 // `error_count` and `total_count` are existing fields on the data point.
+//
 type EvalNode struct {
 	chainnode
 
 	// The name of the field that results from applying the expression.
-	As string
+	// tick:ignore
+	AsList []string
 
 	// tick:ignore
-	Expression tick.Node
+	Expressions []tick.Node
 
 	// tick:ignore
 	KeepFlag bool
+	// List of fields to keep
+	// if empty and KeepFlag is true
+	// keep all fields.
+	// tick:ignore
+	KeepList []string
 }
 
-func newEvalNode(e EdgeType, expr tick.Node) *EvalNode {
+func newEvalNode(e EdgeType, exprs []tick.Node) *EvalNode {
 	n := &EvalNode{
-		chainnode:  newBasicChainNode("eval", e, e),
-		Expression: expr,
+		chainnode:   newBasicChainNode("eval", e, e),
+		Expressions: exprs,
 	}
 	return n
 }
 
+// List of names for each expression.
+// The expressions are evaluated in order and the result
+// of a previous will be available in later expressions
+// via the name provided.
+//
+// tick:property
+func (e *EvalNode) As(names ...string) *EvalNode {
+	e.AsList = names
+	return e
+}
+
 // If called the existing fields will be preserved in addition
-// to the new field being set.
-//tick:property
-func (e *EvalNode) Keep() *EvalNode {
+// to the new fields being set.
+//
+// Optionally a list of field names can be given.
+// Only fields in the list will be kept.
+// If no list is given then all fields are kept.
+// The list of fields to keep is evaluated after all
+// expressions have been evaluated.
+// This way intermediate values can be discarded.
+//
+// tick:property
+func (e *EvalNode) Keep(fields ...string) *EvalNode {
 	e.KeepFlag = true
+	e.KeepList = fields
 	return e
 }

--- a/pipeline/map_reduce.go
+++ b/pipeline/map_reduce.go
@@ -4,6 +4,7 @@ package pipeline
 type MapReduceInfo struct {
 	Map    interface{}
 	Reduce interface{}
+	Edge   EdgeType
 }
 
 // Performs a map operation on the data stream.
@@ -27,9 +28,9 @@ type MapNode struct {
 	Map interface{}
 }
 
-func newMapNode(i interface{}) *MapNode {
+func newMapNode(wants EdgeType, i interface{}) *MapNode {
 	return &MapNode{
-		chainnode: newBasicChainNode("map", BatchEdge, ReduceEdge),
+		chainnode: newBasicChainNode("map", wants, ReduceEdge),
 		Map:       i,
 	}
 }
@@ -53,11 +54,26 @@ type ReduceNode struct {
 	//The reduce function
 	// tick:ignore
 	Reduce interface{}
+
+	// Whether to use the max time or the
+	// time of the selected point
+	// tick:ignore
+	PointTimes bool
 }
 
-func newReduceNode(i interface{}) *ReduceNode {
+func newReduceNode(i interface{}, et EdgeType) *ReduceNode {
 	return &ReduceNode{
-		chainnode: newBasicChainNode("reduce", ReduceEdge, StreamEdge),
+		chainnode: newBasicChainNode("reduce", ReduceEdge, et),
 		Reduce:    i,
 	}
+}
+
+// Use the time of the selected point instead of the time of the batch.
+//
+// Only applies to selector MR functions like first, last, top, bottom, etc.
+// Aggregation functions always use the batch time.
+// tick:property
+func (r *ReduceNode) UsePointTimes() *ReduceNode {
+	r.PointTimes = true
+	return r
 }

--- a/pipeline/window.go
+++ b/pipeline/window.go
@@ -28,10 +28,22 @@ type WindowNode struct {
 	Period time.Duration
 	// How often the current window is emitted into the pipeline.
 	Every time.Duration
+	// Wether to align the window edges with the zero time
+	// tick:ignore
+	AlignFlag bool
 }
 
 func newWindowNode() *WindowNode {
 	return &WindowNode{
 		chainnode: newBasicChainNode("window", StreamEdge, BatchEdge),
 	}
+}
+
+// Wether to align the window edges with the zero time.
+// If not aligned the window starts and ends relative to the
+// first data point it receives.
+// tick:property
+func (w *WindowNode) Align() *WindowNode {
+	w.AlignFlag = true
+	return w
 }

--- a/services/reporting/service.go
+++ b/services/reporting/service.go
@@ -156,7 +156,10 @@ func (s *Service) registerServer() error {
 		Version:   s.version,
 		Product:   s.product,
 	}
-	_, err := s.client.Save(server)
+	resp, err := s.client.Save(server)
+	if resp != nil {
+		resp.Body.Close()
+	}
 	return err
 }
 
@@ -178,7 +181,10 @@ func (s *Service) sendUsageReport() error {
 		Data:    []client.UsageData{data},
 	}
 
-	_, err := s.client.Save(usage)
+	resp, err := s.client.Save(usage)
+	if resp != nil {
+		resp.Body.Close()
+	}
 	return err
 }
 
@@ -194,8 +200,11 @@ func (s *Service) sendStatsReport() error {
 		Product:   s.product,
 		Data:      data,
 	}
-	_, err = s.client.Save(stats)
 
+	resp, err := s.client.Save(stats)
+	if resp != nil {
+		resp.Body.Close()
+	}
 	return err
 }
 

--- a/task_master.go
+++ b/task_master.go
@@ -91,6 +91,7 @@ func (tm *TaskMaster) Close() error {
 }
 
 func (tm *TaskMaster) StartTask(t *Task) (*ExecutingTask, error) {
+	tm.logger.Println("D! Starting task:", t.Name)
 	et, err := NewExecutingTask(tm, t)
 	if err != nil {
 		return nil, err

--- a/tick/TICKscript.md
+++ b/tick/TICKscript.md
@@ -66,10 +66,13 @@ Function     = identifier "(" Parameters ")" .
 Parameters   = { Parameter "," } [ Parameter ] .
 Parameter    = Expression | "lambda:" LambdaExpr | Primary .
 Primary      = "(" LambdaExpr ")" | number_lit | string_lit |
-                boolean_lit | duration_lit | regex_lit | star_lit
-                Reference | "-" Primary | "!" Primary .
+                boolean_lit | duration_lit | regex_lit | star_lit |
+                LFunc | Reference | "-" Primary | "!" Primary .
 Reference    = `"` { unicode_char } `"` .
-LambdaExpr   = "lambda:" Primary operator_lit Primary .
+LambdaExpr   = Primary operator_lit Primary .
+LFunc        = identifier "(" LParameters ")"
+LParameters   = { LParameter "," } [ LParameter ] .
+LParameter    = LambdaExpr |  Primary .
 
 ```
 

--- a/where.go
+++ b/where.go
@@ -46,7 +46,7 @@ func (w *WhereNode) runWhere() error {
 	case pipeline.BatchEdge:
 		for b, ok := w.ins[0].NextBatch(); ok; b, ok = w.ins[0].NextBatch() {
 			for i, p := range b.Points {
-				if pass, err := EvalPredicate(w.expression, p.Fields, b.Tags); !pass {
+				if pass, err := EvalPredicate(w.expression, p.Fields, p.Tags); !pass {
 					if err != nil {
 						w.logger.Println("E! error while evaluating WHERE expression:", err)
 					}


### PR DESCRIPTION
Point Tags are preserved for MR jobs to consume
They way time is handled on MR jobs is explicit
MR jobs can consume stream data by creating a batch on the fly

These changes allow for the live leaderboard use case.

Fixes #42 
