### PR TITLE
Add shift node so values from different times can be joined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ kapacitor*.zip
 *.pyc
 *.test
 /test-logs
+*.prof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Release Notes
 
 ### Features
+- [#231](https://github.com/influxdata/kapacitor/pull/231): Add ShiftNode so values can be shifted in time for joining/comparisons.
+
 
 ### Bugfixes
 - [#199](https://github.com/influxdata/kapacitor/issues/199): BREAKING: Various fixes for the Alerta integration.

--- a/integrations/data/TestStream_Shift.srpl
+++ b/integrations/data/TestStream_Shift.srpl
@@ -1,0 +1,78 @@
+dbname
+rpname
+cpu,type=idle,host=serverA value=97.1 0000000001
+dbname
+rpname
+cpu,type=idle,host=serverB value=97.1 0000000001
+dbname
+rpname
+disk,type=sda,host=serverB value=39   0000000001
+dbname
+rpname
+cpu,type=idle,host=serverB value=92.6 0000000002
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.6 0000000003
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.6 0000000003
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.1 0000000004
+dbname
+rpname
+cpu,type=idle,host=serverB value=93.1 0000000004
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.6 0000000005
+dbname
+rpname
+cpu,type=idle,host=serverB value=92.6 0000000005
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.8 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.8 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverC value=95.8 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.7 0000000007
+dbname
+rpname
+cpu,type=idle,host=serverB value=92.7 0000000007
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.0 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverB value=96.0 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.4 0000000009
+dbname
+rpname
+cpu,type=idle,host=serverB value=93.4 0000000009
+dbname
+rpname
+disk,type=sda,host=serverB value=423  0000000009
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.3 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.3 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.4 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverB value=96.4 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1 0000000012
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.1 0000000012

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -428,3 +428,10 @@ func (n *chainnode) Derivative(field string) *DerivativeNode {
 	n.linkChild(s)
 	return s
 }
+
+// Create a new node that shifts the incoming points or batches in time.
+func (n *chainnode) Shift(shift time.Duration) *ShiftNode {
+	s := newShiftNode(n.Provides(), shift)
+	n.linkChild(s)
+	return s
+}

--- a/pipeline/shift.go
+++ b/pipeline/shift.go
@@ -1,0 +1,34 @@
+package pipeline
+
+import (
+	"time"
+)
+
+// Shift points and batches in time, this is useful for comparing
+// batches or points from different times.
+//
+// Example:
+//    stream
+//        .shift(5m)
+//
+// Shift all data points 5m forward in time.
+//
+// Example:
+//    stream
+//        .shift(-10s)
+//
+// Shift all data points 10s backward in time.
+type ShiftNode struct {
+	chainnode
+
+	// Keep one point or batch every Duration
+	// tick:ignore
+	Shift time.Duration
+}
+
+func newShiftNode(wants EdgeType, shift time.Duration) *ShiftNode {
+	return &ShiftNode{
+		chainnode: newBasicChainNode("shift", wants, wants),
+		Shift:     shift,
+	}
+}

--- a/shift.go
+++ b/shift.go
@@ -1,0 +1,59 @@
+package kapacitor
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"github.com/influxdata/kapacitor/pipeline"
+)
+
+type ShiftNode struct {
+	node
+	s *pipeline.ShiftNode
+
+	shift time.Duration
+}
+
+// Create a new  ShiftNode which shifts points and batches in time.
+func newShiftNode(et *ExecutingTask, n *pipeline.ShiftNode, l *log.Logger) (*ShiftNode, error) {
+	sn := &ShiftNode{
+		node:  node{Node: n, et: et, logger: l},
+		s:     n,
+		shift: n.Shift,
+	}
+	sn.node.runF = sn.runShift
+	if n.Shift == 0 {
+		return nil, errors.New("invalid shift value: must be non zero duration")
+	}
+	return sn, nil
+}
+
+func (s *ShiftNode) runShift([]byte) error {
+	switch s.Wants() {
+	case pipeline.StreamEdge:
+		for p, ok := s.ins[0].NextPoint(); ok; p, ok = s.ins[0].NextPoint() {
+			p.Time = p.Time.Add(s.shift)
+			for _, child := range s.outs {
+				err := child.CollectPoint(p)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	case pipeline.BatchEdge:
+		for b, ok := s.ins[0].NextBatch(); ok; b, ok = s.ins[0].NextBatch() {
+			b.TMax = b.TMax.Add(s.shift)
+			for i, p := range b.Points {
+				b.Points[i].Time = p.Time.Add(s.shift)
+			}
+			for _, child := range s.outs {
+				err := child.CollectBatch(b)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/task.go
+++ b/task.go
@@ -340,6 +340,8 @@ func (et *ExecutingTask) createNode(p pipeline.Node, l *log.Logger) (Node, error
 		return newUDFNode(et, t, l)
 	case *pipeline.StatsNode:
 		return newStatsNode(et, t, l)
+	case *pipeline.ShiftNode:
+		return newShiftNode(et, t, l)
 	default:
 		return nil, fmt.Errorf("unknown pipeline node type %T", p)
 	}

--- a/tick/eval_test.go
+++ b/tick/eval_test.go
@@ -173,3 +173,68 @@ func TestEvaluate_DynamicMethod(t *testing.T) {
 		t.Errorf("unexpected x.args[1]: got %v exp %v", got, exp)
 	}
 }
+
+func TestEvaluate_Vars(t *testing.T) {
+	script := `
+var x = 3m
+var y = -x
+
+var n = TRUE 
+var m = !n 
+`
+
+	scope := tick.NewScope()
+	err := tick.Evaluate(script, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	x, err := scope.Get("x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := x.(time.Duration); ok {
+		if exp, got := time.Minute*3, value; exp != got {
+			t.Errorf("unexpected x value: exp %v got %v", exp, got)
+		}
+	} else {
+		t.Errorf("unexpected x value type: exp time.Duration got %T", x)
+	}
+
+	y, err := scope.Get("y")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := y.(time.Duration); ok {
+		if exp, got := time.Minute*-3, value; exp != got {
+			t.Errorf("unexpected y value: exp %v got %v", exp, got)
+		}
+	} else {
+		t.Errorf("unexpected y value type: exp time.Duration got %T", x)
+	}
+
+	n, err := scope.Get("n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := n.(bool); ok {
+		if exp, got := true, value; exp != got {
+			t.Errorf("unexpected n value: exp %v got %v", exp, got)
+		}
+	} else {
+		t.Errorf("unexpected m value type: exp bool got %T", x)
+	}
+
+	m, err := scope.Get("m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := m.(bool); ok {
+		if exp, got := false, value; exp != got {
+			t.Errorf("unexpected m value: exp %v got %v", exp, got)
+		}
+	} else {
+		t.Errorf("unexpected m value type: exp bool got %T", x)
+	}
+
+}

--- a/tick/parser_test.go
+++ b/tick/parser_test.go
@@ -365,6 +365,42 @@ func TestParseStatements(t *testing.T) {
 			},
 		},
 		{
+			script: `var x = 3m
+			var y = -x`,
+			Root: &ListNode{
+				Nodes: []Node{
+					&BinaryNode{
+						pos:      6,
+						Operator: TokenAsgn,
+						Left: &IdentifierNode{
+							pos:   4,
+							Ident: "x",
+						},
+						Right: &DurationNode{
+							pos: 8,
+							Dur: time.Minute * 3,
+						},
+					},
+					&BinaryNode{
+						pos:      20,
+						Operator: TokenAsgn,
+						Left: &IdentifierNode{
+							pos:   18,
+							Ident: "y",
+						},
+						Right: &UnaryNode{
+							pos:      22,
+							Operator: TokenMinus,
+							Node: &IdentifierNode{
+								pos:   23,
+								Ident: "x",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			script: `var t = 42
 			stream.where(lambda: "value" > t)
 			`,


### PR DESCRIPTION
Example from tests:

```javascript
var period  = 5s

var data  = stream
	.from()
		.measurement('cpu')
		.where(lambda: "host" == 'serverA')

var past = data
	.window()
		.period(period)
		.every(period)
		.align()
	.mapReduce(influxql.count('value'))
	//shift values from the past forward so they can be compared with current values.
	.shift(period)

var current = data
	.window()
		.period(period)
		.every(period)
		.align()
	.mapReduce(influxql.count('value'))

past.join(current)
	.as('past', 'current')
	.eval(lambda: "current.count" - "past.count")
		.keep()
		.as('diff')
	.httpOut('TestStream_Shift')
```