### PR TITLE
Add deadman's switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ See [udf/agent/README.md](https://github.com/influxdata/kapacitor/blob/master/ud
 With the addition of UDFs it is now possible to run custom anomaly detection alogrithms suited to your needs.
 There are simple examples of how to use UDFs in [udf/agent/examples](https://github.com/influxdata/kapacitor/tree/master/udf/agent/examples/).
 
-
 The version has jumped significantly so that it is inline with other projects in the TICK stack.
 This way you can easily tell which versions of Telegraf, InfluxDB, Chronograf and Kapacitor work together.
 
 
 ### Features
+- [#137](https://github.com/influxdata/kapacitor/issues/137): Add deadman's switch. Can be setup via TICKscript and globally via configuration.
 - [#72](https://github.com/influxdata/kapacitor/issues/72): Add support for User Defined Functions (UDFs).
 - [#138](https://github.com/influxdata/kapacitor/issues/138): Change over to influxdata github org.
 - [#139](https://github.com/influxdata/kapacitor/issues/139): Alerta.io support thanks! @md14454

--- a/alert.go
+++ b/alert.go
@@ -392,6 +392,9 @@ type idInfo struct {
 	// Measurement name
 	Name string
 
+	// Task name
+	TaskName string
+
 	// Concatenation of all group-by tags of the form [key=value,]+.
 	// If not groupBy is performed equal to literal 'nil'
 	Group string
@@ -418,9 +421,10 @@ func (a *AlertNode) renderID(name string, group models.GroupID, tags models.Tags
 		g = "nil"
 	}
 	info := idInfo{
-		Name:  name,
-		Group: g,
-		Tags:  tags,
+		Name:     name,
+		TaskName: a.et.Task.Name,
+		Group:    g,
+		Tags:     tags,
 	}
 	var id bytes.Buffer
 	err := a.idTmpl.Execute(&id, info)
@@ -437,9 +441,10 @@ func (a *AlertNode) renderMessage(id, name string, group models.GroupID, tags mo
 	}
 	info := messageInfo{
 		idInfo: idInfo{
-			Name:  name,
-			Group: g,
-			Tags:  tags,
+			Name:     name,
+			TaskName: a.et.Task.Name,
+			Group:    g,
+			Tags:     tags,
 		},
 		ID:     id,
 		Fields: fields,

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -616,6 +616,11 @@ func reloadUsage() {
 }
 
 func doReload(args []string) error {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "Must pass at least one task name")
+		reloadUsage()
+		os.Exit(2)
+	}
 	err := doDisable(args)
 	if err != nil {
 		return err

--- a/cmd/kapacitord/run/config.go
+++ b/cmd/kapacitord/run/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/kapacitor/services/alerta"
+	"github.com/influxdata/kapacitor/services/deadman"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/influxdb"
@@ -54,6 +55,7 @@ type Config struct {
 	Reporting reporting.Config  `toml:"reporting"`
 	Stats     stats.Config      `toml:"stats"`
 	UDF       udf.Config        `toml:"udf"`
+	Deadman   deadman.Config    `toml:"deadman"`
 
 	Hostname string `toml:"hostname"`
 	DataDir  string `toml:"data_dir"`
@@ -64,6 +66,7 @@ func NewConfig() *Config {
 	c := &Config{
 		Hostname: "localhost",
 	}
+
 	c.HTTP = httpd.NewConfig()
 	c.Replay = replay.NewConfig()
 	c.Task = task_store.NewConfig()
@@ -82,6 +85,7 @@ func NewConfig() *Config {
 	c.Reporting = reporting.NewConfig()
 	c.Stats = stats.NewConfig()
 	c.UDF = udf.NewConfig()
+	c.Deadman = deadman.NewConfig()
 
 	return c
 }

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/services/alerta"
+	"github.com/influxdata/kapacitor/services/deadman"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/influxdb"
@@ -130,6 +131,7 @@ func NewServer(c *Config, buildInfo *BuildInfo, logService logging.Interface) (*
 
 	// Append Kapacitor services.
 	s.appendUDFService(c.UDF)
+	s.appendDeadmanService(c.Deadman)
 	s.appendSMTPService(c.SMTP)
 	s.appendHTTPDService(c.HTTP)
 	s.appendInfluxDBService(c.InfluxDB, c.Hostname)
@@ -220,6 +222,14 @@ func (s *Server) appendReplayStoreService(c replay.Config) {
 	srv.TaskMaster = s.TaskMaster
 
 	s.ReplayService = srv
+	s.Services = append(s.Services, srv)
+}
+
+func (s *Server) appendDeadmanService(c deadman.Config) {
+	l := s.LogService.NewLogger("[deadman] ", log.LstdFlags)
+	srv := deadman.NewService(c, l)
+
+	s.TaskMaster.DeadmanService = srv
 	s.Services = append(s.Services, srv)
 }
 

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -705,33 +704,16 @@ func TestServer_UDFAgents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "testStreamTaskRecording")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
 	agents := []struct {
 		buildFunc func() error
 		config    udf.FunctionConfig
 	}{
 		// Go
 		{
-			buildFunc: func() error {
-				cmd := exec.Command(
-					"go",
-					"build",
-					"-o",
-					filepath.Join(tmpDir, "go-moving_avg"),
-					filepath.Join(udfDir, "agent/examples/moving_avg.go"),
-				)
-				out, err := cmd.CombinedOutput()
-				if err != nil {
-					return fmt.Errorf("go build failed: %v: %s", err, string(out))
-				}
-				return nil
-			},
+			buildFunc: func() error { return nil },
 			config: udf.FunctionConfig{
-				Prog:    filepath.Join(tmpDir, "go-moving_avg"),
+				Prog:    "go",
+				Args:    []string{"run", filepath.Join(udfDir, "agent/examples/moving_avg.go")},
 				Timeout: toml.Duration(time.Minute),
 			},
 		},

--- a/edge.go
+++ b/edge.go
@@ -5,6 +5,7 @@ import (
 	"expvar"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
@@ -61,8 +62,20 @@ func newEdge(taskName, parentName, childName string, t pipeline.EdgeType, logSer
 	return e
 }
 
-func (e *Edge) collectedCount() string {
-	return e.statMap.Get(statCollected).String()
+func (e *Edge) emittedCount() int64 {
+	c, err := strconv.ParseUint(e.statMap.Get(statEmitted).String(), 10, 64)
+	if err != nil {
+		panic("emitted count is not an int")
+	}
+	return int64(c)
+}
+
+func (e *Edge) collectedCount() int64 {
+	c, err := strconv.ParseUint(e.statMap.Get(statCollected).String(), 10, 64)
+	if err != nil {
+		panic("collected count is not an int")
+	}
+	return int64(c)
 }
 
 // Close the edge, this can only be called after all

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -36,6 +36,21 @@ data_dir = "/var/lib/kapacitor"
   # How often to snapshot running task state.
   snapshot-interval = "60s"
 
+[deadman]
+  # Configure a deadman's switch
+  # Globally configure deadman's switches on all stream tasks.
+  # NOTE: for this to be of use you must also globally configure at least one alerting method.
+  global = false
+  # Threshold, if globally configured the alert will be triggered if the throughput in points/interval is <= threshold.
+  threshold = 0.0
+  # Interval, if globally configured the frequency at which to check the throughput.
+  interval = "10s"
+  # Id -- the alert Id, NODE_NAME will be replaced with the name of the node being monitored.
+  id = "node 'NODE_NAME' in task '{{ .TaskName }}'"
+  # The message of the alert. INTERVAL will be replaced by the interval.
+  message = "{{ .ID }} is dead: {{ index .Fields \"collected\" }} points/INTERVAL"
+
+
 [influxdb]
   # Connect to an InfluxDB cluster
   # Kapacitor can subscribe, query and write to this cluster.

--- a/global_stats.go
+++ b/global_stats.go
@@ -1,0 +1,238 @@
+package kapacitor
+
+import (
+	"expvar"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/twinj/uuid"
+)
+
+const (
+	// List of names for top-level exported vars
+	ClusterIDVarName = "cluster_id"
+	ServerIDVarName  = "server_id"
+	HostVarName      = "host"
+	ProductVarName   = "product"
+	VersionVarName   = "version"
+
+	NumTasksVarName         = "num_tasks"
+	NumEnabledTasksVarName  = "num_enabled_tasks"
+	NumSubscriptionsVarName = "num_subscriptions"
+
+	UptimeVarName = "uptime"
+
+	// The name of the product
+	Product = "kapacitor"
+)
+
+var (
+	// Global expvars
+	NumTasks         = &expvar.Int{}
+	NumEnabledTasks  = &expvar.Int{}
+	NumSubscriptions = &expvar.Int{}
+)
+
+var (
+	startTime time.Time
+)
+
+func init() {
+	startTime = time.Now().UTC()
+	expvar.Publish(NumTasksVarName, NumTasks)
+	expvar.Publish(NumEnabledTasksVarName, NumEnabledTasks)
+	expvar.Publish(NumSubscriptionsVarName, NumSubscriptions)
+}
+
+// Gets an exported var and returns its unquoted string contents
+func GetStringVar(name string) string {
+	s, err := strconv.Unquote(expvar.Get(name).String())
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// Gets an exported var and returns its int value
+func GetIntVar(name string) int64 {
+	i, err := strconv.ParseInt(expvar.Get(name).String(), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+// Gets an exported var and returns its float value
+func GetFloatVar(name string) float64 {
+	f, err := strconv.ParseFloat(expvar.Get(name).String(), 64)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+func Uptime() time.Duration {
+	return time.Now().Sub(startTime)
+}
+
+var expvarMu sync.Mutex
+
+// NewStatistics creates an expvar-based map. Within there "name" is the Measurement name, "tags" are the tags,
+// and values are placed at the key "values".
+// The "values" map is returned so that statistics can be set.
+func NewStatistics(name string, tags map[string]string) *expvar.Map {
+	expvarMu.Lock()
+	defer expvarMu.Unlock()
+
+	key := uuid.NewV4().String()
+
+	m := &expvar.Map{}
+	m.Init()
+	expvar.Publish(key, m)
+
+	// Set the name
+	nameVar := &expvar.String{}
+	nameVar.Set(name)
+	m.Set("name", nameVar)
+
+	// Set the tags
+	tagsVar := &expvar.Map{}
+	tagsVar.Init()
+	for k, v := range tags {
+		value := &expvar.String{}
+		value.Set(v)
+		tagsVar.Set(k, value)
+	}
+	m.Set("tags", tagsVar)
+
+	// Create and set the values entry used for actual stats.
+	statMap := &expvar.Map{}
+	statMap.Init()
+	m.Set("values", statMap)
+
+	return statMap
+}
+
+type StatsData struct {
+	Name   string                 `json:"name"`
+	Tags   map[string]string      `json:"tags"`
+	Values map[string]interface{} `json:"values"`
+}
+
+// Return all stats data from the expvars.
+func GetStatsData() ([]StatsData, error) {
+	allData := make([]StatsData, 0)
+	// Add Global expvars
+	globalData := StatsData{
+		Name:   "kapacitor",
+		Values: make(map[string]interface{}),
+	}
+
+	allData = append(allData, globalData)
+
+	expvar.Do(func(kv expvar.KeyValue) {
+		var f interface{}
+		var err error
+		switch v := kv.Value.(type) {
+		case *expvar.Float:
+			f, err = strconv.ParseFloat(v.String(), 64)
+			if err == nil {
+				globalData.Values[kv.Key] = f
+			}
+		case *expvar.Int:
+			f, err = strconv.ParseInt(v.String(), 10, 64)
+			if err == nil {
+				globalData.Values[kv.Key] = f
+			}
+		case *expvar.Map:
+			data := StatsData{
+				Tags:   make(map[string]string),
+				Values: make(map[string]interface{}),
+			}
+
+			v.Do(func(subKV expvar.KeyValue) {
+				switch subKV.Key {
+				case "name":
+					// straight to string name.
+					u, err := strconv.Unquote(subKV.Value.String())
+					if err != nil {
+						return
+					}
+					data.Name = u
+				case "tags":
+					// string-string tags map.
+					n := subKV.Value.(*expvar.Map)
+					n.Do(func(t expvar.KeyValue) {
+						u, err := strconv.Unquote(t.Value.String())
+						if err != nil {
+							return
+						}
+						data.Tags[t.Key] = u
+					})
+				case "values":
+					// string-interface map.
+					n := subKV.Value.(*expvar.Map)
+					n.Do(func(kv expvar.KeyValue) {
+						var f interface{}
+						var err error
+						switch v := kv.Value.(type) {
+						case *expvar.Float:
+							f, err = strconv.ParseFloat(v.String(), 64)
+							if err != nil {
+								return
+							}
+						case *expvar.Int:
+							f, err = strconv.ParseInt(v.String(), 10, 64)
+							if err != nil {
+								return
+							}
+						default:
+							return
+						}
+						data.Values[kv.Key] = f
+					})
+				}
+			})
+
+			// If no field data, don't include it in the results
+			if len(data.Values) == 0 {
+				return
+			}
+
+			allData = append(allData, data)
+		}
+	})
+
+	// Add uptime to globalData
+	globalData.Values[UptimeVarName] = Uptime().Seconds()
+
+	// Add Go memstats.
+	data := StatsData{
+		Name: "runtime",
+	}
+
+	var rt runtime.MemStats
+	runtime.ReadMemStats(&rt)
+	data.Values = map[string]interface{}{
+		"Alloc":        int64(rt.Alloc),
+		"TotalAlloc":   int64(rt.TotalAlloc),
+		"Sys":          int64(rt.Sys),
+		"Lookups":      int64(rt.Lookups),
+		"Mallocs":      int64(rt.Mallocs),
+		"Frees":        int64(rt.Frees),
+		"HeapAlloc":    int64(rt.HeapAlloc),
+		"HeapSys":      int64(rt.HeapSys),
+		"HeapIdle":     int64(rt.HeapIdle),
+		"HeapInUse":    int64(rt.HeapInuse),
+		"HeapReleased": int64(rt.HeapReleased),
+		"HeapObjects":  int64(rt.HeapObjects),
+		"PauseTotalNs": int64(rt.PauseTotalNs),
+		"NumGC":        int64(rt.NumGC),
+		"NumGoroutine": int64(runtime.NumGoroutine()),
+	}
+	allData = append(allData, data)
+
+	return allData, nil
+}

--- a/integrations/batcher_test.go
+++ b/integrations/batcher_test.go
@@ -313,11 +313,11 @@ func testBatcher(t *testing.T, name, script string) (clock.Setter, *kapacitor.Ex
 	tm := kapacitor.NewTaskMaster(logService)
 	tm.HTTPDService = httpService
 	tm.TaskStore = taskStore{}
+	tm.DeadmanService = deadman{}
 	tm.Open()
-	scope := tm.CreateTICKScope()
 
 	// Create task
-	task, err := kapacitor.NewTask(name, script, kapacitor.BatchTask, dbrps, 0, scope)
+	task, err := tm.NewTask(name, script, kapacitor.BatchTask, dbrps, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integrations/helpers_test.go
+++ b/integrations/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/wlog"
@@ -126,3 +127,17 @@ func (ts taskStore) HasSnapshot(name string) bool                               
 func (ts taskStore) LoadSnapshot(name string) (*kapacitor.TaskSnapshot, error) {
 	return nil, errors.New("not implemented")
 }
+
+type deadman struct {
+	interval  time.Duration
+	threshold float64
+	id        string
+	message   string
+	global    bool
+}
+
+func (d deadman) Interval() time.Duration { return d.interval }
+func (d deadman) Threshold() float64      { return d.threshold }
+func (d deadman) Id() string              { return d.id }
+func (d deadman) Message() string         { return d.message }
+func (d deadman) Global() bool            { return d.global }

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -2224,11 +2224,11 @@ func testStreamer(
 	tm.HTTPDService = httpService
 	tm.UDFService = udfService
 	tm.TaskStore = taskStore{}
+	tm.DeadmanService = deadman{}
 	tm.Open()
-	scope := tm.CreateTICKScope()
 
 	//Create the task
-	task, err := kapacitor.NewTask(name, script, kapacitor.StreamTask, dbrps, 0, scope)
+	task, err := tm.NewTask(name, script, kapacitor.StreamTask, dbrps, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node.go
+++ b/node.go
@@ -38,6 +38,9 @@ type Node interface {
 
 	// executing dot
 	edot(buf *bytes.Buffer)
+
+	// the number of points/batches this node has collected
+	collectedCount() int64
 }
 
 //implementation of Node
@@ -159,11 +162,22 @@ func (n *node) closeChildEdges() {
 func (n *node) edot(buf *bytes.Buffer) {
 	for i, c := range n.children {
 		buf.Write([]byte(
-			fmt.Sprintf("%s -> %s [label=\"%s\"];\n",
+			fmt.Sprintf("%s -> %s [label=\"%d\"];\n",
 				n.Name(),
 				c.Name(),
 				n.outs[i].collectedCount(),
 			),
 		))
 	}
+}
+
+// Return the number of points/batches this node
+// has collected.
+func (n *node) collectedCount() (c int64) {
+
+	// Count how many points each parent edge has emitted.
+	for _, in := range n.ins {
+		c += in.emittedCount()
+	}
+	return c
 }

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -81,6 +81,7 @@ type AlertNode struct {
 	// Available template data:
 	//
 	//    * Name -- Measurement name.
+	//    * TaskName -- The name of the task
 	//    * Group -- Concatenation of all group-by tags of the form [key=value,]+.
 	//        If no groupBy is performed equal to literal 'nil'.
 	//    * Tags -- Map of tags. Use '{{ index .Tags "key" }}' to get a specific tag value.
@@ -118,6 +119,7 @@ type AlertNode struct {
 	//
 	//    * ID -- The ID of the alert.
 	//    * Name -- Measurement name.
+	//    * TaskName -- The name of the task
 	//    * Group -- Concatenation of all group-by tags of the form [key=value,]+.
 	//        If no groupBy is performed equal to literal 'nil'.
 	//    * Tags -- Map of tags. Use '{{ index .Tags "key" }}' to get a specific tag value.

--- a/pipeline/stats.go
+++ b/pipeline/stats.go
@@ -1,0 +1,19 @@
+package pipeline
+
+import "time"
+
+type StatsNode struct {
+	chainnode
+	// tick:ignore
+	SourceNode Node
+	// tick:ignore
+	Interval time.Duration
+}
+
+func newStatsNode(n Node, interval time.Duration) *StatsNode {
+	return &StatsNode{
+		chainnode:  newBasicChainNode("stats", StreamEdge, StreamEdge),
+		SourceNode: n,
+		Interval:   interval,
+	}
+}

--- a/services/deadman/config.go
+++ b/services/deadman/config.go
@@ -1,0 +1,35 @@
+package deadman
+
+import (
+	"time"
+
+	"github.com/influxdb/influxdb/toml"
+)
+
+const (
+	// Default deadman's switch interval
+	DefaultInterval = toml.Duration(time.Second * 10)
+	// Default deadman's switch threshold
+	DefaultThreshold = float64(0)
+	// Default deadman's switch id
+	DefaultId = "node 'NODE_NAME' in task '{{ .TaskName }}'"
+	// Default deadman's switch message
+	DefaultMessage = "{{ .ID }} is {{ if eq .Level \"OK\" }}alive{{ else }}dead{{ end }}: {{ index .Fields \"collected\" | printf \"%0.3f\" }} points/INTERVAL."
+)
+
+type Config struct {
+	Interval  toml.Duration `toml:"interval"`
+	Threshold float64       `toml:"threshold"`
+	Id        string        `toml:"id"`
+	Message   string        `toml:"message"`
+	Global    bool          `toml:"global"`
+}
+
+func NewConfig() Config {
+	return Config{
+		Interval:  DefaultInterval,
+		Threshold: DefaultThreshold,
+		Id:        DefaultId,
+		Message:   DefaultMessage,
+	}
+}

--- a/services/deadman/service.go
+++ b/services/deadman/service.go
@@ -1,0 +1,49 @@
+package deadman
+
+import (
+	"log"
+	"time"
+)
+
+type Service struct {
+	c      Config
+	logger *log.Logger
+}
+
+func NewService(c Config, l *log.Logger) *Service {
+	return &Service{
+		c:      c,
+		logger: l,
+	}
+}
+
+func (s *Service) Interval() time.Duration {
+	return time.Duration(s.c.Interval)
+}
+
+func (s *Service) Threshold() float64 {
+	return s.c.Threshold
+}
+
+func (s *Service) Id() string {
+	return s.c.Id
+}
+
+func (s *Service) Message() string {
+	return s.c.Message
+}
+
+func (s *Service) Global() bool {
+	return s.c.Global
+}
+
+func (s *Service) Open() error {
+	if s.Global() {
+		s.logger.Println("I! Deadman's switch is configured globally")
+	}
+	return nil
+}
+
+func (s *Service) Close() error {
+	return nil
+}

--- a/stats.go
+++ b/stats.go
@@ -1,238 +1,64 @@
 package kapacitor
 
 import (
-	"expvar"
-	"runtime"
-	"strconv"
-	"sync"
+	"fmt"
+	"log"
 	"time"
 
-	"github.com/twinj/uuid"
+	"github.com/influxdata/kapacitor/models"
+	"github.com/influxdata/kapacitor/pipeline"
 )
 
-const (
-	// List of names for top-level exported vars
-	ClusterIDVarName = "cluster_id"
-	ServerIDVarName  = "server_id"
-	HostVarName      = "host"
-	ProductVarName   = "product"
-	VersionVarName   = "version"
-
-	NumTasksVarName         = "num_tasks"
-	NumEnabledTasksVarName  = "num_enabled_tasks"
-	NumSubscriptionsVarName = "num_subscriptions"
-
-	UptimeVarName = "uptime"
-
-	// The name of the product
-	Product = "kapacitor"
-)
-
-var (
-	// Global expvars
-	NumTasks         = &expvar.Int{}
-	NumEnabledTasks  = &expvar.Int{}
-	NumSubscriptions = &expvar.Int{}
-)
-
-var (
-	startTime time.Time
-)
-
-func init() {
-	startTime = time.Now().UTC()
-	expvar.Publish(NumTasksVarName, NumTasks)
-	expvar.Publish(NumEnabledTasksVarName, NumEnabledTasks)
-	expvar.Publish(NumSubscriptionsVarName, NumSubscriptions)
+type StatsNode struct {
+	node
+	s       *pipeline.StatsNode
+	en      Node
+	closing chan struct{}
 }
 
-// Gets an exported var and returns its unquoted string contents
-func GetStringVar(name string) string {
-	s, err := strconv.Unquote(expvar.Get(name).String())
-	if err != nil {
-		panic(err)
+// Create a new  StreamNode which filters data from a source.
+func newStatsNode(et *ExecutingTask, n *pipeline.StatsNode, l *log.Logger) (*StatsNode, error) {
+	// Lookup the executing node for stats.
+	en := et.lookup[n.SourceNode.ID()]
+	if en == nil {
+		return nil, fmt.Errorf("no node found for %s", n.SourceNode.Name())
 	}
-	return s
-}
-
-// Gets an exported var and returns its int value
-func GetIntVar(name string) int64 {
-	i, err := strconv.ParseInt(expvar.Get(name).String(), 10, 64)
-	if err != nil {
-		panic(err)
+	sn := &StatsNode{
+		node:    node{Node: n, et: et, logger: l},
+		s:       n,
+		en:      en,
+		closing: make(chan struct{}),
 	}
-	return i
+	sn.node.runF = sn.runStats
+	sn.node.stopF = sn.stopStats
+	return sn, nil
 }
 
-// Gets an exported var and returns its float value
-func GetFloatVar(name string) float64 {
-	f, err := strconv.ParseFloat(expvar.Get(name).String(), 64)
-	if err != nil {
-		panic(err)
+func (s *StatsNode) runStats([]byte) error {
+	ticker := time.NewTicker(s.s.Interval)
+	defer ticker.Stop()
+	point := models.Point{
+		Name: "stats",
+		Tags: map[string]string{"node": s.en.Name()},
 	}
-	return f
-}
-
-func Uptime() time.Duration {
-	return time.Now().Sub(startTime)
-}
-
-var expvarMu sync.Mutex
-
-// NewStatistics creates an expvar-based map. Within there "name" is the Measurement name, "tags" are the tags,
-// and values are placed at the key "values".
-// The "values" map is returned so that statistics can be set.
-func NewStatistics(name string, tags map[string]string) *expvar.Map {
-	expvarMu.Lock()
-	defer expvarMu.Unlock()
-
-	key := uuid.NewV4().String()
-
-	m := &expvar.Map{}
-	m.Init()
-	expvar.Publish(key, m)
-
-	// Set the name
-	nameVar := &expvar.String{}
-	nameVar.Set(name)
-	m.Set("name", nameVar)
-
-	// Set the tags
-	tagsVar := &expvar.Map{}
-	tagsVar.Init()
-	for k, v := range tags {
-		value := &expvar.String{}
-		value.Set(v)
-		tagsVar.Set(k, value)
-	}
-	m.Set("tags", tagsVar)
-
-	// Create and set the values entry used for actual stats.
-	statMap := &expvar.Map{}
-	statMap.Init()
-	m.Set("values", statMap)
-
-	return statMap
-}
-
-type StatsData struct {
-	Name   string                 `json:"name"`
-	Tags   map[string]string      `json:"tags"`
-	Values map[string]interface{} `json:"values"`
-}
-
-// Return all stats data from the expvars.
-func GetStatsData() ([]StatsData, error) {
-	allData := make([]StatsData, 0)
-	// Add Global expvars
-	globalData := StatsData{
-		Name:   "kapacitor",
-		Values: make(map[string]interface{}),
-	}
-
-	allData = append(allData, globalData)
-
-	expvar.Do(func(kv expvar.KeyValue) {
-		var f interface{}
-		var err error
-		switch v := kv.Value.(type) {
-		case *expvar.Float:
-			f, err = strconv.ParseFloat(v.String(), 64)
-			if err == nil {
-				globalData.Values[kv.Key] = f
-			}
-		case *expvar.Int:
-			f, err = strconv.ParseInt(v.String(), 10, 64)
-			if err == nil {
-				globalData.Values[kv.Key] = f
-			}
-		case *expvar.Map:
-			data := StatsData{
-				Tags:   make(map[string]string),
-				Values: make(map[string]interface{}),
-			}
-
-			v.Do(func(subKV expvar.KeyValue) {
-				switch subKV.Key {
-				case "name":
-					// straight to string name.
-					u, err := strconv.Unquote(subKV.Value.String())
-					if err != nil {
-						return
-					}
-					data.Name = u
-				case "tags":
-					// string-string tags map.
-					n := subKV.Value.(*expvar.Map)
-					n.Do(func(t expvar.KeyValue) {
-						u, err := strconv.Unquote(t.Value.String())
-						if err != nil {
-							return
-						}
-						data.Tags[t.Key] = u
-					})
-				case "values":
-					// string-interface map.
-					n := subKV.Value.(*expvar.Map)
-					n.Do(func(kv expvar.KeyValue) {
-						var f interface{}
-						var err error
-						switch v := kv.Value.(type) {
-						case *expvar.Float:
-							f, err = strconv.ParseFloat(v.String(), 64)
-							if err != nil {
-								return
-							}
-						case *expvar.Int:
-							f, err = strconv.ParseInt(v.String(), 10, 64)
-							if err != nil {
-								return
-							}
-						default:
-							return
-						}
-						data.Values[kv.Key] = f
-					})
+	for {
+		select {
+		case <-s.closing:
+			return nil
+		case now := <-ticker.C:
+			point.Time = now
+			count := s.en.collectedCount()
+			point.Fields = models.Fields{"collected": count}
+			for _, out := range s.outs {
+				err := out.CollectPoint(point)
+				if err != nil {
+					return err
 				}
-			})
-
-			// If no field data, don't include it in the results
-			if len(data.Values) == 0 {
-				return
 			}
-
-			allData = append(allData, data)
 		}
-	})
-
-	// Add uptime to globalData
-	globalData.Values[UptimeVarName] = Uptime().Seconds()
-
-	// Add Go memstats.
-	data := StatsData{
-		Name: "runtime",
 	}
+}
 
-	var rt runtime.MemStats
-	runtime.ReadMemStats(&rt)
-	data.Values = map[string]interface{}{
-		"Alloc":        int64(rt.Alloc),
-		"TotalAlloc":   int64(rt.TotalAlloc),
-		"Sys":          int64(rt.Sys),
-		"Lookups":      int64(rt.Lookups),
-		"Mallocs":      int64(rt.Mallocs),
-		"Frees":        int64(rt.Frees),
-		"HeapAlloc":    int64(rt.HeapAlloc),
-		"HeapSys":      int64(rt.HeapSys),
-		"HeapIdle":     int64(rt.HeapIdle),
-		"HeapInUse":    int64(rt.HeapInuse),
-		"HeapReleased": int64(rt.HeapReleased),
-		"HeapObjects":  int64(rt.HeapObjects),
-		"PauseTotalNs": int64(rt.PauseTotalNs),
-		"NumGC":        int64(rt.NumGC),
-		"NumGoroutine": int64(runtime.NumGoroutine()),
-	}
-	allData = append(allData, data)
-
-	return allData, nil
+func (s *StatsNode) stopStats() {
+	close(s.closing)
 }

--- a/stream.go
+++ b/stream.go
@@ -39,7 +39,6 @@ func newStreamNode(et *ExecutingTask, n *pipeline.StreamNode, l *log.Logger) (*S
 }
 
 func (s *StreamNode) runStream([]byte) error {
-
 	for pt, ok := s.ins[0].NextPoint(); ok; pt, ok = s.ins[0].NextPoint() {
 		if s.matches(pt) {
 			if s.s.Truncate != 0 {

--- a/task.go
+++ b/task.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/influxdata/kapacitor/pipeline"
-	"github.com/influxdata/kapacitor/tick"
 )
 
 // The type of a task
@@ -56,37 +55,6 @@ type Task struct {
 	Type             TaskType
 	DBRPs            []DBRP
 	SnapshotInterval time.Duration
-}
-
-func NewTask(
-	name,
-	script string,
-	tt TaskType,
-	dbrps []DBRP,
-	snapshotInterval time.Duration,
-	scope *tick.Scope,
-) (*Task, error) {
-	t := &Task{
-		Name:             name,
-		Type:             tt,
-		DBRPs:            dbrps,
-		SnapshotInterval: snapshotInterval,
-	}
-
-	var srcEdge pipeline.EdgeType
-	switch tt {
-	case StreamTask:
-		srcEdge = pipeline.StreamEdge
-	case BatchTask:
-		srcEdge = pipeline.BatchEdge
-	}
-
-	p, err := pipeline.CreatePipeline(script, srcEdge, scope)
-	if err != nil {
-		return nil, err
-	}
-	t.Pipeline = p
-	return t, nil
 }
 
 func (t *Task) Dot() []byte {
@@ -369,6 +337,8 @@ func (et *ExecutingTask) createNode(p pipeline.Node, l *log.Logger) (Node, error
 		return newDerivativeNode(et, t, l)
 	case *pipeline.UDFNode:
 		return newUDFNode(et, t, l)
+	case *pipeline.StatsNode:
+		return newStatsNode(et, t, l)
 	default:
 		return nil, fmt.Errorf("unknown pipeline node type %T", p)
 	}

--- a/tick/eval.go
+++ b/tick/eval.go
@@ -154,7 +154,7 @@ func eval(n Node, scope *Scope, stck *stack) (err error) {
 func evalUnary(op tokenType, scope *Scope, stck *stack) error {
 	v := stck.Pop()
 	switch op {
-	case tokenMinus:
+	case TokenMinus:
 		switch n := v.(type) {
 		case float64:
 			stck.Push(-1 * n)
@@ -163,7 +163,7 @@ func evalUnary(op tokenType, scope *Scope, stck *stack) error {
 		default:
 			return fmt.Errorf("invalid arugument to '-' %v", v)
 		}
-	case tokenNot:
+	case TokenNot:
 		if b, ok := v.(bool); ok {
 			stck.Push(!b)
 		} else {
@@ -177,10 +177,10 @@ func evalBinary(op tokenType, scope *Scope, stck *stack) error {
 	r := stck.Pop()
 	l := stck.Pop()
 	switch op {
-	case tokenAsgn:
+	case TokenAsgn:
 		i := l.(*IdentifierNode)
 		scope.Set(i.Ident, r)
-	case tokenDot:
+	case TokenDot:
 		// Resolve identifier
 		if left, ok := l.(*IdentifierNode); ok {
 			var err error

--- a/tick/lex.go
+++ b/tick/lex.go
@@ -14,24 +14,24 @@ type stateFn func(*lexer) stateFn
 const eof = -1
 
 const (
-	tokenError tokenType = iota
-	tokenEOF
-	tokenVar
-	tokenAsgn
-	tokenDot
-	tokenIdent
-	tokenReference
-	tokenLambda
-	tokenNumber
-	tokenString
-	tokenDuration
-	tokenLParen
-	tokenRParen
-	tokenComma
-	tokenNot
-	tokenTrue
-	tokenFalse
-	tokenRegex
+	TokenError tokenType = iota
+	TokenEOF
+	TokenVar
+	TokenAsgn
+	TokenDot
+	TokenIdent
+	TokenReference
+	TokenLambda
+	TokenNumber
+	TokenString
+	TokenDuration
+	TokenLParen
+	TokenRParen
+	TokenComma
+	TokenNot
+	TokenTrue
+	TokenFalse
+	TokenRegex
 
 	// begin operator tokens
 	begin_tok_operator
@@ -39,11 +39,11 @@ const (
 	//begin mathematical operators
 	begin_tok_operator_math
 
-	tokenPlus
-	tokenMinus
-	tokenMult
-	tokenDiv
-	tokenMod
+	TokenPlus
+	TokenMinus
+	TokenMult
+	TokenDiv
+	TokenMod
 
 	//end mathematical operators
 	end_tok_operator_math
@@ -51,16 +51,16 @@ const (
 	// begin comparison operators
 	begin_tok_operator_comp
 
-	tokenAnd
-	tokenOr
-	tokenEqual
-	tokenNotEqual
-	tokenLess
-	tokenGreater
-	tokenLessEqual
-	tokenGreaterEqual
-	tokenRegexEqual
-	tokenRegexNotEqual
+	TokenAnd
+	TokenOr
+	TokenEqual
+	TokenNotEqual
+	TokenLess
+	TokenGreater
+	TokenLessEqual
+	TokenGreaterEqual
+	TokenRegexEqual
+	TokenRegexNotEqual
 
 	//end comparison operators
 	end_tok_operator_comp
@@ -70,33 +70,33 @@ const (
 )
 
 var operatorStr = [...]string{
-	tokenNot:           "!",
-	tokenPlus:          "+",
-	tokenMinus:         "-",
-	tokenMult:          "*",
-	tokenDiv:           "/",
-	tokenMod:           "%",
-	tokenEqual:         "==",
-	tokenNotEqual:      "!=",
-	tokenLess:          "<",
-	tokenGreater:       ">",
-	tokenLessEqual:     "<=",
-	tokenGreaterEqual:  ">=",
-	tokenRegexEqual:    "=~",
-	tokenRegexNotEqual: "!~",
-	tokenAnd:           "AND",
-	tokenOr:            "OR",
+	TokenNot:           "!",
+	TokenPlus:          "+",
+	TokenMinus:         "-",
+	TokenMult:          "*",
+	TokenDiv:           "/",
+	TokenMod:           "%",
+	TokenEqual:         "==",
+	TokenNotEqual:      "!=",
+	TokenLess:          "<",
+	TokenGreater:       ">",
+	TokenLessEqual:     "<=",
+	TokenGreaterEqual:  ">=",
+	TokenRegexEqual:    "=~",
+	TokenRegexNotEqual: "!~",
+	TokenAnd:           "AND",
+	TokenOr:            "OR",
 }
 
 var strToOperator map[string]tokenType
 
 var keywords = map[string]tokenType{
-	"AND":    tokenAnd,
-	"OR":     tokenOr,
-	"TRUE":   tokenTrue,
-	"FALSE":  tokenFalse,
-	"var":    tokenVar,
-	"lambda": tokenLambda,
+	"AND":    TokenAnd,
+	"OR":     TokenOr,
+	"TRUE":   TokenTrue,
+	"FALSE":  TokenFalse,
+	"var":    TokenVar,
+	"lambda": TokenLambda,
 }
 
 func init() {
@@ -109,39 +109,39 @@ func init() {
 //String representation of an tokenType
 func (t tokenType) String() string {
 	switch {
-	case t == tokenError:
+	case t == TokenError:
 		return "ERR"
-	case t == tokenEOF:
+	case t == TokenEOF:
 		return "EOF"
-	case t == tokenVar:
+	case t == TokenVar:
 		return "var"
-	case t == tokenIdent:
+	case t == TokenIdent:
 		return "identifier"
-	case t == tokenReference:
+	case t == TokenReference:
 		return "reference"
-	case t == tokenDuration:
+	case t == TokenDuration:
 		return "duration"
-	case t == tokenNumber:
+	case t == TokenNumber:
 		return "number"
-	case t == tokenString:
+	case t == TokenString:
 		return "string"
-	case t == tokenRegex:
+	case t == TokenRegex:
 		return "regex"
-	case t == tokenDot:
+	case t == TokenDot:
 		return "."
-	case t == tokenAsgn:
+	case t == TokenAsgn:
 		return "="
-	case t == tokenLParen:
+	case t == TokenLParen:
 		return "("
-	case t == tokenRParen:
+	case t == TokenRParen:
 		return ")"
-	case t == tokenComma:
+	case t == TokenComma:
 		return ","
-	case t == tokenNot:
+	case t == TokenNot:
 		return "!"
-	case t == tokenTrue:
+	case t == TokenTrue:
 		return "TRUE"
-	case t == tokenFalse:
+	case t == TokenFalse:
 		return "FALSE"
 	case isOperator(t):
 		return operatorStr[t]
@@ -235,7 +235,7 @@ func (l *lexer) next() (r rune) {
 // errorf returns an error token and terminates the scan by passing
 // back a nil pointer that will be the next state, terminating l.nextToken.
 func (l *lexer) errorf(format string, args ...interface{}) stateFn {
-	l.tokens <- token{tokenError, l.start, fmt.Sprintf(format, args...)}
+	l.tokens <- token{TokenError, l.start, fmt.Sprintf(format, args...)}
 	return nil
 }
 
@@ -297,19 +297,19 @@ func lexToken(l *lexer) stateFn {
 		case isSpace(r):
 			l.ignore()
 		case r == '(':
-			l.emit(tokenLParen)
+			l.emit(TokenLParen)
 			return lexToken
 		case r == ')':
-			l.emit(tokenRParen)
+			l.emit(TokenRParen)
 			return lexToken
 		case r == '.':
-			l.emit(tokenDot)
+			l.emit(TokenDot)
 			return lexToken
 		case r == ',':
-			l.emit(tokenComma)
+			l.emit(TokenComma)
 			return lexToken
 		case r == eof:
-			l.emit(tokenEOF)
+			l.emit(TokenEOF)
 			return nil
 		default:
 			l.errorf("unknown state")
@@ -345,7 +345,7 @@ func lexOperator(l *lexer) stateFn {
 			}
 			op := strToOperator[l.current()]
 			l.emit(op)
-			if op == tokenRegexNotEqual {
+			if op == TokenRegexNotEqual {
 				l.ignoreSpace()
 				if l.peek() == '/' {
 					return lexRegex
@@ -364,14 +364,14 @@ func lexOperator(l *lexer) stateFn {
 				l.next()
 				op := strToOperator[l.current()]
 				l.emit(op)
-				if op == tokenRegexEqual {
+				if op == TokenRegexEqual {
 					l.ignoreSpace()
 					if l.peek() == '/' {
 						return lexRegex
 					}
 				}
 			} else {
-				l.emit(tokenAsgn)
+				l.emit(TokenAsgn)
 				l.ignoreSpace()
 				if l.peek() == '/' {
 					return lexRegex
@@ -390,12 +390,12 @@ func lexIdentOrKeyword(l *lexer) stateFn {
 		default:
 			l.backup()
 			if t := keywords[l.current()]; t > 0 {
-				if t == tokenLambda && l.next() != ':' {
+				if t == TokenLambda && l.next() != ':' {
 					return l.errorf("missing ':' on lambda keyword")
 				}
 				l.emit(t)
 			} else {
-				l.emit(tokenIdent)
+				l.emit(TokenIdent)
 			}
 			return lexToken
 		}
@@ -433,11 +433,11 @@ func lexNumberOrDuration(l *lexer) stateFn {
 			if r == 'm' && l.peek() == 's' {
 				l.next()
 			}
-			l.emit(tokenDuration)
+			l.emit(TokenDuration)
 			return lexToken
 		default:
 			l.backup()
-			l.emit(tokenNumber)
+			l.emit(TokenNumber)
 			return lexToken
 		}
 	}
@@ -451,7 +451,7 @@ func lexReference(l *lexer) stateFn {
 				l.next()
 			}
 		case '"':
-			l.emit(tokenReference)
+			l.emit(TokenReference)
 			return lexToken
 		case eof:
 			return l.errorf("unterminated field reference")
@@ -474,7 +474,7 @@ func lexSingleOrTripleString(l *lexer) stateFn {
 					count++
 					l.next()
 				} else {
-					l.emit(tokenString)
+					l.emit(TokenString)
 					return lexToken
 				}
 			}
@@ -490,7 +490,7 @@ func lexSingleOrTripleString(l *lexer) stateFn {
 					case r == '\'':
 						count--
 						if count == 0 {
-							l.emit(tokenString)
+							l.emit(TokenString)
 							return lexToken
 						}
 					case r == eof:
@@ -517,7 +517,7 @@ func lexRegex(l *lexer) stateFn {
 				l.next()
 			}
 		case r == '/':
-			l.emit(tokenRegex)
+			l.emit(TokenRegex)
 			return lexToken
 		default:
 			//absorb

--- a/tick/lex_test.go
+++ b/tick/lex_test.go
@@ -36,378 +36,378 @@ func TestLexer(t *testing.T) {
 		{
 			in: "!",
 			tokens: []token{
-				token{tokenNot, 0, "!"},
-				token{tokenEOF, 1, ""},
+				token{TokenNot, 0, "!"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: "+",
 			tokens: []token{
-				token{tokenPlus, 0, "+"},
-				token{tokenEOF, 1, ""},
+				token{TokenPlus, 0, "+"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: "-",
 			tokens: []token{
-				token{tokenMinus, 0, "-"},
-				token{tokenEOF, 1, ""},
+				token{TokenMinus, 0, "-"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: "*",
 			tokens: []token{
-				token{tokenMult, 0, "*"},
-				token{tokenEOF, 1, ""},
+				token{TokenMult, 0, "*"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: "/",
 			tokens: []token{
-				token{tokenDiv, 0, "/"},
-				token{tokenEOF, 1, ""},
+				token{TokenDiv, 0, "/"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: "=",
 			tokens: []token{
-				token{tokenAsgn, 0, "="},
-				token{tokenEOF, 1, ""},
+				token{TokenAsgn, 0, "="},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: "==",
 			tokens: []token{
-				token{tokenEqual, 0, "=="},
-				token{tokenEOF, 2, ""},
+				token{TokenEqual, 0, "=="},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "!=",
 			tokens: []token{
-				token{tokenNotEqual, 0, "!="},
-				token{tokenEOF, 2, ""},
+				token{TokenNotEqual, 0, "!="},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: ">",
 			tokens: []token{
-				token{tokenGreater, 0, ">"},
-				token{tokenEOF, 1, ""},
+				token{TokenGreater, 0, ">"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: ">=",
 			tokens: []token{
-				token{tokenGreaterEqual, 0, ">="},
-				token{tokenEOF, 2, ""},
+				token{TokenGreaterEqual, 0, ">="},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "<",
 			tokens: []token{
-				token{tokenLess, 0, "<"},
-				token{tokenEOF, 1, ""},
+				token{TokenLess, 0, "<"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: "<=",
 			tokens: []token{
-				token{tokenLessEqual, 0, "<="},
-				token{tokenEOF, 2, ""},
+				token{TokenLessEqual, 0, "<="},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "=~",
 			tokens: []token{
-				token{tokenRegexEqual, 0, "=~"},
-				token{tokenEOF, 2, ""},
+				token{TokenRegexEqual, 0, "=~"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "!~",
 			tokens: []token{
-				token{tokenRegexNotEqual, 0, "!~"},
-				token{tokenEOF, 2, ""},
+				token{TokenRegexNotEqual, 0, "!~"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "(",
 			tokens: []token{
-				token{tokenLParen, 0, "("},
-				token{tokenEOF, 1, ""},
+				token{TokenLParen, 0, "("},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: ")",
 			tokens: []token{
-				token{tokenRParen, 0, ")"},
-				token{tokenEOF, 1, ""},
+				token{TokenRParen, 0, ")"},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: ".",
 			tokens: []token{
-				token{tokenDot, 0, "."},
-				token{tokenEOF, 1, ""},
+				token{TokenDot, 0, "."},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		// Keywords
 		{
 			in: "AND",
 			tokens: []token{
-				token{tokenAnd, 0, "AND"},
-				token{tokenEOF, 3, ""},
+				token{TokenAnd, 0, "AND"},
+				token{TokenEOF, 3, ""},
 			},
 		},
 		{
 			in: "OR",
 			tokens: []token{
-				token{tokenOr, 0, "OR"},
-				token{tokenEOF, 2, ""},
+				token{TokenOr, 0, "OR"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "TRUE",
 			tokens: []token{
-				token{tokenTrue, 0, "TRUE"},
-				token{tokenEOF, 4, ""},
+				token{TokenTrue, 0, "TRUE"},
+				token{TokenEOF, 4, ""},
 			},
 		},
 		{
 			in: "FALSE",
 			tokens: []token{
-				token{tokenFalse, 0, "FALSE"},
-				token{tokenEOF, 5, ""},
+				token{TokenFalse, 0, "FALSE"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
 			in: "var",
 			tokens: []token{
-				token{tokenVar, 0, "var"},
-				token{tokenEOF, 3, ""},
+				token{TokenVar, 0, "var"},
+				token{TokenEOF, 3, ""},
 			},
 		},
 		//Numbers
 		{
 			in: "42",
 			tokens: []token{
-				token{tokenNumber, 0, "42"},
-				token{tokenEOF, 2, ""},
+				token{TokenNumber, 0, "42"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "42.21",
 			tokens: []token{
-				token{tokenNumber, 0, "42.21"},
-				token{tokenEOF, 5, ""},
+				token{TokenNumber, 0, "42.21"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
 			in: ".421",
 			tokens: []token{
-				token{tokenDot, 0, "."},
-				token{tokenNumber, 1, "421"},
-				token{tokenEOF, 4, ""},
+				token{TokenDot, 0, "."},
+				token{TokenNumber, 1, "421"},
+				token{TokenEOF, 4, ""},
 			},
 		},
 		{
 			in: "0.421",
 			tokens: []token{
-				token{tokenNumber, 0, "0.421"},
-				token{tokenEOF, 5, ""},
+				token{TokenNumber, 0, "0.421"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		//Durations
 		{
 			in: "42s",
 			tokens: []token{
-				token{tokenDuration, 0, "42s"},
-				token{tokenEOF, 3, ""},
+				token{TokenDuration, 0, "42s"},
+				token{TokenEOF, 3, ""},
 			},
 		},
 		{
 			in: "42.21m",
 			tokens: []token{
-				token{tokenDuration, 0, "42.21m"},
-				token{tokenEOF, 6, ""},
+				token{TokenDuration, 0, "42.21m"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
 			in: ".421h",
 			tokens: []token{
-				token{tokenDot, 0, "."},
-				token{tokenDuration, 1, "421h"},
-				token{tokenEOF, 5, ""},
+				token{TokenDot, 0, "."},
+				token{TokenDuration, 1, "421h"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
 			in: "0.421s",
 			tokens: []token{
-				token{tokenDuration, 0, "0.421s"},
-				token{tokenEOF, 6, ""},
+				token{TokenDuration, 0, "0.421s"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
 			in: "1u",
 			tokens: []token{
-				token{tokenDuration, 0, "1u"},
-				token{tokenEOF, 2, ""},
+				token{TokenDuration, 0, "1u"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "1µ",
 			tokens: []token{
-				token{tokenDuration, 0, "1µ"},
-				token{tokenEOF, 3, ""},
+				token{TokenDuration, 0, "1µ"},
+				token{TokenEOF, 3, ""},
 			},
 		},
 		{
 			in: "1ms",
 			tokens: []token{
-				token{tokenDuration, 0, "1ms"},
-				token{tokenEOF, 3, ""},
+				token{TokenDuration, 0, "1ms"},
+				token{TokenEOF, 3, ""},
 			},
 		},
 		{
 			in: "1h",
 			tokens: []token{
-				token{tokenDuration, 0, "1h"},
-				token{tokenEOF, 2, ""},
+				token{TokenDuration, 0, "1h"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "1d",
 			tokens: []token{
-				token{tokenDuration, 0, "1d"},
-				token{tokenEOF, 2, ""},
+				token{TokenDuration, 0, "1d"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: "1w",
 			tokens: []token{
-				token{tokenDuration, 0, "1w"},
-				token{tokenEOF, 2, ""},
+				token{TokenDuration, 0, "1w"},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		//Identifier
 		{
 			in: "variable",
 			tokens: []token{
-				token{tokenIdent, 0, "variable"},
-				token{tokenEOF, 8, ""},
+				token{TokenIdent, 0, "variable"},
+				token{TokenEOF, 8, ""},
 			},
 		},
 		{
 			in: "myVar01",
 			tokens: []token{
-				token{tokenIdent, 0, "myVar01"},
-				token{tokenEOF, 7, ""},
+				token{TokenIdent, 0, "myVar01"},
+				token{TokenEOF, 7, ""},
 			},
 		},
 		// References
 		{
 			in: `""`,
 			tokens: []token{
-				token{tokenReference, 0, `""`},
-				token{tokenEOF, 2, ""},
+				token{TokenReference, 0, `""`},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: `"ref with spaces"`,
 			tokens: []token{
-				token{tokenReference, 0, `"ref with spaces"`},
-				token{tokenEOF, 17, ""},
+				token{TokenReference, 0, `"ref with spaces"`},
+				token{TokenEOF, 17, ""},
 			},
 		},
 		{
 			in: `"ref\""`,
 			tokens: []token{
-				token{tokenReference, 0, `"ref\""`},
-				token{tokenEOF, 7, ""},
+				token{TokenReference, 0, `"ref\""`},
+				token{TokenEOF, 7, ""},
 			},
 		},
 		//Strings
 		{
 			in: `''`,
 			tokens: []token{
-				token{tokenString, 0, `''`},
-				token{tokenEOF, 2, ""},
+				token{TokenString, 0, `''`},
+				token{TokenEOF, 2, ""},
 			},
 		},
 		{
 			in: `''''''`,
 			tokens: []token{
-				token{tokenString, 0, `''''''`},
-				token{tokenEOF, 6, ""},
+				token{TokenString, 0, `''''''`},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
 			in: `'str'`,
 			tokens: []token{
-				token{tokenString, 0, `'str'`},
-				token{tokenEOF, 5, ""},
+				token{TokenString, 0, `'str'`},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
 			in: `'str\''`,
 			tokens: []token{
-				token{tokenString, 0, `'str\''`},
-				token{tokenEOF, 7, ""},
+				token{TokenString, 0, `'str\''`},
+				token{TokenEOF, 7, ""},
 			},
 		},
 		{
 			in: `'''s'tr'''`,
 			tokens: []token{
-				token{tokenString, 0, `'''s'tr'''`},
-				token{tokenEOF, 10, ""},
+				token{TokenString, 0, `'''s'tr'''`},
+				token{TokenEOF, 10, ""},
 			},
 		},
 		{
 			in: `'''s\'tr'''`,
 			tokens: []token{
-				token{tokenString, 0, `'''s\'tr'''`},
-				token{tokenEOF, 11, ""},
+				token{TokenString, 0, `'''s\'tr'''`},
+				token{TokenEOF, 11, ""},
 			},
 		},
 		{
 			in: `'''str'''`,
 			tokens: []token{
-				token{tokenString, 0, `'''str'''`},
-				token{tokenEOF, 9, ""},
+				token{TokenString, 0, `'''str'''`},
+				token{TokenEOF, 9, ""},
 			},
 		},
 		// Regex -- can only be lexed within context
 		{
 			in: `=~ //`,
 			tokens: []token{
-				token{tokenRegexEqual, 0, "=~"},
-				token{tokenRegex, 3, "//"},
-				token{tokenEOF, 5, ""},
+				token{TokenRegexEqual, 0, "=~"},
+				token{TokenRegex, 3, "//"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
 			in: `!~ //`,
 			tokens: []token{
-				token{tokenRegexNotEqual, 0, "!~"},
-				token{tokenRegex, 3, "//"},
-				token{tokenEOF, 5, ""},
+				token{TokenRegexNotEqual, 0, "!~"},
+				token{TokenRegex, 3, "//"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
 			in: `= //`,
 			tokens: []token{
-				token{tokenAsgn, 0, "="},
-				token{tokenRegex, 2, "//"},
-				token{tokenEOF, 4, ""},
+				token{TokenAsgn, 0, "="},
+				token{TokenRegex, 2, "//"},
+				token{TokenEOF, 4, ""},
 			},
 		},
 		{
 			in: `= /^((.*)[a-z]+\S{0,2})|cat\/\/$/`,
 			tokens: []token{
-				token{tokenAsgn, 0, "="},
-				token{tokenRegex, 2, `/^((.*)[a-z]+\S{0,2})|cat\/\/$/`},
-				token{tokenEOF, 33, ""},
+				token{TokenAsgn, 0, "="},
+				token{TokenRegex, 2, `/^((.*)[a-z]+\S{0,2})|cat\/\/$/`},
+				token{TokenEOF, 33, ""},
 			},
 		},
 
@@ -415,89 +415,89 @@ func TestLexer(t *testing.T) {
 		{
 			in: " ",
 			tokens: []token{
-				token{tokenEOF, 1, ""},
+				token{TokenEOF, 1, ""},
 			},
 		},
 		{
 			in: " \t\n",
 			tokens: []token{
-				token{tokenEOF, 3, ""},
+				token{TokenEOF, 3, ""},
 			},
 		},
 		//Combinations
 		{
 			in: "var x = avg()",
 			tokens: []token{
-				token{tokenVar, 0, "var"},
-				token{tokenIdent, 4, "x"},
-				token{tokenAsgn, 6, "="},
-				token{tokenIdent, 8, "avg"},
-				token{tokenLParen, 11, "("},
-				token{tokenRParen, 12, ")"},
-				token{tokenEOF, 13, ""},
+				token{TokenVar, 0, "var"},
+				token{TokenIdent, 4, "x"},
+				token{TokenAsgn, 6, "="},
+				token{TokenIdent, 8, "avg"},
+				token{TokenLParen, 11, "("},
+				token{TokenRParen, 12, ")"},
+				token{TokenEOF, 13, ""},
 			},
 		},
 		{
 			in: "var x = avg().parallel(4)x.groupby('cpu').window().period(10s)",
 			tokens: []token{
-				token{tokenVar, 0, "var"},
-				token{tokenIdent, 4, "x"},
-				token{tokenAsgn, 6, "="},
-				token{tokenIdent, 8, "avg"},
-				token{tokenLParen, 11, "("},
-				token{tokenRParen, 12, ")"},
-				token{tokenDot, 13, "."},
-				token{tokenIdent, 14, "parallel"},
-				token{tokenLParen, 22, "("},
-				token{tokenNumber, 23, "4"},
-				token{tokenRParen, 24, ")"},
-				token{tokenIdent, 25, "x"},
-				token{tokenDot, 26, "."},
-				token{tokenIdent, 27, "groupby"},
-				token{tokenLParen, 34, "("},
-				token{tokenString, 35, "'cpu'"},
-				token{tokenRParen, 40, ")"},
-				token{tokenDot, 41, "."},
-				token{tokenIdent, 42, "window"},
-				token{tokenLParen, 48, "("},
-				token{tokenRParen, 49, ")"},
-				token{tokenDot, 50, "."},
-				token{tokenIdent, 51, "period"},
-				token{tokenLParen, 57, "("},
-				token{tokenDuration, 58, "10s"},
-				token{tokenRParen, 61, ")"},
-				token{tokenEOF, 62, ""},
+				token{TokenVar, 0, "var"},
+				token{TokenIdent, 4, "x"},
+				token{TokenAsgn, 6, "="},
+				token{TokenIdent, 8, "avg"},
+				token{TokenLParen, 11, "("},
+				token{TokenRParen, 12, ")"},
+				token{TokenDot, 13, "."},
+				token{TokenIdent, 14, "parallel"},
+				token{TokenLParen, 22, "("},
+				token{TokenNumber, 23, "4"},
+				token{TokenRParen, 24, ")"},
+				token{TokenIdent, 25, "x"},
+				token{TokenDot, 26, "."},
+				token{TokenIdent, 27, "groupby"},
+				token{TokenLParen, 34, "("},
+				token{TokenString, 35, "'cpu'"},
+				token{TokenRParen, 40, ")"},
+				token{TokenDot, 41, "."},
+				token{TokenIdent, 42, "window"},
+				token{TokenLParen, 48, "("},
+				token{TokenRParen, 49, ")"},
+				token{TokenDot, 50, "."},
+				token{TokenIdent, 51, "period"},
+				token{TokenLParen, 57, "("},
+				token{TokenDuration, 58, "10s"},
+				token{TokenRParen, 61, ")"},
+				token{TokenEOF, 62, ""},
 			},
 		},
 		//Comments
 		{
 			in: "var x = avg()\n// Comment all of this is ignored\nx.groupby('cpu')",
 			tokens: []token{
-				token{tokenVar, 0, "var"},
-				token{tokenIdent, 4, "x"},
-				token{tokenAsgn, 6, "="},
-				token{tokenIdent, 8, "avg"},
-				token{tokenLParen, 11, "("},
-				token{tokenRParen, 12, ")"},
-				token{tokenIdent, 48, "x"},
-				token{tokenDot, 49, "."},
-				token{tokenIdent, 50, "groupby"},
-				token{tokenLParen, 57, "("},
-				token{tokenString, 58, "'cpu'"},
-				token{tokenRParen, 63, ")"},
-				token{tokenEOF, 64, ""},
+				token{TokenVar, 0, "var"},
+				token{TokenIdent, 4, "x"},
+				token{TokenAsgn, 6, "="},
+				token{TokenIdent, 8, "avg"},
+				token{TokenLParen, 11, "("},
+				token{TokenRParen, 12, ")"},
+				token{TokenIdent, 48, "x"},
+				token{TokenDot, 49, "."},
+				token{TokenIdent, 50, "groupby"},
+				token{TokenLParen, 57, "("},
+				token{TokenString, 58, "'cpu'"},
+				token{TokenRParen, 63, ")"},
+				token{TokenEOF, 64, ""},
 			},
 		},
 		{
 			in: "var x = avg()\n// Comment all of this is ignored",
 			tokens: []token{
-				token{tokenVar, 0, "var"},
-				token{tokenIdent, 4, "x"},
-				token{tokenAsgn, 6, "="},
-				token{tokenIdent, 8, "avg"},
-				token{tokenLParen, 11, "("},
-				token{tokenRParen, 12, ")"},
-				token{tokenEOF, 47, ""},
+				token{TokenVar, 0, "var"},
+				token{TokenIdent, 4, "x"},
+				token{TokenAsgn, 6, "="},
+				token{TokenIdent, 8, "avg"},
+				token{TokenLParen, 11, "("},
+				token{TokenRParen, 12, ")"},
+				token{TokenEOF, 47, ""},
 			},
 		},
 	}

--- a/tick/node_test.go
+++ b/tick/node_test.go
@@ -108,7 +108,7 @@ func TestNewBinaryNode(t *testing.T) {
 			Right: nil,
 			Operator: token{
 				pos: 0,
-				typ: tokenEqual,
+				typ: TokenEqual,
 				val: "=",
 			},
 		},

--- a/tick/parser_test.go
+++ b/tick/parser_test.go
@@ -15,16 +15,16 @@ func TestParserLookAhead(t *testing.T) {
 	p := &parser{}
 	p.lex = lex("0 1 2 3")
 
-	assert.Equal(token{tokenNumber, 0, "0"}, p.next())
-	assert.Equal(token{tokenNumber, 2, "1"}, p.peek())
-	assert.Equal(token{tokenNumber, 2, "1"}, p.next())
+	assert.Equal(token{TokenNumber, 0, "0"}, p.next())
+	assert.Equal(token{TokenNumber, 2, "1"}, p.peek())
+	assert.Equal(token{TokenNumber, 2, "1"}, p.next())
 	p.backup()
-	assert.Equal(token{tokenNumber, 2, "1"}, p.next())
-	assert.Equal(token{tokenNumber, 4, "2"}, p.peek())
+	assert.Equal(token{TokenNumber, 2, "1"}, p.next())
+	assert.Equal(token{TokenNumber, 4, "2"}, p.peek())
 	p.backup()
-	assert.Equal(token{tokenNumber, 2, "1"}, p.next())
-	assert.Equal(token{tokenNumber, 4, "2"}, p.next())
-	assert.Equal(token{tokenNumber, 6, "3"}, p.next())
+	assert.Equal(token{TokenNumber, 2, "1"}, p.next())
+	assert.Equal(token{TokenNumber, 4, "2"}, p.next())
+	assert.Equal(token{TokenNumber, 6, "3"}, p.next())
 }
 
 func TestParseErrors(t *testing.T) {
@@ -133,7 +133,7 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
@@ -152,7 +152,7 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
@@ -171,14 +171,14 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
 						},
 						Right: &UnaryNode{
 							pos:      8,
-							Operator: tokenNot,
+							Operator: TokenNot,
 							Node: &BoolNode{
 								pos:  9,
 								Bool: false,
@@ -194,7 +194,7 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
@@ -214,14 +214,14 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
 						},
 						Right: &UnaryNode{
 							pos:      8,
-							Operator: tokenMinus,
+							Operator: TokenMinus,
 							Node: &NumberNode{
 								pos:   9,
 								IsInt: true,
@@ -238,7 +238,7 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
@@ -258,14 +258,14 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
 						},
 						Right: &UnaryNode{
 							pos:      8,
-							Operator: tokenMinus,
+							Operator: TokenMinus,
 							Node: &NumberNode{
 								pos:     9,
 								IsFloat: true,
@@ -282,7 +282,7 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
@@ -301,14 +301,14 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
 						},
 						Right: &UnaryNode{
 							pos:      8,
-							Operator: tokenMinus,
+							Operator: TokenMinus,
 							Node: &DurationNode{
 								pos: 9,
 								Dur: time.Hour * 5,
@@ -324,7 +324,7 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
@@ -343,14 +343,14 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "x",
 						},
 						Right: &BinaryNode{
 							pos:      9,
-							Operator: tokenDot,
+							Operator: TokenDot,
 							Left: &IdentifierNode{
 								pos:   8,
 								Ident: "a",
@@ -372,7 +372,7 @@ func TestParseStatements(t *testing.T) {
 				Nodes: []Node{
 					&BinaryNode{
 						pos:      6,
-						Operator: tokenAsgn,
+						Operator: TokenAsgn,
 						Left: &IdentifierNode{
 							pos:   4,
 							Ident: "t",
@@ -385,7 +385,7 @@ func TestParseStatements(t *testing.T) {
 					},
 					&BinaryNode{
 						pos:      20,
-						Operator: tokenDot,
+						Operator: TokenDot,
 						Left: &IdentifierNode{
 							pos:   14,
 							Ident: "stream",
@@ -398,7 +398,7 @@ func TestParseStatements(t *testing.T) {
 									pos: 27,
 									Node: &BinaryNode{
 										pos:      43,
-										Operator: tokenGreater,
+										Operator: TokenGreater,
 										Left: &ReferenceNode{
 											pos:       35,
 											Reference: "value",
@@ -426,23 +426,23 @@ var x = stream
 				pos: 1,
 				Nodes: []Node{&BinaryNode{
 					pos:      7,
-					Operator: tokenAsgn,
+					Operator: TokenAsgn,
 					Left: &IdentifierNode{
 						pos:   5,
 						Ident: "x",
 					},
 					Right: &BinaryNode{
 						pos:      57,
-						Operator: tokenDot,
+						Operator: TokenDot,
 						Left: &BinaryNode{
 							pos:      44,
-							Operator: tokenDot,
+							Operator: TokenDot,
 							Left: &BinaryNode{
 								pos:      30,
-								Operator: tokenDot,
+								Operator: TokenDot,
 								Left: &BinaryNode{
 									pos:      18,
-									Operator: tokenDot,
+									Operator: TokenDot,
 									Left: &IdentifierNode{
 										pos:   9,
 										Ident: "stream",
@@ -475,10 +475,10 @@ var x = stream
 							Func: "map",
 							Args: []Node{&BinaryNode{
 								pos:      74,
-								Operator: tokenDot,
+								Operator: TokenDot,
 								Left: &BinaryNode{
 									pos:      70,
-									Operator: tokenDot,
+									Operator: TokenDot,
 									Left: &IdentifierNode{
 										pos:   62,
 										Ident: "influxql",

--- a/tick/stateful_expr.go
+++ b/tick/stateful_expr.go
@@ -151,7 +151,7 @@ func (s *StatefulExpr) eval(n Node, scope *Scope, stck *stack) (err error) {
 func (s *StatefulExpr) evalUnary(op tokenType, scope *Scope, stck *stack) error {
 	v := stck.Pop()
 	switch op {
-	case tokenMinus:
+	case TokenMinus:
 		switch n := v.(type) {
 		case float64:
 			stck.Push(-1 * n)
@@ -160,7 +160,7 @@ func (s *StatefulExpr) evalUnary(op tokenType, scope *Scope, stck *stack) error 
 		default:
 			return fmt.Errorf("invalid arugument to '-' %v", v)
 		}
-	case tokenNot:
+	case TokenNot:
 		if b, ok := v.(bool); ok {
 			stck.Push(!b)
 		} else {
@@ -264,15 +264,15 @@ func (s *StatefulExpr) evalBinary(op tokenType, scope *Scope, stck *stack) (err 
 
 func doIntMath(op tokenType, l, r int64) (v int64, err error) {
 	switch op {
-	case tokenPlus:
+	case TokenPlus:
 		v = l + r
-	case tokenMinus:
+	case TokenMinus:
 		v = l - r
-	case tokenMult:
+	case TokenMult:
 		v = l * r
-	case tokenDiv:
+	case TokenDiv:
 		v = l / r
-	case tokenMod:
+	case TokenMod:
 		v = l % r
 	default:
 		return 0, fmt.Errorf("invalid integer math operator %v", op)
@@ -282,13 +282,13 @@ func doIntMath(op tokenType, l, r int64) (v int64, err error) {
 
 func doFloatMath(op tokenType, l, r float64) (v float64, err error) {
 	switch op {
-	case tokenPlus:
+	case TokenPlus:
 		v = l + r
-	case tokenMinus:
+	case TokenMinus:
 		v = l - r
-	case tokenMult:
+	case TokenMult:
 		v = l * r
-	case tokenDiv:
+	case TokenDiv:
 		v = l / r
 	default:
 		return math.NaN(), fmt.Errorf("invalid float math operator %v", op)
@@ -298,13 +298,13 @@ func doFloatMath(op tokenType, l, r float64) (v float64, err error) {
 
 func doBoolComp(op tokenType, l, r bool) (v bool, err error) {
 	switch op {
-	case tokenEqual:
+	case TokenEqual:
 		v = l == r
-	case tokenNotEqual:
+	case TokenNotEqual:
 		v = l != r
-	case tokenAnd:
+	case TokenAnd:
 		v = l && r
-	case tokenOr:
+	case TokenOr:
 		v = l || r
 	default:
 		err = fmt.Errorf("invalid boolean comparison operator %v", op)
@@ -314,17 +314,17 @@ func doBoolComp(op tokenType, l, r bool) (v bool, err error) {
 
 func doFloatComp(op tokenType, l, r float64) (v bool, err error) {
 	switch op {
-	case tokenEqual:
+	case TokenEqual:
 		v = l == r
-	case tokenNotEqual:
+	case TokenNotEqual:
 		v = l != r
-	case tokenLess:
+	case TokenLess:
 		v = l < r
-	case tokenGreater:
+	case TokenGreater:
 		v = l > r
-	case tokenLessEqual:
+	case TokenLessEqual:
 		v = l <= r
-	case tokenGreaterEqual:
+	case TokenGreaterEqual:
 		v = l >= r
 	default:
 		err = fmt.Errorf("invalid float comparison operator %v", op)
@@ -334,17 +334,17 @@ func doFloatComp(op tokenType, l, r float64) (v bool, err error) {
 
 func doStringComp(op tokenType, l, r string) (v bool, err error) {
 	switch op {
-	case tokenEqual:
+	case TokenEqual:
 		v = l == r
-	case tokenNotEqual:
+	case TokenNotEqual:
 		v = l != r
-	case tokenLess:
+	case TokenLess:
 		v = l < r
-	case tokenGreater:
+	case TokenGreater:
 		v = l > r
-	case tokenLessEqual:
+	case TokenLessEqual:
 		v = l <= r
-	case tokenGreaterEqual:
+	case TokenGreaterEqual:
 		v = l >= r
 	default:
 		err = fmt.Errorf("invalid string comparison operator %v", op)
@@ -354,9 +354,9 @@ func doStringComp(op tokenType, l, r string) (v bool, err error) {
 
 func doRegexComp(op tokenType, l string, r *regexp.Regexp) (v bool, err error) {
 	switch op {
-	case tokenRegexEqual:
+	case TokenRegexEqual:
 		v = r.MatchString(l)
-	case tokenRegexNotEqual:
+	case TokenRegexNotEqual:
 		v = !r.MatchString(l)
 	default:
 		err = fmt.Errorf("invalid regex comparison operator %v", op)


### PR DESCRIPTION
Fixes #137 

A deadman's switch can now be added to any node within any task. This is accomplished via exposing the internal statistics per node to the TICKscript itself via the `stats` method.

The `stats` method emits the internal stats of a node at a given interval. The deaman's switch uses the `collected` stat to trigger an alert if it drops below a threshold.

The method `deadman` is available on all nodes and is a helper function to easily create a deadman's switch.

This:
```javascript
 var data = stream.from()...
    // Trigger critical alert if the throughput drops below 100 events per 10s and checked every 10s.
    data.deadman(100.0, 10s)
    //Do normal processing of data
    data....
```
 is equivalent to this:

```javascript
 var data = stream.from()...
    // Trigger critical alert if the throughput drops below 100 events per 1s and checked every 10s.
    data.stats(10s)
          .derivative('collected')
              .nonNegative()
              .unit(10s)
          .alert()
              .id('node \'stream0\' in task \'{{ .TaskName }}\'')
              .message('{{ .ID }} is dead: {{ index .Fields "collected" }} points/10s')
              .crit(lamdba: "collected" <= 100.0)
    //Do normal processing of data
    data....
```

In addition to the `deadman` method you can globally configure all stream tasks to have deadman's switches.

```
[deadman]
  global = true
  interval = "10s"
  threshold = 100.0
```

The `id` and `message` fields can also be configured globally.

EDIT: Changed examples to match final implementation