### PR TITLE
fix window errors when there are missing windows in the data stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#199](https://github.com/influxdata/kapacitor/issues/199): BREAKING: Various fixes for the Alerta integration.
     The `event` property has been removed from the Alerta node and is now set as the value of the alert ID.
 - [#232](https://github.com/influxdata/kapacitor/issues/232): Better error message for alert integrations. Better error message for VictorOps 404 response.
+- [#231](https://github.com/influxdata/kapacitor/issues/231): Fix window logic when there were gaps in the data stream longer than window every value.
 
 ## v0.10.1 [2016-02-08]
 

--- a/integrations/data/TestStream_WindowMissing.srpl
+++ b/integrations/data/TestStream_WindowMissing.srpl
@@ -1,0 +1,18 @@
+dbname
+rpname
+cpu,type=idle,host=serverA value=97.1 0000000001
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.4 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.4 0000000009
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.3 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.4 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1 0000000012

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -174,6 +174,77 @@ stream
 	testStreamerWithOutput(t, "TestStream_DerivativeNN", script, 15*time.Second, er, nil, false)
 }
 
+func TestStream_WindowMissing(t *testing.T) {
+
+	var script = `
+var period = 3s
+var every = 2s
+stream
+	.from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+		.where(lambda: "host" == 'serverA')
+	.window()
+		.period(period)
+		.every(every)
+	.mapReduce(influxql.count('value'))
+	.httpOut('TestStream_WindowMissing')
+`
+
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "cpu",
+				Tags:    nil,
+				Columns: []string{"time", "count"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 11, 0, time.UTC),
+					3.0,
+				}},
+			},
+		},
+	}
+
+	testStreamerWithOutput(t, "TestStream_WindowMissing", script, 13*time.Second, er, nil, false)
+}
+
+func TestStream_WindowMissingAligned(t *testing.T) {
+
+	var script = `
+var period = 3s
+var every = 2s
+stream
+	.from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+		.where(lambda: "host" == 'serverA')
+	.window()
+		.period(period)
+		.every(every)
+		.align()
+	.mapReduce(influxql.count('value'))
+	.httpOut('TestStream_WindowMissing')
+`
+
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "cpu",
+				Tags:    nil,
+				Columns: []string{"time", "count"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					3.0,
+				}},
+			},
+		},
+	}
+
+	testStreamerWithOutput(t, "TestStream_WindowMissing", script, 13*time.Second, er, nil, false)
+}
+
 func TestStream_Window(t *testing.T) {
 
 	var script = `


### PR DESCRIPTION
Fixes #221 

Thanks @yosiat for the detailed steps to reproduce. 

The bug was that the window node could not handle gaps in the data set larger than the `every` value. It assumed that there was always at least on point in each emitted window. As a result the emitted times would get behind the data times and extra points would make it into each window. Again thanks for the detailed write up. You will notice a few tests have been added for this scenario. 