### PR TITLE
Adds derivative node

### DIFF
--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -308,7 +308,7 @@ stream
 
 	// Request data before any writes and expect null responses
 	nullResponse := `{"Series":null,"Err":null}`
-	err = s.HTTPGetRetry(endpoint, "", nullResponse, 20, time.Millisecond*5)
+	err = s.HTTPGetRetry(endpoint, "", nullResponse, 100, time.Millisecond*5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -336,7 +336,7 @@ test value=1 0000000011
 	s.MustWrite("mydb", "myrp", points, v)
 
 	exp := `{"Series":[{"name":"test","columns":["time","count"],"values":[["1970-01-01T00:00:10Z",15]]}],"Err":null}`
-	err = s.HTTPGetRetry(endpoint, nullResponse, exp, 20, time.Millisecond*5)
+	err = s.HTTPGetRetry(endpoint, nullResponse, exp, 100, time.Millisecond*5)
 	if err != nil {
 		t.Error(err)
 	}
@@ -410,7 +410,7 @@ batch
 
 	nullResponse := `{"Series":null,"Err":null}`
 	exp := `{"Series":[{"name":"cpu","columns":["time","count"],"values":[["1971-01-01T00:00:01.002Z",2]]}],"Err":null}`
-	err = s.HTTPGetRetry(endpoint, nullResponse, exp, 20, time.Millisecond*5)
+	err = s.HTTPGetRetry(endpoint, nullResponse, exp, 100, time.Millisecond*5)
 	if err != nil {
 		t.Error(err)
 	}

--- a/derivative.go
+++ b/derivative.go
@@ -1,0 +1,102 @@
+package kapacitor
+
+import (
+	"time"
+
+	"github.com/influxdb/kapacitor/models"
+	"github.com/influxdb/kapacitor/pipeline"
+)
+
+type DerivativeNode struct {
+	node
+	d *pipeline.DerivativeNode
+}
+
+// Create a new derivative node.
+func newDerivativeNode(et *ExecutingTask, n *pipeline.DerivativeNode) (*DerivativeNode, error) {
+	dn := &DerivativeNode{
+		node: node{Node: n, et: et},
+		d:    n,
+	}
+	// Create stateful expressions
+	dn.node.runF = dn.runDerivative
+	return dn, nil
+}
+
+func (d *DerivativeNode) runDerivative() error {
+	switch d.Provides() {
+	case pipeline.StreamEdge:
+		previous := make(map[models.GroupID]models.Point)
+		for p, ok := d.ins[0].NextPoint(); ok; p, ok = d.ins[0].NextPoint() {
+			pr, ok := previous[p.Group]
+			if !ok {
+				previous[p.Group] = p
+				continue
+			}
+
+			value, ok := d.derivative(pr.Fields, p.Fields, pr.Time, p.Time)
+			if ok {
+				fields := pr.Fields.Copy()
+				fields[d.d.As] = value
+				pr.Fields = fields
+				for _, child := range d.outs {
+					err := child.CollectPoint(pr)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			previous[p.Group] = p
+		}
+	case pipeline.BatchEdge:
+		for b, ok := d.ins[0].NextBatch(); ok; b, ok = d.ins[0].NextBatch() {
+			if len(b.Points) > 0 {
+				pr := b.Points[0]
+				var p models.BatchPoint
+				for i := 1; i < len(b.Points); i++ {
+					p = b.Points[i]
+					value, ok := d.derivative(pr.Fields, p.Fields, pr.Time, p.Time)
+					if ok {
+						fields := pr.Fields.Copy()
+						fields[d.d.As] = value
+						b.Points[i-1].Fields = fields
+					} else {
+						b.Points = append(b.Points[:i-1], b.Points[i:]...)
+						i--
+					}
+					pr = p
+				}
+				b.Points = b.Points[:len(b.Points)-1]
+			}
+			for _, child := range d.outs {
+				err := child.CollectBatch(b)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (d *DerivativeNode) derivative(prev, curr models.Fields, prevTime, currTime time.Time) (float64, bool) {
+	f0, ok := prev[d.d.Field].(float64)
+	if !ok {
+		return 0, false
+	}
+
+	f1, ok := curr[d.d.Field].(float64)
+	if !ok {
+		return 0, false
+	}
+
+	elapsed := currTime.Sub(prevTime)
+	diff := f1 - f0
+	// Drop negative values for non-negative derivatives
+	if d.d.NonNegativeFlag && diff < 0 {
+		return 0, false
+	}
+
+	value := float64(diff) / (float64(elapsed) / float64(d.d.Unit))
+	return value, true
+}

--- a/integrations/data/TestBatch_Derivative.0.brpl
+++ b/integrations/data/TestBatch_Derivative.0.brpl
@@ -1,0 +1,1 @@
+{"name":"packets","points":[{"fields":{"value":1000},"time":"2015-10-18T00:00:00Z"},{"fields":{"value":1001},"time":"2015-10-18T00:00:02Z"},{"fields":{"value":1002},"time":"2015-10-18T00:00:04Z"},{"fields":{"value":1003},"time":"2015-10-18T00:00:06Z"},{"fields":{"value":1004},"time":"2015-10-18T00:00:08Z"}]}

--- a/integrations/data/TestBatch_DerivativeNN.0.brpl
+++ b/integrations/data/TestBatch_DerivativeNN.0.brpl
@@ -1,0 +1,1 @@
+{"name":"packets","points":[{"fields":{"value":1000},"time":"2015-10-18T00:00:00Z"},{"fields":{"value":1001},"time":"2015-10-18T00:00:02Z"},{"fields":{"value":1002},"time":"2015-10-18T00:00:04Z"},{"fields":{"value":0},"time":"2015-10-18T00:00:06Z"},{"fields":{"value":1},"time":"2015-10-18T00:00:08Z"}]}

--- a/integrations/data/TestStream_Derivative.srpl
+++ b/integrations/data/TestStream_Derivative.srpl
@@ -1,0 +1,36 @@
+dbname
+rpname
+packets value=1000 0000000001
+dbname
+rpname
+packets value=1001 0000000002
+dbname
+rpname
+packets value=1002 0000000003
+dbname
+rpname
+packets value=1003 0000000004
+dbname
+rpname
+packets value=1004 0000000005
+dbname
+rpname
+packets value=1006 0000000006
+dbname
+rpname
+packets value=1007 0000000007
+dbname
+rpname
+packets value=1007 0000000008
+dbname
+rpname
+packets value=1008 0000000009
+dbname
+rpname
+packets value=1009 0000000010
+dbname
+rpname
+packets value=1010 0000000011
+dbname
+rpname
+packets value=1011 0000000012

--- a/integrations/data/TestStream_DerivativeNN.srpl
+++ b/integrations/data/TestStream_DerivativeNN.srpl
@@ -1,0 +1,36 @@
+dbname
+rpname
+packets value=1000 0000000001
+dbname
+rpname
+packets value=1001 0000000002
+dbname
+rpname
+packets value=1002 0000000003
+dbname
+rpname
+packets value=1003 0000000004
+dbname
+rpname
+packets value=1004 0000000005
+dbname
+rpname
+packets value=1005 0000000006
+dbname
+rpname
+packets value=0006 0000000007
+dbname
+rpname
+packets value=0000 0000000008
+dbname
+rpname
+packets value=0001 0000000009
+dbname
+rpname
+packets value=0002 0000000010
+dbname
+rpname
+packets value=0003 0000000011
+dbname
+rpname
+packets value=0004 0000000012

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -43,6 +43,240 @@ func init() {
 	}
 }
 
+func TestStream_Derivative(t *testing.T) {
+
+	var script = `
+stream
+	.from().measurement('packets')
+	.derivative('value')
+	.window()
+		.period(10s)
+		.every(10s)
+	.mapReduce(influxql.mean('value'))
+	.httpOut('TestStream_Derivative')
+`
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "packets",
+				Tags:    nil,
+				Columns: []string{"time", "mean"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					1.0,
+				}},
+			},
+		},
+	}
+
+	clock, et, errCh, tm := testStreamer(t, "TestStream_Derivative", script)
+	defer tm.Close()
+
+	// Move time forward
+	clock.Set(clock.Zero().Add(15 * time.Second))
+	// Wait till the replay has finished
+	if e := <-errCh; e != nil {
+		t.Error(e)
+	}
+	// Wait till the task is finished
+	if e := et.Err(); e != nil {
+		t.Error(e)
+	}
+
+	// Get the result
+	output, err := et.GetOutput("TestStream_Derivative")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(output.Endpoint())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert we got the expected result
+	result := kapacitor.ResultFromJSON(resp.Body)
+	if eq, msg := compareResults(er, result); !eq {
+		t.Error(msg)
+	}
+}
+
+func TestStream_DerivativeUnit(t *testing.T) {
+
+	var script = `
+stream
+	.from().measurement('packets')
+	.derivative('value')
+		.unit(10s)
+	.window()
+		.period(10s)
+		.every(10s)
+	.mapReduce(influxql.mean('value'))
+	.httpOut('TestStream_Derivative')
+`
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "packets",
+				Tags:    nil,
+				Columns: []string{"time", "mean"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					10.0,
+				}},
+			},
+		},
+	}
+
+	clock, et, errCh, tm := testStreamer(t, "TestStream_Derivative", script)
+	defer tm.Close()
+
+	// Move time forward
+	clock.Set(clock.Zero().Add(15 * time.Second))
+	// Wait till the replay has finished
+	if e := <-errCh; e != nil {
+		t.Error(e)
+	}
+	// Wait till the task is finished
+	if e := et.Err(); e != nil {
+		t.Error(e)
+	}
+
+	// Get the result
+	output, err := et.GetOutput("TestStream_Derivative")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(output.Endpoint())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert we got the expected result
+	result := kapacitor.ResultFromJSON(resp.Body)
+	if eq, msg := compareResults(er, result); !eq {
+		t.Error(msg)
+	}
+}
+
+func TestStream_DerivativeNN(t *testing.T) {
+
+	var script = `
+stream
+	.from().measurement('packets')
+	.derivative('value')
+		.nonNegative()
+	.window()
+		.period(10s)
+		.every(10s)
+	.mapReduce(influxql.mean('value'))
+	.httpOut('TestStream_Derivative')
+`
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "packets",
+				Tags:    nil,
+				Columns: []string{"time", "mean"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					1.0,
+				}},
+			},
+		},
+	}
+
+	clock, et, errCh, tm := testStreamer(t, "TestStream_DerivativeNN", script)
+	defer tm.Close()
+
+	// Move time forward
+	clock.Set(clock.Zero().Add(15 * time.Second))
+	// Wait till the replay has finished
+	if e := <-errCh; e != nil {
+		t.Error(e)
+	}
+	// Wait till the task is finished
+	if e := et.Err(); e != nil {
+		t.Error(e)
+	}
+
+	// Get the result
+	output, err := et.GetOutput("TestStream_Derivative")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(output.Endpoint())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert we got the expected result
+	result := kapacitor.ResultFromJSON(resp.Body)
+	if eq, msg := compareResults(er, result); !eq {
+		t.Error(msg)
+	}
+}
+
+func TestStream_DerivativeN(t *testing.T) {
+
+	var script = `
+stream
+	.from().measurement('packets')
+	.derivative('value')
+	.window()
+		.period(10s)
+		.every(10s)
+	.mapReduce(influxql.mean('value'))
+	.httpOut('TestStream_Derivative')
+`
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "packets",
+				Tags:    nil,
+				Columns: []string{"time", "mean"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					-99.7,
+				}},
+			},
+		},
+	}
+
+	clock, et, errCh, tm := testStreamer(t, "TestStream_DerivativeNN", script)
+	defer tm.Close()
+
+	// Move time forward
+	clock.Set(clock.Zero().Add(15 * time.Second))
+	// Wait till the replay has finished
+	if e := <-errCh; e != nil {
+		t.Error(e)
+	}
+	// Wait till the task is finished
+	if e := et.Err(); e != nil {
+		t.Error(e)
+	}
+
+	// Get the result
+	output, err := et.GetOutput("TestStream_Derivative")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(output.Endpoint())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert we got the expected result
+	result := kapacitor.ResultFromJSON(resp.Body)
+	if eq, msg := compareResults(er, result); !eq {
+		t.Error(msg)
+	}
+}
+
 func TestStream_Window(t *testing.T) {
 
 	var script = `
@@ -1613,6 +1847,7 @@ func testStreamer(t *testing.T, name, script string) (clock.Setter, *kapacitor.E
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Use 1971 so that we don't get true negatives on Epoch 0 collisions
 	c := clock.New(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
 	r := kapacitor.NewReplay(c)
 

--- a/models/point.go
+++ b/models/point.go
@@ -133,3 +133,11 @@ func PointToRow(p Point) (row *models.Row) {
 	}
 	return
 }
+
+func (f Fields) Copy() Fields {
+	cf := make(Fields, len(f))
+	for k, v := range f {
+		cf[k] = v
+	}
+	return cf
+}

--- a/pipeline/derivative.go
+++ b/pipeline/derivative.go
@@ -1,0 +1,43 @@
+package pipeline
+
+import (
+	"time"
+)
+
+type DerivativeNode struct {
+	chainnode
+
+	// The field to use when calculating the derivative
+	// tick:ignore
+	Field string
+
+	// The new name of the derivative field.
+	// Default is the name of the field used
+	// when calculating the derivative.
+	As string
+
+	// The time unit of the resulting derivative value.
+	// Default: 1s
+	Unit time.Duration
+
+	// Where negative values are acceptable.
+	// tick:ignore
+	NonNegativeFlag bool
+}
+
+func newDerivativeNode(wants EdgeType, field string) *DerivativeNode {
+	return &DerivativeNode{
+		chainnode: newBasicChainNode("derivative", wants, wants),
+		Unit:      time.Second,
+		Field:     field,
+		As:        field,
+	}
+}
+
+// If called the derivative will never return a negative
+// value.
+// tick:property
+func (d *DerivativeNode) NonNegative() *DerivativeNode {
+	d.NonNegativeFlag = true
+	return d
+}

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -316,3 +316,10 @@ func (n *chainnode) Sample(rate interface{}) *SampleNode {
 	n.linkChild(s)
 	return s
 }
+
+// Create a new node that computes the derivative of adjacent points.
+func (n *chainnode) Derivative(field string) *DerivativeNode {
+	s := newDerivativeNode(n.Provides(), field)
+	n.linkChild(s)
+	return s
+}

--- a/task.go
+++ b/task.go
@@ -316,6 +316,8 @@ func (et *ExecutingTask) createNode(p pipeline.Node) (Node, error) {
 		return newWhereNode(et, t)
 	case *pipeline.SampleNode:
 		return newSampleNode(et, t)
+	case *pipeline.DerivativeNode:
+		return newDerivativeNode(et, t)
 	default:
 		return nil, fmt.Errorf("unknown pipeline node type %T", p)
 	}


### PR DESCRIPTION
Fixes #61 

Dervivative is not implemented as a MapReduce job since we do not have clustering yet and it requires reordering inputs. This implementation will work efficiently for now but will have to change once we have real clustering.
