### PR TITLE
Change stream from to use explict db, rp, measurement properties

### DIFF
--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -58,7 +58,7 @@ func TestServer_DefineTask(t *testing.T) {
 			RetentionPolicy: "default",
 		},
 	}
-	tick := "stream.from('test')"
+	tick := "stream.from().measurement('test')"
 	r, err := s.DefineTask(name, ttype, tick, dbrps)
 	if err != nil {
 		t.Fatal(err)
@@ -113,7 +113,7 @@ func TestServer_EnableTask(t *testing.T) {
 			RetentionPolicy: "default",
 		},
 	}
-	tick := "stream.from('test')"
+	tick := "stream.from().measurement('test')"
 	r, err := s.DefineTask(name, ttype, tick, dbrps)
 	if err != nil {
 		t.Fatal(err)
@@ -176,7 +176,7 @@ func TestServer_DisableTask(t *testing.T) {
 			RetentionPolicy: "default",
 		},
 	}
-	tick := "stream.from('test')"
+	tick := "stream.from().measurement('test')"
 	r, err := s.DefineTask(name, ttype, tick, dbrps)
 	if err != nil {
 		t.Fatal(err)
@@ -247,7 +247,7 @@ func TestServer_DeleteTask(t *testing.T) {
 			RetentionPolicy: "default",
 		},
 	}
-	tick := "stream.from('test')"
+	tick := "stream.from().measurement('test')"
 	r, err := s.DefineTask(name, ttype, tick, dbrps)
 	if err != nil {
 		t.Fatal(err)
@@ -280,7 +280,7 @@ func TestServer_StreamTask(t *testing.T) {
 	}}
 	tick := `
 stream
-	.from('test')
+	.from().measurement('test')
 	.window()
 		.period(10s)
 		.every(10s)

--- a/examples/scores/top_scores.tick
+++ b/examples/scores/top_scores.tick
@@ -1,6 +1,6 @@
 // Define a result that contains the most recent score per player.
 var topPlayerScores = stream
-    .from('scores')
+    .from().measurement('scores')
     // Get the most recent score for each player per game.
     // Not likely that a player is playing two games but just in case.
     .groupBy('game', 'player')

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -47,8 +47,11 @@ func TestStream_Window(t *testing.T) {
 
 	var script = `
 stream
-	.from('"dbname"."rpname"."cpu"')
-	.where(lambda: "host" == 'serverA')
+	.from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+		.where(lambda: "host" == 'serverA')
 	.window()
 		.period(10s)
 		.every(10s)
@@ -125,7 +128,7 @@ func TestStream_SimpleMR(t *testing.T) {
 
 	var script = `
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA')
 	.window()
 		.period(10s)
@@ -183,7 +186,7 @@ func TestStream_GroupBy(t *testing.T) {
 
 	var script = `
 stream
-	.from('errors')
+	.from().measurement('errors')
 	.groupBy('service')
 	.window()
 		.period(10s)
@@ -260,7 +263,7 @@ func TestStream_Join(t *testing.T) {
 
 	var script = `
 var errorCounts = stream
-			.from('errors')
+			.from().measurement('errors')
 			.groupBy('service')
 			.window()
 				.period(10s)
@@ -269,7 +272,7 @@ var errorCounts = stream
 			.mapReduce(influxql.sum('value'))
 
 var viewCounts = stream
-			.from('views')
+			.from().measurement('views')
 			.groupBy('service')
 			.window()
 				.period(10s)
@@ -360,11 +363,11 @@ func TestStream_JoinTolerance(t *testing.T) {
 
 	var script = `
 var errorCounts = stream
-			.from('errors')
+			.from().measurement('errors')
 			.groupBy('service')
 
 var viewCounts = stream
-			.from('views')
+			.from().measurement('views')
 			.groupBy('service')
 
 errorCounts.join(viewCounts)
@@ -448,11 +451,11 @@ errorCounts.join(viewCounts)
 func TestStream_JoinFill(t *testing.T) {
 	var script = `
 var errorCounts = stream
-			.from('errors')
+			.from().measurement('errors')
 			.groupBy('service')
 
 var viewCounts = stream
-			.from('views')
+			.from().measurement('views')
 			.groupBy('service')
 
 errorCounts.join(viewCounts)
@@ -536,13 +539,13 @@ func TestStream_JoinN(t *testing.T) {
 
 	var script = `
 var cpu = stream
-			.from('cpu')
+			.from().measurement('cpu')
 			.where(lambda: "cpu" == 'total')
 var mem = stream
-			.from('memory')
+			.from().measurement('memory')
 			.where(lambda: "type" == 'free')
 var disk = stream
-			.from('disk')
+			.from().measurement('disk')
 			.where(lambda: "device" == 'sda')
 
 cpu.join(mem, disk)
@@ -606,13 +609,13 @@ func TestStream_Union(t *testing.T) {
 
 	var script = `
 var cpu = stream
-			.from('cpu')
+			.from().measurement('cpu')
 			.where(lambda: "cpu" == 'total')
 var mem = stream
-			.from('memory')
+			.from().measurement('memory')
 			.where(lambda: "type" == 'free')
 var disk = stream
-			.from('disk')
+			.from().measurement('disk')
 			.where(lambda: "device" == 'sda')
 
 cpu.union(mem, disk)
@@ -681,7 +684,7 @@ func TestStream_Aggregations(t *testing.T) {
 
 	var scriptTmpl = `
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA')
 	.window()
 		.period(10s)
@@ -1156,7 +1159,7 @@ func TestStream_CustomFunctions(t *testing.T) {
 var fMap = loadMapFunc('./TestCustomMapFunction.py')
 var fReduce = loadReduceFunc('./TestCustomReduceFunction.py')
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA')
 	.window()
 		.period(1s)
@@ -1176,7 +1179,7 @@ func TestStream_CustomMRFunction(t *testing.T) {
 	var script = `
 var fMapReduce = loadMapReduceFunc('./TestCustomMapReduceFunction.py')
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" = 'serverA')
 	.window()
 		.period(1s)
@@ -1208,7 +1211,7 @@ func TestStream_Alert(t *testing.T) {
 
 	var script = `
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA')
 	.window()
 		.period(10s)
@@ -1258,7 +1261,7 @@ func TestStream_AlertSigma(t *testing.T) {
 
 	var script = `
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA')
 	.eval(lambda: sigma("value"))
 		.as('sigma')
@@ -1307,7 +1310,7 @@ func TestStream_AlertComplexWhere(t *testing.T) {
 
 	var script = `
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA' AND sigma("value") > 2)
 	.alert()
 		.crit(lambda: TRUE)
@@ -1342,7 +1345,7 @@ func TestStream_AlertFlapping(t *testing.T) {
 	defer ts.Close()
 	var script = `
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA')
 	.alert()
 		.info(lambda: "value" < 95)
@@ -1376,7 +1379,7 @@ func TestStream_InfluxDBOut(t *testing.T) {
 
 	var script = `
 stream
-	.from('cpu')
+	.from().measurement('cpu')
 	.where(lambda: "host" == 'serverA')
 	.window()
 		.period(10s)
@@ -1465,7 +1468,7 @@ func TestStream_TopSelector(t *testing.T) {
 
 	var script = `
 var topScores = stream
-    .from('scores')
+    .from().measurement('scores')
     // Get the most recent score for each player
     .groupBy('game', 'player')
     .window()

--- a/pipeline/join.go
+++ b/pipeline/join.go
@@ -20,9 +20,9 @@ import (
 //
 // Example:
 //    var errors = stream
-//                   .from('errors')
+//                   .from().measurement('errors')
 //    var requests = stream
-//                   .from('requests')
+//                   .from().measurement('requests')
 //    // Join the errors and requests streams
 //    errors.join(requests)
 //            // Provide prefix names for the fields of the data points.

--- a/pipeline/stream.go
+++ b/pipeline/stream.go
@@ -15,7 +15,10 @@ import (
 //
 // Example:
 //    stream
-//        .from('"mydb"."myrp"."mymeasurement"')
+//        .from()
+//           .database('mydb')
+//           .retentionPolicy('myrp')
+//           .measurement('mymeasurement')
 //           .where(lambda: "host" =~ /logger\d+/)
 //        .window()
 //        ...
@@ -29,15 +32,23 @@ type StreamNode struct {
 	// tick:ignore
 	Expression tick.Node
 
-	// The db.rp.m from clause
-	// tick:ignore
-	FromSelector string
+	// The database name.
+	// If empty any database will be used.
+	Database string
+
+	// The retention policy name
+	// If empty any retention policy will be used.
+	RetentionPolicy string
+
+	// The measurement name
+	// If empty any measurement will be used.
+	Measurement string
 
 	// Optional duration for truncating timestamps.
 	// Helpful to ensure data points land on specfic boundaries
 	// Example:
 	//    stream
-	//       .from('mydata')
+	//       .from().measurement('mydata')
 	//           .truncate(1s)
 	//
 	// All incoming data will be truncated to 1 second resolution.
@@ -50,28 +61,28 @@ func newStreamNode() *StreamNode {
 	}
 }
 
-// Which database, retention policy and measurement to select.
-// This is equivalent to the FROM statement in an InfluxQL
-// query. As such shortened selectors can be supplied
-// (i.e. "mymeasurement" is valid and selects all data points
-// from the measurement "mymeasurement" independent
-// of database or retention policy).
-//
 // Creates a new stream node that can be further
-// filtered using the Where property.
+// filtered using the Database, RetentionPolicy, Measurement and Where properties.
 // From can be called multiple times to create multiple
 // independent forks of the data stream.
 //
 // Example:
-//    var cpu = stream.from('cpu')
-//    var load = stream.from('load')
-//    // Join cpu and load streams and do further processing
+//    // Select the 'cpu' measurement from just the database 'mydb'
+//    // and retention policy 'myrp'.
+//    var cpu = stream.from()
+//                       .database('mydb')
+//                       .retentionPolicy('myrp')
+//                       .measurement('cpu')
+//    // Select the 'load' measurement from any database and retention policy.
+//    var load = stream.from()
+//                        .measurement('load')
+//    // Join cpu and load streams and do further processing.
 //    cpu.join(load)
 //            .as('cpu', 'load')
 //        ...
-func (s *StreamNode) From(from string) *StreamNode {
+//
+func (s *StreamNode) From() *StreamNode {
 	f := newStreamNode()
-	f.FromSelector = from
 	s.linkChild(f)
 	return f
 }

--- a/pipeline/union.go
+++ b/pipeline/union.go
@@ -6,9 +6,9 @@ package pipeline
 // without modification.
 //
 // Example:
-//    var logins = stream.from('logins')
-//    var logouts = stream.from('logouts')
-//    var frontpage = stream.from('frontpage')
+//    var logins = stream.from().measurement('logins')
+//    var logouts = stream.from().measurement('logouts')
+//    var frontpage = stream.from().measurement('frontpage')
 //    // Union all user actions into a single stream
 //    logins.union(logouts, frontpage)
 //            .rename('user_actions')

--- a/stream.go
+++ b/stream.go
@@ -23,15 +23,12 @@ func newStreamNode(et *ExecutingTask, n *pipeline.StreamNode) (*StreamNode, erro
 	sn := &StreamNode{
 		node: node{Node: n, et: et},
 		s:    n,
+		db:   n.Database,
+		rp:   n.RetentionPolicy,
+		name: n.Measurement,
 	}
 	sn.node.runF = sn.runStream
-	var err error
-	if sn.s.FromSelector != "" {
-		sn.db, sn.rp, sn.name, err = parseFromClause(sn.s.FromSelector)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing FROM clause %q %v", sn.s.FromSelector, err)
-		}
-	}
+
 	if n.Expression != nil {
 		sn.expression = tick.NewStatefulExpr(n.Expression)
 	}


### PR DESCRIPTION
If users have dots `.` in their measurement names they had to do this `.from('"xxx.yyy"')` which is confusing. Changing the structure to be: `.from().measurement('xxx.yyy')`

Much cleaner and explicit.
