### PR TITLE
Remove incompatible api pathing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ There are simple examples of how to use UDFs in [udf/agent/examples](https://git
 The version has jumped significantly so that it is inline with other projects in the TICK stack.
 This way you can easily tell which versions of Telegraf, InfluxDB, Chronograf and Kapacitor work together.
 
+See note on a breaking change in the HTTP API below. #163
+
 
 ### Features
 - [#137](https://github.com/influxdata/kapacitor/issues/137): Add deadman's switch. Can be setup via TICKscript and globally via configuration.
@@ -24,6 +26,9 @@ This way you can easily tell which versions of Telegraf, InfluxDB, Chronograf an
 - [#153](https://github.com/influxdata/kapacitor/issues/153): Fix panic if referencing non existant field in MapReduce function.
 - [#138](https://github.com/influxdata/kapacitor/issues/138): Change over to influxdata github org.
 - [#164](https://github.com/influxdata/kapacitor/issues/164): Update imports etc from InfluxDB as per the new meta store/client changes.
+- [#163](https://github.com/influxdata/kapacitor/issues/163): BREAKING CHANGE: Removed the 'api/v1' pathing from the HTTP API so that Kapacitor is 
+    path compatible with InfluxDB. While this is a breaking change the kapacitor cli has been updated accordingly and you will not experience any distruptions unless you 
+    were calling the HTTP API directly.
 
 ## v0.2.4 [2016-01-07]
 

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -78,7 +78,7 @@ func main() {
 		url = *kapacitordURL
 	}
 
-	kapacitorEndpoint = url + "/api/v1"
+	kapacitorEndpoint = url
 
 	args := mainFlags.Args()
 

--- a/cmd/kapacitord/run/server_helper_test.go
+++ b/cmd/kapacitord/run/server_helper_test.go
@@ -148,7 +148,7 @@ func (s *Server) Write(db, rp, body string, params url.Values) (results string, 
 	if params.Get("rp") == "" {
 		params.Set("rp", rp)
 	}
-	resp, err := http.Post(s.URL()+"/api/v1/write?"+params.Encode(), "", strings.NewReader(body))
+	resp, err := http.Post(s.URL()+"/write?"+params.Encode(), "", strings.NewReader(body))
 	if err != nil {
 		return "", err
 	} else if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
@@ -166,26 +166,26 @@ func (s *Server) DefineTask(name, ttype, tick string, dbrps []kapacitor.DBRP) (r
 	v.Add("name", name)
 	v.Add("type", ttype)
 	v.Add("dbrps", string(dbrpsStr))
-	results, err = s.HTTPPost(s.URL()+"/api/v1/task?"+v.Encode(), []byte(tick))
+	results, err = s.HTTPPost(s.URL()+"/task?"+v.Encode(), []byte(tick))
 	return
 }
 
 func (s *Server) EnableTask(name string) (string, error) {
 	v := url.Values{}
 	v.Add("name", name)
-	return s.HTTPPost(s.URL()+"/api/v1/enable?"+v.Encode(), nil)
+	return s.HTTPPost(s.URL()+"/enable?"+v.Encode(), nil)
 }
 
 func (s *Server) DisableTask(name string) (string, error) {
 	v := url.Values{}
 	v.Add("name", name)
-	return s.HTTPPost(s.URL()+"/api/v1/disable?"+v.Encode(), nil)
+	return s.HTTPPost(s.URL()+"/disable?"+v.Encode(), nil)
 }
 
 func (s *Server) DeleteTask(name string) error {
 	v := url.Values{}
 	v.Add("name", name)
-	req, err := http.NewRequest("DELETE", s.URL()+"/api/v1/task?"+v.Encode(), nil)
+	req, err := http.NewRequest("DELETE", s.URL()+"/task?"+v.Encode(), nil)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func (s *Server) DeleteTask(name string) error {
 func (s *Server) GetTask(name string) (ti task_store.TaskInfo, err error) {
 	v := url.Values{}
 	v.Add("name", name)
-	resp, err := http.Get(s.URL() + "/api/v1/task?" + v.Encode())
+	resp, err := http.Get(s.URL() + "/task?" + v.Encode())
 	if err != nil {
 		return
 	}
@@ -251,7 +251,7 @@ func (s *Server) DoStreamRecording(name string, duration time.Duration, started 
 	v.Add("type", "stream")
 	v.Add("name", name)
 	v.Add("duration", duration.String())
-	r, err := http.Post(s.URL()+"/api/v1/record?"+v.Encode(), "", nil)
+	r, err := http.Post(s.URL()+"/record?"+v.Encode(), "", nil)
 	if err != nil {
 		return
 	}
@@ -277,7 +277,7 @@ func (s *Server) DoStreamRecording(name string, duration time.Duration, started 
 	close(started)
 	v = url.Values{}
 	v.Add("id", id)
-	_, err = s.HTTPGet(s.URL() + "/api/v1/record?" + v.Encode())
+	_, err = s.HTTPGet(s.URL() + "/record?" + v.Encode())
 	return
 }
 
@@ -286,7 +286,7 @@ func (s *Server) DoBatchRecording(name string, past time.Duration) (id string, e
 	v.Add("type", "batch")
 	v.Add("name", name)
 	v.Add("past", past.String())
-	r, err := http.Post(s.URL()+"/api/v1/record?"+v.Encode(), "", nil)
+	r, err := http.Post(s.URL()+"/record?"+v.Encode(), "", nil)
 	if err != nil {
 		return
 	}
@@ -311,7 +311,7 @@ func (s *Server) DoBatchRecording(name string, past time.Duration) (id string, e
 	id = rp.RecordingID
 	v = url.Values{}
 	v.Add("id", id)
-	_, err = s.HTTPGet(s.URL() + "/api/v1/record?" + v.Encode())
+	_, err = s.HTTPGet(s.URL() + "/record?" + v.Encode())
 	return
 }
 
@@ -321,7 +321,7 @@ func (s *Server) DoReplay(name, id string) (string, error) {
 	v.Add("id", id)
 	v.Add("clock", "fast")
 	v.Add("rec-time", "true")
-	return s.HTTPPost(s.URL()+"/api/v1/replay?"+v.Encode(), nil)
+	return s.HTTPPost(s.URL()+"/replay?"+v.Encode(), nil)
 }
 
 // NewConfig returns the default config with temporary paths.

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -27,7 +27,7 @@ import (
 func TestServer_Ping(t *testing.T) {
 	s := OpenDefaultServer()
 	defer s.Close()
-	r, err := s.HTTPGet(s.URL() + "/api/v1/ping")
+	r, err := s.HTTPGet(s.URL() + "/ping")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestServer_Ping(t *testing.T) {
 func TestServer_Version(t *testing.T) {
 	s := OpenDefaultServer()
 	defer s.Close()
-	resp, err := http.Get(s.URL() + "/api/v1/ping")
+	resp, err := http.Get(s.URL() + "/ping")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +308,7 @@ stream
 		t.Fatal("unexpected result", r)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/v1/%s/count", s.URL(), name)
+	endpoint := fmt.Sprintf("%s/%s/count", s.URL(), name)
 
 	// Request data before any writes and expect null responses
 	nullResponse := `{"Series":null,"Err":null}`
@@ -409,7 +409,7 @@ batch
 		t.Fatal("unexpected result", r)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/v1/%s/count", s.URL(), name)
+	endpoint := fmt.Sprintf("%s/%s/count", s.URL(), name)
 
 	exp := `{"Series":[{"name":"cpu","columns":["time","count"],"values":[["1971-01-01T00:00:01.002Z",2]]}],"Err":null}`
 	err = s.HTTPGetRetry(endpoint, exp, 100, time.Millisecond*5)
@@ -790,7 +790,7 @@ stream
 		t.Fatal("unexpected result", r)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/v1/%s/moving_avg", s.URL(), name)
+	endpoint := fmt.Sprintf("%s/%s/moving_avg", s.URL(), name)
 
 	// Request data before any writes and expect null responses
 	nullResponse := `{"Series":null,"Err":null}`

--- a/http_out.go
+++ b/http_out.go
@@ -70,7 +70,7 @@ func (h *HTTPOutNode) runOut([]byte) error {
 		HandlerFunc: hndl,
 	}}
 
-	h.endpoint = h.et.tm.HTTPDService.URL() + httpd.APIRoot + p
+	h.endpoint = h.et.tm.HTTPDService.URL() + p
 	func() {
 		h.mu.Lock()
 		defer h.mu.Unlock()

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -32,10 +32,6 @@ const (
 	statPointsWrittenFail         = "points_written_fail" // Number of points that failed to be written
 )
 
-const (
-	APIRoot = "/api/v1"
-)
-
 type Route struct {
 	Name        string
 	Method      string
@@ -103,23 +99,22 @@ func NewHandler(requireAuthentication, loggingEnabled, writeTrace bool, statMap 
 			"log-level", // Display current API routes
 			"POST", "/loglevel", true, true, h.serveLogLevel,
 		},
-	})
-
-	h.addRawRoute(Route{
-		"404", // Catch all 404
-		"GET", "/", true, true, h.serve404,
-	})
-	h.addRawRoute(Route{
-		"404", // Catch all 404
-		"POST", "/", true, true, h.serve404,
-	})
-	h.addRawRoute(Route{
-		"404", // Catch all 404
-		"DELETE", "/", true, true, h.serve404,
-	})
-	h.addRawRoute(Route{
-		"404", // Catch all 404
-		"HEAD", "/", true, true, h.serve404,
+		Route{
+			"404", // Catch all 404
+			"GET", "/", true, true, h.serve404,
+		},
+		Route{
+			"404", // Catch all 404
+			"POST", "/", true, true, h.serve404,
+		},
+		Route{
+			"404", // Catch all 404
+			"DELETE", "/", true, true, h.serve404,
+		},
+		Route{
+			"404", // Catch all 404
+			"HEAD", "/", true, true, h.serve404,
+		},
 	})
 
 	return h
@@ -134,12 +129,8 @@ func (h *Handler) AddRoutes(routes []Route) error {
 	}
 	return nil
 }
-func (h *Handler) AddRoute(r Route) error {
-	r.Pattern = APIRoot + r.Pattern
-	return h.addRawRoute(r)
-}
 
-func (h *Handler) addRawRoute(r Route) error {
+func (h *Handler) AddRoute(r Route) error {
 	var handler http.Handler
 	// If it's a handler func that requires authorization, wrap it in authorization
 	if hf, ok := r.HandlerFunc.(func(http.ResponseWriter, *http.Request, *meta.UserInfo)); ok {
@@ -179,7 +170,7 @@ func (h *Handler) DelRoutes(routes []Route) {
 func (h *Handler) DelRoute(r Route) {
 	mux, ok := h.methodMux[r.Method]
 	if ok {
-		mux.Deregister(APIRoot + r.Pattern)
+		mux.Deregister(r.Pattern)
 	}
 }
 


### PR DESCRIPTION
Fixes #163 
Turns out Telegraf ignores any errors to the Create Database call so we don't have to mock it. I also checked the python client and it does not explicitly check that the database exists either. 

I like this behavior because the actual write request returns its own success/failure codes and so there should not be any need to explicitly check that a database exists. Just write the data...