### PR TITLE
Minor build updates

### DIFF
--- a/build.py
+++ b/build.py
@@ -685,9 +685,6 @@ def main():
         elif '--nightly' in arg:
             # Signifies that this is a nightly build.
             nightly = True
-            # In order to cleanly delineate nightly version, we are adding the epoch timestamp
-            # to the version so that version numbers are always greater than the previous nightly.
-            version = "{}.n{}".format(version, int(time.time()))
         elif '--update' in arg:
             # Signifies that dependencies should be updated.
             update = True
@@ -740,7 +737,15 @@ def main():
     if nightly and rc:
         print "!! Cannot be both nightly and a release candidate! Stopping."
         return 1
-
+    
+    if nightly:
+        # In order to cleanly delineate nightly version, we are adding the epoch timestamp
+        # to the version so that version numbers are always greater than the previous nightly.
+        version = "{}.n{}".format(version, int(time.time()))
+        iteration = 0
+    elif rc:
+        iteration = 0
+    
     # Pre-build checks
     check_environ()
     check_prereqs()
@@ -758,9 +763,6 @@ def main():
             target_arch = system_arch
     if not target_platform:
         target_platform = get_system_platform()
-    if rc or nightly:
-        # If a release candidate or nightly, set iteration to 0 (instead of 1)
-        iteration = 0
 
     if target_arch == '386':
         target_arch = 'i386'

--- a/build.py
+++ b/build.py
@@ -472,7 +472,7 @@ def go_get(branch, platform=None, update=False, no_stash=False):
         run("git reset --hard")
 
         print "Retrieving Go dependencies (moving to master)..."
-        run(get_command)
+        run(get_command, shell=True)
         sys.stdout.flush()
 
         print "Moving back to branch '{}'...".format(branch)
@@ -482,7 +482,7 @@ def go_get(branch, platform=None, update=False, no_stash=False):
         run("git stash apply {}".format(stash))
     else:
         print "Retrieving Go dependencies..."
-        run(get_command)
+        run(get_command, shell=True)
 
         print "Moving back to branch '{}'...".format(branch)
         run("git checkout {}".format(branch))


### PR DESCRIPTION
Fixes:

- Moved nightly versioning to be set after CLI parsing due to an error that would occur if the `--nightly` was specified before `--version`
- Moved `go get` to be run for every platform, as some projects have platform-specific includes (and I didn't know `go get` was affected by the `GOOS` env variable)