### PR TITLE
Add Enterprise reporting to Kapacitor

### DIFF
--- a/services/stats/config.go
+++ b/services/stats/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	Database        string         `toml:"database"`
 	RetentionPolicy string         `toml:"retention-policy"`
 	EnterpriseHosts []*client.Host `toml:"enterprise-hosts"`
+	AdminPort       uint16         `toml:"admin-port"`
+	AdminHost       string         `toml:"admin-host"`
 }
 
 func NewConfig() Config {
@@ -27,5 +29,7 @@ func NewConfig() Config {
 		Database:        DefaultDatabse,
 		RetentionPolicy: DefaultRetentionPolicy,
 		StatsInterval:   DefaultStatsInterval,
+		AdminPort:       9095,
+		AdminHost:       "localhost",
 	}
 }

--- a/services/stats/config.go
+++ b/services/stats/config.go
@@ -3,6 +3,7 @@ package stats
 import (
 	"time"
 
+	"github.com/influxdata/enterprise-client/v2"
 	"github.com/influxdb/influxdb/toml"
 )
 
@@ -13,10 +14,11 @@ const (
 )
 
 type Config struct {
-	Enabled         bool          `toml:"enabled"`
-	StatsInterval   toml.Duration `toml:"stats-interval"`
-	Database        string        `toml:"database"`
-	RetentionPolicy string        `toml:"retention-policy"`
+	Enabled         bool           `toml:"enabled"`
+	StatsInterval   toml.Duration  `toml:"stats-interval"`
+	Database        string         `toml:"database"`
+	RetentionPolicy string         `toml:"retention-policy"`
+	EnterpriseHosts []*client.Host `toml:"enterprise-hosts"`
 }
 
 func NewConfig() Config {

--- a/services/stats/config.go
+++ b/services/stats/config.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/influxdata/enterprise-client/v2"
-	"github.com/influxdb/influxdb/toml"
+	"github.com/influxdata/influxdb/toml"
 )
 
 const (

--- a/services/stats/config.go
+++ b/services/stats/config.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/influxdata/enterprise-client/v2"
-	"github.com/influxdata/influxdb/toml"
+	"github.com/influxdb/influxdb/toml"
 )
 
 const (

--- a/services/stats/service.go
+++ b/services/stats/service.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/enterprise-client/v2"
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/models"
 )
@@ -114,7 +115,7 @@ func (s *Service) Close() error {
 }
 
 func (s *Service) registerServer() error {
-	if !s.enabled || len(s.enterpriseHosts) == 0 {
+	if len(s.enterpriseHosts) == 0 {
 		return nil
 	}
 
@@ -136,10 +137,10 @@ func (s *Service) registerServer() error {
 	go func() {
 		defer s.wg.Done()
 
-		resp, err := cl.Register(&product)
+		_, err := cl.Register(&product)
 
 		if err != nil {
-			s.logger.Printf("failed to register Kapacitor with %s, received code %s, error: %s", resp.Response.Request.URL.String(), resp.Status, err)
+			s.logger.Printf("E! failed to register Kapacitor, err: %s", err)
 			return
 		}
 	}()


### PR DESCRIPTION
This causes Kapacitor to report stats to one or more enterprise hosts when
configured. Also, an admin interface is setup for enterprise to (eventually)
perform privileged administrative operations as well as ping nodes, etc.