### PR TITLE
Add test.sh for testing various envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ kapacitor*.tar
 kapacitor*.zip
 *.pyc
 *.test
+/test-logs

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -1,0 +1,53 @@
+FROM 32bit/ubuntu:14.04
+
+# This dockerfile capabable  of the the minumum required
+# to run the tests and nothing else.
+
+MAINTAINER support@influxdb.com
+
+RUN apt-get update && apt-get install -y \
+    wget \
+    git \
+    mercurial \
+    build-essential \
+    autoconf \
+    automake \
+    libtool \
+    python-setuptools \
+    zip \
+    curl
+
+# Install protobuf3
+ENV PROTO_VERSION 3.0.0-beta-2
+# Download and compile protoc
+RUN wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz && \
+    tar xf v${PROTO_VERSION}.tar.gz && \
+    rm -f v${PROTO_VERSION}.tar.gz && \
+    cd protobuf-${PROTO_VERSION} && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr && \
+    make -j $(nproc) && \
+    make check && \
+    make install
+
+# Install Python Protobuf3
+RUN cd protobuf-${PROTO_VERSION}/python && \
+    python setup.py install;
+
+# Install go
+ENV GOPATH /root/go
+ENV GO_VERSION 1.5.3
+ENV GO_ARCH 386
+RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
+   tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \
+   rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV PROJECT_DIR $GOPATH/src/github.com/influxdata/kapacitor
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p $PROJECT_DIR
+WORKDIR $PROJECT_DIR
+
+VOLUME $PROJECT_DIR
+
+ENTRYPOINT [ "/root/go/src/github.com/influxdata/kapacitor/build.py" ]

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,0 +1,64 @@
+FROM ubuntu:latest
+
+# This dockerfile is capabable of performing all
+# build/test/package/deploy actions needed for Kapacitor.
+
+MAINTAINER support@influxdb.com
+
+RUN apt-get update && apt-get install -y \
+    python-software-properties \
+    software-properties-common \
+    wget \
+    git \
+    mercurial \
+    make \
+    ruby \
+    ruby-dev \
+    rpm \
+    zip \
+    python \
+    python-boto \
+    build-essential \
+    autoconf \
+    automake \
+    libtool \
+    python-setuptools \
+    curl
+
+RUN gem install fpm
+
+# Install protobuf3
+ENV PROTO_VERSION 3.0.0-beta-2
+# Download and compile protoc
+RUN wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz && \
+    tar xf v${PROTO_VERSION}.tar.gz && \
+    rm -f v${PROTO_VERSION}.tar.gz && \
+    cd protobuf-${PROTO_VERSION} && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr && \
+    make -j $(nproc) && \
+    make check && \
+    make install
+
+# Install Python Protobuf3
+RUN cd protobuf-${PROTO_VERSION}/python && \
+    python setup.py install;
+
+
+# Install go
+ENV GOPATH /root/go
+ENV GO_VERSION 1.5.3
+ENV GO_ARCH amd64
+RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
+   tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \
+   rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV PROJECT_DIR $GOPATH/src/github.com/influxdata/kapacitor
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p $PROJECT_DIR
+WORKDIR $PROJECT_DIR
+
+VOLUME $PROJECT_DIR
+
+ENTRYPOINT [ "/root/go/src/github.com/influxdata/kapacitor/build.py" ]

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -1,33 +1,23 @@
-# This Dockerfile provides the needed environment to build Kapacitor.
-FROM ubuntu:trusty
+FROM ubuntu:latest
+
+# This dockerfile capabable  of the the minumum required
+# to run the tests and nothing else.
 
 MAINTAINER support@influxdb.com
 
-# Install deps
-RUN apt-get update
-RUN apt-get install -y \
-    make \
-    wget  \
+RUN apt-get update && apt-get install -y \
+    wget \
     git \
     mercurial \
-    ruby \
-    ruby-dev \
-    rpm \
-    zip \
-    python \
-    python-boto
-
-RUN gem install fpm
-
-# Install protobuf3
-RUN apt-get install -y \
     build-essential \
     autoconf \
     automake \
     libtool \
     python-setuptools \
+    zip \
     curl
 
+# Install protobuf3
 ENV PROTO_VERSION 3.0.0-beta-2
 # Download and compile protoc
 RUN wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz && \
@@ -44,30 +34,29 @@ RUN wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz && 
 RUN cd protobuf-${PROTO_VERSION}/python && \
     python setup.py install;
 
+# Setup env
+ENV GOPATH /root/go
+ENV PROJECT_DIR $GOPATH/src/github.com/influxdata/kapacitor
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p $PROJECT_DIR
+
+VOLUME $PROJECT_DIR
 
 
 # Install go
-ENV GO_VERSION 1.5.3
+ENV GO_VERSION 1.4.3
 ENV GO_ARCH amd64
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \
    rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
-ENV PATH /usr/local/go/bin:$PATH
-ENV GOPATH /gopath
-ENV PATH $GOPATH/bin:$PATH
-ENV PROJECT_PATH $GOPATH/src/github.com/influxdata/kapacitor
-RUN mkdir -p $PROJECT_PATH
 
-WORKDIR $PROJECT_PATH
-ENTRYPOINT ["/usr/local/bin/build"]
-CMD []
+# Clone Go tip for compilation
+ENV GOROOT_BOOTSTRAP /usr/local/go
+RUN git clone https://go.googlesource.com/go
+ENV PATH /go/bin:$PATH
 
-# Get gogo for golang protobuf
-RUN go get github.com/gogo/protobuf/protoc-gen-gogo
 
-# Initialize git, needed to stash changes before 'go get ./...'
-RUN git config --global user.email "support@influxdb.com"
-RUN git config --global user.name "Docker Builder"
-
-ADD ./build.py /usr/local/bin/build
-
+# Add script for compiling go
+ENV GO_CHECKOUT master
+ADD ./gobuild.sh /gobuild.sh
+ENTRYPOINT [ "/gobuild.sh" ]

--- a/build.py
+++ b/build.py
@@ -115,6 +115,7 @@ def package_scripts(build_root):
 
 def run_generate():
     print "Running generate..."
+    run("go get github.com/gogo/protobuf/protoc-gen-gogo")
     command = "go generate ./..."
     code = os.system(command)
     if code != 0:

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ cd $DIR
 
 
 # Build new docker image
-docker build -t influxdata/kapacitor-builder $DIR
+docker build -f Dockerfile_build_ubuntu64 -t influxdata/kapacitor-builder $DIR
 echo "Running build.py"
 # Run docker
 docker run --rm \

--- a/circle-test.sh
+++ b/circle-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# This is the InfluxDB test script for CircleCI, it is a light wrapper around ./test.sh.
+
+# Exit if any command fails
+set -e
+
+# Get dir of script and make it is our working directory.
+DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+cd $DIR
+
+
+export OUTPUT_DIR="$CIRCLE_ARTIFACTS"
+# Don't delete the container since CircleCI doesn't have permission to do so.
+export DOCKER_RM="false"
+
+# Get number of test environments.
+count=$(./test.sh count)
+# Check that we aren't wasting CircleCI nodes.
+if [ $CIRCLE_NODE_TOTAL -gt $count ]
+then
+    echo "More CircleCI nodes allocated than tests environments to run!"
+    exit 1
+fi
+
+# Map CircleCI nodes to test environments.
+tests=$(seq 0 $((count - 1)))
+for i in $tests
+do
+    mine=$(( $i % $CIRCLE_NODE_TOTAL ))
+    if [ $mine -eq $CIRCLE_NODE_INDEX ]
+    then
+        echo "Running test env index: $i"
+        ./test.sh $i
+    fi
+done

--- a/circle.yml
+++ b/circle.yml
@@ -1,32 +1,23 @@
-# The forces Circle CI to get a fresh clone of the repo.
-#checkout:
-#  post:
-#    - rm -rf ~/kapacitor
-#    - git clone git@github.com:influxdata/kapacitor.git ~/kapacitor
-
 machine:
-  services:
-    - docker
+    services:
+        - docker
 
 dependencies:
-  pre:
-    # setup ipv6
-    - sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 net.ipv6.conf.default.disable_ipv6=0 net.ipv6.conf.all.disable_ipv6=0
-  cache_directories:
-    - "~/docker"
-  override:
-    - if [[ -e ~/docker/kapacitor-builder.tar ]]; then docker load -i ~/docker/kapacitor-builder.tar; fi
-    - docker build -t influxdata/kapacitor-builder .
-    - mkdir -p ~/docker; docker save influxdata/kapacitor-builder > ~/docker/kapacitor-builder.tar
+    pre:
+      # setup ipv6
+      - sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 net.ipv6.conf.default.disable_ipv6=0 net.ipv6.conf.all.disable_ipv6=0
+    cache_directories:
+        - "~/docker"
+    override:
+      - ./test.sh save
 
 test:
-  override:
-    - ./build.sh --test --generate --no-stash
-    - ./build.sh --test --generate --no-stash --race
-
+    override:
+        - bash circle-test.sh:
+            parallel: true
 
 deployment:
-  release:
-    tag: /v[0-9]+(\.[0-9]+){2}(-rc[0-9]+)?/
-    commands:
-      - ./build.sh --clean --generate --package --upload --platform=all --arch=all
+    release:
+        tag: /v[0-9]+(\.[0-9]+){2}(-rc[0-9]+)?/
+        commands:
+            - ./build.sh --clean --generate --package --upload --platform=all --arch=all

--- a/gobuild.sh
+++ b/gobuild.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script run inside the Dockerfile_build_ubuntu64_git container and
+# gets the latests Go source code and compiles it.
+# Then passes control over to the normal build.py script
+
+set -e
+
+cd /go/src
+git fetch --all
+git checkout $GO_CHECKOUT
+# Merge in recent changes if we are on a branch
+# if we checked out a tag just ignore the error
+git pull || true
+./make.bash
+
+# Run normal build.py
+cd "$PROJECT_DIR"
+exec ./build.py "$@"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+#
+# This is the Kapacitor test script.
+# This script can run tests in different environments.
+# # Usage: ./test.sh <environment_index>
+# Corresponding environments for environment_index:
+#      0: normal 64bit tests
+#      1: race enabled 64bit tests
+#      2: normal 32bit tests
+#      3: normal 64bit tests against Go 1.6beta2
+#      save: build the docker images and save them to DOCKER_SAVE_DIR. Do not run tests.
+#      count: print the number of test environments
+#      *: to run all tests in parallel containers
+#
+# Logs from the test runs will be saved in OUTPUT_DIR, which defaults to ./test-logs
+#
+
+# Get dir of script and make it is our working directory.
+DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+cd $DIR
+
+ENVIRONMENT_INDEX=$1
+# Set the default OUTPUT_DIR
+OUTPUT_DIR=${OUTPUT_DIR-./test-logs}
+# Set the default DOCKER_SAVE_DIR
+DOCKER_SAVE_DIR=${DOCKER_SAVE_DIR-$HOME/docker}
+# Set default parallelism
+PARALLELISM=${PARALLELISM-1}
+# Set default timeout
+TIMEOUT=${TIMEOUT-480s}
+
+# Default to deleteing the container
+DOCKER_RM=${DOCKER_RM-true}
+
+# Update this value if you add a new test environment.
+ENV_COUNT=4
+
+# Default return code 0
+rc=0
+
+# Executes the given statement, and exits if the command returns a non-zero code.
+function exit_if_fail {
+    command=$@
+    echo "Executing '$command'"
+    $command
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "'$command' returned $rc."
+        exit $rc
+    fi
+}
+
+# Convert dockerfile name to valid docker image tag name.
+function filename2imagename {
+    echo ${1/Dockerfile/kapacitor}
+}
+
+# Run a test in a docker container
+# Usage: run_test_docker <Dockerfile> <env_name>
+function run_test_docker {
+    local dockerfile=$1
+    local imagename=$(filename2imagename "$dockerfile")
+    shift
+    local name=$1
+    shift
+    local logfile="$OUTPUT_DIR/${name}.log"
+
+    build_docker_image "$dockerfile" "$imagename"
+    echo "Running test in docker $name with args $@"
+
+    docker run \
+         --rm=$DOCKER_RM \
+         -v "$DIR:/root/go/src/github.com/influxdata/kapacitor" \
+         -e "INFLUXDB_DATA_ENGINE=$INFLUXDB_DATA_ENGINE" \
+         -e "GORACE=$GORACE" \
+         -e "GO_CHECKOUT=$GO_CHECKOUT" \
+         "$imagename" \
+         "--parallel=$PARALLELISM" \
+         "--timeout=$TIMEOUT" \
+         "$@" \
+         2>&1 | tee "$logfile"
+    return "${PIPESTATUS[0]}"
+
+}
+
+# Build the docker image defined by given dockerfile.
+function build_docker_image {
+    local dockerfile=$1
+    local imagename=$2
+
+    echo "Building docker image $imagename"
+    exit_if_fail docker build -f "$dockerfile" -t "$imagename" .
+}
+
+
+# Saves a docker image to $DOCKER_SAVE_DIR
+function save_docker_image {
+    local dockerfile=$1
+    local imagename=$(filename2imagename "$dockerfile")
+    local imagefile="$DOCKER_SAVE_DIR/${imagename}.tar.gz"
+
+    if [ ! -d  "$DOCKER_SAVE_DIR" ]
+    then
+        mkdir -p "$DOCKER_SAVE_DIR"
+    fi
+
+    if [[ -e "$imagefile" ]]
+    then
+        zcat $imagefile | docker load
+    fi
+    imageid=$(docker images -q --no-trunc "$imagename")
+    build_docker_image "$dockerfile" "$imagename"
+    newimageid=$(docker images -q --no-trunc "$imagename")
+    rc=0
+    if [ "$imageid" != "$newimageid" ]
+    then
+        docker save "$imagename" | gzip > "$imagefile"
+        rc="${PIPESTATUS[0]}"
+    fi
+    return "$rc"
+}
+
+if [ ! -d "$OUTPUT_DIR" ]
+then
+    mkdir -p "$OUTPUT_DIR"
+fi
+
+# Run the tests.
+case $ENVIRONMENT_INDEX in
+    0)
+        # 64 bit tests
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit --test --generate --no-stash
+        rc=$?
+        ;;
+    1)
+        # 64 bit race tests
+        GORACE="halt_on_error=1"
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit_race --test --generate --no-stash --race
+        rc=$?
+        ;;
+    2)
+        # 32 bit tests
+        run_test_docker Dockerfile_build_ubuntu32 test_32bit --test --generate --no-stash
+        rc=$?
+        ;;
+    3)
+        # 64 bit tests on golang go1.6
+        GO_CHECKOUT=go1.6rc2
+        run_test_docker Dockerfile_build_ubuntu64_git test_64bit_go1.6 --test --generate --no-stash
+        rc=$?
+        ;;
+    "save")
+        # Save docker images for every Dockerfile_build* file.
+        # Useful for creating an external cache.
+        pids=()
+        tail_cmds=()
+        for d in Dockerfile_build*
+        do
+            echo "Building and saving $d ..."
+            out="$OUTPUT_DIR/${d}.log"
+            save_docker_image "$d" > "$out" 2>&1 &
+            pid=$!
+            pids+=($pid)
+            tail_cmds+=("tail -n +0 --pid $pid -F $out")
+        done
+        echo "Waiting..."
+        # Wait for all saves to finish
+        i=0
+        for pid in "${pids[@]}"
+        do
+            tail_cmd="${tail_cmds[$i]}"
+            $tail_cmd
+            wait $pid
+            rc=$(($? + $rc))
+            i=$((i+1))
+        done
+        # Check if all saves passed
+        if [ $rc -eq 0 ]
+        then
+            echo "All saves succeeded"
+        else
+            echo "Some saves failed, check logs in $OUTPUT_DIR"
+        fi
+        ;;
+    "count")
+        echo $ENV_COUNT
+        ;;
+    *)
+        echo "No individual test environment specified running tests for all $ENV_COUNT environments."
+        # Run all test environments
+        pids=()
+        for t in $(seq 0 "$(($ENV_COUNT - 1))")
+        do
+            $0 $t 2>&1 > /dev/null &
+            # add PID to list
+            pids+=($!)
+        done
+
+        echo "Started all tests. Follow logs in ${OUTPUT_DIR}. Waiting..."
+
+        # Wait for all tests to finish
+        for pid in "${pids[@]}"
+        do
+            wait $pid
+            rc=$(($? + $rc))
+        done
+
+        # Check if all tests passed
+        if [ $rc -eq 0 ]
+        then
+            echo "All test have passed"
+        else
+            echo "Some tests failed check logs in $OUTPUT_DIR for results"
+        fi
+        ;;
+esac
+
+exit $rc
+


### PR DESCRIPTION
This takes the work done for InfluxDB. Now Kapacitor can be tested against various envs.

There is an experimental arm env which uses qemu. If its too slow we will have to remove it but for now I would like to see if its possible.