### PR TITLE
deadmans stats by group and for emitted not collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 - [#231](https://github.com/influxdata/kapacitor/pull/231): Add ShiftNode so values can be shifted in time for joining/comparisons.
+- [#190](https://github.com/influxdata/kapacitor/issues/190): BREAKING: Deadman's switch now triggers off emitted counts and is grouped by to original grouping of the data.
+    The breaking change is that the 'collected' stat is no longer output for `.stats` and has been replaced by `emitted`.
 
 
 ### Bugfixes

--- a/noop.go
+++ b/noop.go
@@ -1,0 +1,44 @@
+package kapacitor
+
+import (
+	"log"
+
+	"github.com/influxdata/kapacitor/pipeline"
+)
+
+type NoOpNode struct {
+	node
+}
+
+// Create a new  NoOpNode which does nothing with the data and just passes it through.
+func newNoOpNode(et *ExecutingTask, n *pipeline.NoOpNode, l *log.Logger) (*NoOpNode, error) {
+	nn := &NoOpNode{
+		node: node{Node: n, et: et, logger: l},
+	}
+	nn.node.runF = nn.runNoOp
+	return nn, nil
+}
+
+func (s *NoOpNode) runNoOp([]byte) error {
+	switch s.Wants() {
+	case pipeline.StreamEdge:
+		for p, ok := s.ins[0].NextPoint(); ok; p, ok = s.ins[0].NextPoint() {
+			for _, child := range s.outs {
+				err := child.CollectPoint(p)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	case pipeline.BatchEdge:
+		for b, ok := s.ins[0].NextBatch(); ok; b, ok = s.ins[0].NextBatch() {
+			for _, child := range s.outs {
+				err := child.CollectBatch(b)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pipeline/noop.go
+++ b/pipeline/noop.go
@@ -1,0 +1,20 @@
+package pipeline
+
+// A node that does not perform any operation.
+//
+// *Do not use this node in a TICKscript there should be no need for it.*
+//
+// If a node does not have any children, then its emitted count remains zero.
+// Using a NoOpNode is a work around so that statistics are accurately reported
+// for nodes with no real children.
+// A NoOpNode is automatically appended to any node that is a source for a StatsNode
+// and does not have any children.
+type NoOpNode struct {
+	chainnode
+}
+
+func newNoOpNode(wants EdgeType) *NoOpNode {
+	return &NoOpNode{
+		chainnode: newBasicChainNode("noop", wants, wants),
+	}
+}

--- a/pipeline/stats.go
+++ b/pipeline/stats.go
@@ -11,18 +11,24 @@ import "time"
 //
 // The currently available internal statistics:
 //
-//    * collected -- the number of points or batches this node has received.
+//    * emitted -- the number of points or batches this node has sent to its children.
 //
-// Each stat is available as a field in the emitted data stream.
+// Each stat is available as a field in the data stream.
+//
+// The stats are in groups according to the original data.
+// Meaning that if the source node is grouped by the tag 'host' as an example,
+// then the counts are output per host with the appropriate 'host' tag.
+// Since its possible for groups to change when crossing a node only the emitted groups
+// are considered.
 //
 // Example:
 //     var data = stream.from()...
 //     // Emit statistics every 1 minute and cache them via the HTTP API.
 //     data.stats(1m).httpOut('stats')
-//     // Contiue normal processing of the data stream
+//     // Continue normal processing of the data stream
 //     data....
 //
-// WARNING: It is not recommened to join the stats stream with the orginal data stream.
+// WARNING: It is not recommended to join the stats stream with the original data stream.
 // Since they operate on different clocks you could potentially create a deadlock.
 // This is a limitation of the current implementation and may be removed in the future.
 type StatsNode struct {

--- a/services/deadman/config.go
+++ b/services/deadman/config.go
@@ -14,7 +14,7 @@ const (
 	// Default deadman's switch id
 	DefaultId = "node 'NODE_NAME' in task '{{ .TaskName }}'"
 	// Default deadman's switch message
-	DefaultMessage = "{{ .ID }} is {{ if eq .Level \"OK\" }}alive{{ else }}dead{{ end }}: {{ index .Fields \"collected\" | printf \"%0.3f\" }} points/INTERVAL."
+	DefaultMessage = "{{ .ID }} is {{ if eq .Level \"OK\" }}alive{{ else }}dead{{ end }}: {{ index .Fields \"emitted\" | printf \"%0.3f\" }} points/INTERVAL."
 )
 
 type Config struct {

--- a/stats.go
+++ b/stats.go
@@ -47,12 +47,17 @@ func (s *StatsNode) runStats([]byte) error {
 			return nil
 		case now := <-ticker.C:
 			point.Time = now.UTC()
-			count := s.en.collectedCount()
-			point.Fields = models.Fields{"collected": count}
-			for _, out := range s.outs {
-				err := out.CollectPoint(point)
-				if err != nil {
-					return err
+			stats := s.en.nodeStatsByGroup()
+			for group, stat := range stats {
+				point.Fields = stat.Fields
+				point.Group = group
+				point.Dimensions = stat.Dimensions
+				point.Tags = stat.Tags
+				for _, out := range s.outs {
+					err := out.CollectPoint(point)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/task.go
+++ b/task.go
@@ -342,6 +342,8 @@ func (et *ExecutingTask) createNode(p pipeline.Node, l *log.Logger) (Node, error
 		return newStatsNode(et, t, l)
 	case *pipeline.ShiftNode:
 		return newShiftNode(et, t, l)
+	case *pipeline.NoOpNode:
+		return newNoOpNode(et, t, l)
 	default:
 		return nil, fmt.Errorf("unknown pipeline node type %T", p)
 	}


### PR DESCRIPTION
Fixes #190 both the groupBy issues and the fact that the `where` clause was ignored.

These changes should make the deadman's switch much more intuitive and easy to use.
