### PR TITLE
Specify RestartSec for systemd

### DIFF
--- a/scripts/kapacitor.service
+++ b/scripts/kapacitor.service
@@ -13,6 +13,7 @@ EnvironmentFile=-/etc/default/kapacitor
 ExecStart=/usr/bin/kapacitord -config /etc/kapacitor/kapacitor.conf $KAPACITOR_OPTS
 KillMode=process
 Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Kapacitor may depend on an external resource (most likely influxdb) to be present when starting. If that service is unavailable, kapacitor will exit immediately. The default restart time for systemd services is
100ms. If a service restarts too often within a timespan, systemd will stop trying to restart it. Adding a higher RestartSec prevents this problem.