### PR TITLE
add alert support for Details property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improved UDFs, lots of bug fixes and improvements on the API. There was a breaki
 
 - [#176](https://github.com/influxdata/kapacitor/issues/176): Improved UDFs and groups. Now it is easy to deal with groups from the UDF process.
     NOTE: There is a breaking change in the BeginBatch protobuf message for this change.
+- [#196](https://github.com/influxdata/kapacitor/issues/196): Adds a 'details' property to the alert node so that the email body can be defined. See also [#75](https://github.com/influxdata/kapacitor/issues/75).
 
 ### Bugfixes
 

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -441,14 +441,20 @@ func (s *Server) Open() error {
 func (s *Server) Close() error {
 	s.stopProfile()
 
-	// Close services to allow any inflight requests to complete
-	// and prevent new requests from being accepted.
+	// First stop all tasks.
+	s.TaskMaster.StopTasks()
+
+	// Close services now that all tasks are stopped.
 	for _, service := range s.Services {
 		s.Logger.Printf("D! closing service: %T", service)
-		service.Close()
+		err := service.Close()
+		if err != nil {
+			s.Logger.Printf("E! error closing service %T: %v", service, err)
+		}
 		s.Logger.Printf("D! closed service: %T", service)
 	}
 
+	// Finally close the task master
 	return s.TaskMaster.Close()
 }
 

--- a/integrations/helpers_test.go
+++ b/integrations/helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/wlog"
 	"github.com/influxdb/influxdb/client"
+	"github.com/influxdb/influxdb/influxql"
 )
 
 type MockInfluxDBService struct {
@@ -99,6 +100,21 @@ func compareResultsIgnoreSeriesOrder(exp, got kapacitor.Result) (bool, string) {
 		}
 	}
 	return true, ""
+}
+
+func compareAlertData(exp, got kapacitor.AlertData) (bool, string) {
+	// Pull out Result for comparision
+	expData := kapacitor.Result(exp.Data)
+	exp.Data = influxql.Result{}
+	gotData := kapacitor.Result(got.Data)
+	kapacitor.ConvertResultTimes(&gotData)
+	got.Data = influxql.Result{}
+
+	if !reflect.DeepEqual(got, exp) {
+		return false, fmt.Sprintf("\ngot %v\nexp %v", got, exp)
+	}
+
+	return compareResults(expData, gotData)
 }
 
 type LogService struct{}

--- a/result.go
+++ b/result.go
@@ -22,16 +22,20 @@ func ResultFromJSON(in io.Reader) (r Result) {
 
 	json.Unmarshal(b, &r)
 	// Convert all times to time.Time
+	ConvertResultTimes(&r)
+	return
+}
+
+func ConvertResultTimes(r *Result) {
 	for _, series := range r.Series {
 		for i, v := range series.Values {
-			var t time.Time
 			for j, c := range series.Columns {
 				if c == "time" {
 					tStr, ok := v[j].(string)
 					if !ok {
 						continue
 					}
-					t, err = time.Parse(time.RFC3339, tStr)
+					t, err := time.Parse(time.RFC3339, tStr)
 					if err != nil {
 						continue
 					}
@@ -41,6 +45,4 @@ func ResultFromJSON(in io.Reader) (r Result) {
 			}
 		}
 	}
-
-	return
 }

--- a/services/smtp/service.go
+++ b/services/smtp/service.go
@@ -92,7 +92,7 @@ func (s *Service) runMailer() {
 	}
 }
 
-func (s *Service) SendMail(to []string, subject, msg string) error {
+func (s *Service) SendMail(to []string, subject, body string) error {
 	if len(to) == 0 {
 		to = s.c.To
 	}
@@ -103,7 +103,7 @@ func (s *Service) SendMail(to []string, subject, msg string) error {
 	m.SetHeader("From", s.c.From)
 	m.SetHeader("To", to...)
 	m.SetHeader("Subject", subject)
-	m.SetBody("text/plain", msg)
+	m.SetBody("text/html", body)
 	s.mail <- m
 	return nil
 }

--- a/task_master.go
+++ b/task_master.go
@@ -150,6 +150,14 @@ func (tm *TaskMaster) Open() (err error) {
 	return
 }
 
+func (tm *TaskMaster) StopTasks() {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	for _, et := range tm.tasks {
+		tm.stopTask(et.Task.Name)
+	}
+}
+
 func (tm *TaskMaster) Close() error {
 	tm.Drain()
 	tm.mu.Lock()


### PR DESCRIPTION
Fixes #196 and Fixes #75 

Now the alert node has a `details` property that can be formatted HTML containing details of the alert. The details property is used as the body of email alerts.