### PR TITLE
Alerta.io Integration

### DIFF
--- a/cmd/kapacitord/run/config.go
+++ b/cmd/kapacitord/run/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/influxdb"
@@ -48,6 +49,7 @@ type Config struct {
 	PagerDuty pagerduty.Config  `toml:"pagerduty"`
 	Slack     slack.Config      `toml:"slack"`
 	HipChat   hipchat.Config    `toml:"hipchat"`
+        Alerta    alerta.Config     `toml:"alerta"`
 	Reporting reporting.Config  `toml:"reporting"`
 	Stats     stats.Config      `toml:"stats"`
 
@@ -74,6 +76,7 @@ func NewConfig() *Config {
 	c.PagerDuty = pagerduty.NewConfig()
 	c.Slack = slack.NewConfig()
 	c.HipChat = hipchat.NewConfig()
+        c.Alerta = alerta.NewConfig()
 	c.Reporting = reporting.NewConfig()
 	c.Stats = stats.NewConfig()
 

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/influxdata/kapacitor"
+	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/influxdb"
@@ -132,6 +133,7 @@ func NewServer(c *Config, buildInfo *BuildInfo, logService logging.Interface) (*
 	s.appendVictorOpsService(c.VictorOps)
 	s.appendPagerDutyService(c.PagerDuty)
 	s.appendHipChatService(c.HipChat)
+	s.appendAlertaService(c.Alerta)
 	s.appendSlackService(c.Slack)
 
 	// Append InfluxDB services
@@ -260,6 +262,16 @@ func (s *Server) appendHipChatService(c hipchat.Config) {
 		l := s.LogService.NewLogger("[hipchat] ", log.LstdFlags)
 		srv := hipchat.NewService(c, l)
 		s.TaskMaster.HipChatService = srv
+
+		s.Services = append(s.Services, srv)
+	}
+}
+
+func (s *Server) appendAlertaService(c alerta.Config) {
+	if c.Enabled {
+		l := s.LogService.NewLogger("[alerta] ", log.LstdFlags)
+		srv := alerta.NewService(c, l)
+		s.TaskMaster.AlertaService = srv
 
 		s.Services = append(s.Services, srv)
 	}

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -167,6 +167,18 @@ data_dir = "/var/lib/kapacitor"
   # without explicitly marking them in the TICKscript.
   global = false
 
+[alerta]
+  # Configure Alerta.
+  enabled = false
+  # The Alerta URL.
+  url = ""
+  # Default authentication token.
+  token = ""
+  # Default environment.
+  environment = ""
+  # Default origin.
+  origin = "kapacitor"
+
 [reporting]
   # Send anonymous usage statistics
   # every 12 hours to Enterprise.

--- a/services/alerta/config.go
+++ b/services/alerta/config.go
@@ -1,0 +1,18 @@
+package alerta
+
+type Config struct {
+        // Whether Alerta integration is enabled.
+        Enabled bool `toml:"enabled"`
+        // The Alerta URL.
+        URL string `toml:"url"`
+        // The authentication token for this notification, can be overridden per alert.
+        Token string `toml:"token"`
+        // The environment in which to raise the alert.
+        Environment string `toml:"environment"`
+        // The origin of the alert.
+        Origin string `toml:"origin"`
+}
+
+func NewConfig() Config {
+        return Config{}
+}

--- a/services/alerta/service.go
+++ b/services/alerta/service.go
@@ -1,0 +1,95 @@
+package alerta
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+type Service struct {
+	url         string
+	token       string
+	environment string
+	origin      string
+	logger      *log.Logger
+}
+
+func NewService(c Config, l *log.Logger) *Service {
+	return &Service{
+		url:         c.URL,
+		token:       c.Token,
+		environment: c.Environment,
+		origin:      c.Origin,
+		logger:      l,
+	}
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+
+func (s *Service) Close() error {
+	return nil
+}
+
+func (s *Service) Alert(token, resource, event, environment, severity, status, group, value, message, origin string, data interface{}) error {
+	if resource == "" || event == "" {
+		return errors.New("Resource and Event are required to send an alert")
+	}
+
+	if token == "" {
+		token = s.token
+	}
+
+	if environment == "" {
+		environment = s.environment
+	}
+
+	if origin == "" {
+		origin = s.origin
+	}
+
+	var Url *url.URL
+	Url, err := url.Parse(s.url + "/alert?api-key=" + token)
+	if err != nil {
+		return err
+	}
+
+	postData := make(map[string]interface{})
+	postData["resource"] = resource
+	postData["event"] = event
+	postData["environment"] = environment
+	postData["severity"] = severity
+	postData["status"] = status
+	postData["group"] = group
+	postData["value"] = value
+	postData["text"] = message
+	postData["origin"] = origin
+	postData["data"] = data
+
+	var post bytes.Buffer
+	enc := json.NewEncoder(&post)
+	err = enc.Encode(postData)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(Url.String(), "application/json", &post)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		type response struct {
+			Error string `json:"error"`
+		}
+		r := &response{Error: "failed to understand Alerta response"}
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(r)
+		return errors.New(r.Error)
+	}
+	return nil
+}

--- a/task_master.go
+++ b/task_master.go
@@ -55,6 +55,9 @@ type TaskMaster struct {
 		Global() bool
 		Alert(room, token, message string, level AlertLevel) error
 	}
+	AlertaService interface {
+		Alert(token, resource, event, environment, severity, status, group, value, message, origin string, data interface{}) error
+	}
 	LogService LogService
 
 	// Incoming streams


### PR DESCRIPTION
Implements integration with [alerta.io](http://alerta.io)

The code has been tested with a local instance of alerta.

Usage:
```
stream
	.from().measurement('cpu')
	.where(lambda: "host" == 'serverA')
	.groupBy('host')
	.window()
		.period(10s)
		.every(10s)
	.mapReduce(influxql.count('idle'))
	.alert()
                .id('{{ index .Tags "host" }}')
		.message('kapacitor/{{ .Name }}/{{ index .Tags "host" }} is {{ .Level }}')
		.info(lambda: "count" > 6.0)
		.warn(lambda: "count" > 7.0)
		.crit(lambda: "count" > 8.0)
		.alerta()
			.token('testtoken1234567')
			.resource('serverA')
			.event('CPU Idle')
			.environment('production')
```

Configuration:
```
[alerta]
  # Configure Alerta.
  enabled = false
  # The Alerta URL.
  url = ""
  # Default authentication token.
  token = ""
  # Default environment.
  environment = ""
  # Default origin.
  origin = "kapacitor"
```

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)