### PR TITLE
Add performance metrics to tasks and node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 ### Release Notes
 
+Kapacitor now exposes more internal metrics for determining the performance of a given task. 
+The internal stats now includes a measurement `node` that contains an averaged execution time for the node, tagged by the task, node, task type and kind of node (i.e. window vs union).
+These stats are also available in the DOT output of the Kapacitor show command.
+
+
 ### Features
 - [#236](https://github.com/influxdata/kapacitor/issues/236): Implement batched group by
 - [#231](https://github.com/influxdata/kapacitor/pull/231): Add ShiftNode so values can be shifted in time for joining/comparisons.
 - [#190](https://github.com/influxdata/kapacitor/issues/190): BREAKING: Deadman's switch now triggers off emitted counts and is grouped by to original grouping of the data.
     The breaking change is that the 'collected' stat is no longer output for `.stats` and has been replaced by `emitted`.
 - [#145](https://github.com/influxdata/kapacitor/issues/145): The InfluxDB Out Node now writes data to InfluxDB in buffers.
+- [#215](https://github.com/influxdata/kapacitor/issues/215): Add performance metrics to nodes for average execution times and node throughput values.
 
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#231](https://github.com/influxdata/kapacitor/pull/231): Add ShiftNode so values can be shifted in time for joining/comparisons.
 - [#190](https://github.com/influxdata/kapacitor/issues/190): BREAKING: Deadman's switch now triggers off emitted counts and is grouped by to original grouping of the data.
     The breaking change is that the 'collected' stat is no longer output for `.stats` and has been replaced by `emitted`.
+- [#145](https://github.com/influxdata/kapacitor/issues/145): The InfluxDB Out Node now writes data to InfluxDB in buffers.
 
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Release Notes
 
-Kapacitor now exposes more internal metrics for determining the performance of a given task. 
-The internal stats now includes a measurement `node` that contains an averaged execution time for the node, tagged by the task, node, task type and kind of node (i.e. window vs union).
+Kapacitor now exposes more internal metrics for determining the performance of a given task.
+The internal statistics includes a new measurement named `node` that contains any stats a node provides, tagged by the task, node, task type and kind of node (i.e. window vs union).
+All nodes provide an averaged execution time for the node.
 These stats are also available in the DOT output of the Kapacitor show command.
+
+Significant performance improvements have also been added.
+In some cases Kapacitor throughput has improved by 4X.
 
 
 ### Features

--- a/alert.go
+++ b/alert.go
@@ -272,9 +272,11 @@ func (a *AlertNode) runAlert([]byte) error {
 	switch a.Wants() {
 	case pipeline.StreamEdge:
 		for p, ok := a.ins[0].NextPoint(); ok; p, ok = a.ins[0].NextPoint() {
+			a.timer.Start()
 			l := a.determineLevel(p.Time, p.Fields, p.Tags)
 			state := a.updateState(l, p.Group)
 			if (a.a.UseFlapping && state.flapping) || (a.a.IsStateChangesOnly && !state.changed) {
+				a.timer.Stop()
 				continue
 			}
 			// send alert if we are not OK or we are OK and state changed (i.e recovery)
@@ -293,9 +295,11 @@ func (a *AlertNode) runAlert([]byte) error {
 					h(ad)
 				}
 			}
+			a.timer.Stop()
 		}
 	case pipeline.BatchEdge:
 		for b, ok := a.ins[0].NextBatch(); ok; b, ok = a.ins[0].NextBatch() {
+			a.timer.Start()
 			triggered := false
 			for _, p := range b.Points {
 				l := a.determineLevel(p.Time, p.Fields, p.Tags)
@@ -331,6 +335,7 @@ func (a *AlertNode) runAlert([]byte) error {
 					}
 				}
 			}
+			a.timer.Stop()
 		}
 	}
 	return nil

--- a/batch.go
+++ b/batch.go
@@ -96,7 +96,7 @@ func (s *SourceBatchNode) Queries(start, stop time.Time) [][]string {
 
 // Do not add the source batch node to the dot output
 // since its not really an edge.
-func (s *SourceBatchNode) edot(*bytes.Buffer, time.Duration) {}
+func (s *SourceBatchNode) edot(*bytes.Buffer) {}
 
 func (s *SourceBatchNode) collectedCount() (count int64) {
 	for _, child := range s.children {

--- a/batch.go
+++ b/batch.go
@@ -96,7 +96,7 @@ func (s *SourceBatchNode) Queries(start, stop time.Time) [][]string {
 
 // Do not add the source batch node to the dot output
 // since its not really an edge.
-func (s *SourceBatchNode) edot(*bytes.Buffer) {}
+func (s *SourceBatchNode) edot(*bytes.Buffer, bool) {}
 
 func (s *SourceBatchNode) collectedCount() (count int64) {
 	for _, child := range s.children {

--- a/batch.go
+++ b/batch.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gorhill/cronexpr"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 	"github.com/influxdb/influxdb/influxql"
 )
 
@@ -274,8 +274,8 @@ func (b *BatchNode) doQuery() error {
 				return err
 			}
 
-			if resp.Err != nil {
-				return resp.Err
+			if err := resp.Error(); err != nil {
+				return err
 			}
 
 			// Collect batches

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -44,27 +43,6 @@ import (
 
 const clusterIDFilename = "cluster.id"
 const serverIDFilename = "server.id"
-
-var (
-	//Published vars
-	cidVar = &expvar.String{}
-
-	sidVar = &expvar.String{}
-
-	hostVar = &expvar.String{}
-
-	productVar = &expvar.String{}
-
-	versionVar = &expvar.String{}
-)
-
-func init() {
-	expvar.Publish(kapacitor.ClusterIDVarName, cidVar)
-	expvar.Publish(kapacitor.ServerIDVarName, sidVar)
-	expvar.Publish(kapacitor.HostVarName, hostVar)
-	expvar.Publish(kapacitor.ProductVarName, productVar)
-	expvar.Publish(kapacitor.VersionVarName, versionVar)
-}
 
 // BuildInfo represents the build details for the server code.
 type BuildInfo struct {
@@ -414,11 +392,11 @@ func (s *Server) Open() error {
 		}
 
 		// Set published vars
-		cidVar.Set(s.ClusterID)
-		sidVar.Set(s.ServerID)
-		hostVar.Set(s.hostname)
-		productVar.Set(kapacitor.Product)
-		versionVar.Set(s.buildInfo.Version)
+		kapacitor.ClusterIDVar.Set(s.ClusterID)
+		kapacitor.ServerIDVar.Set(s.ServerID)
+		kapacitor.HostVar.Set(s.hostname)
+		kapacitor.ProductVar.Set(kapacitor.Product)
+		kapacitor.VersionVar.Set(s.buildInfo.Version)
 		s.Logger.Printf("I! ClusterID: %s ServerID: %s", s.ClusterID, s.ServerID)
 
 		// Start profiling, if set.

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -377,6 +377,7 @@ func (s *Server) appendStatsService(c stats.Config) {
 		srv := stats.NewService(c, l)
 		srv.TaskMaster = s.TaskMaster
 
+		s.TaskMaster.TimingService = srv
 		s.Services = append(s.Services, srv)
 	}
 }

--- a/cmd/kapacitord/run/server_helper_test.go
+++ b/cmd/kapacitord/run/server_helper_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/influxdata/kapacitor/cmd/kapacitord/run"
 	"github.com/influxdata/kapacitor/services/task_store"
 	"github.com/influxdata/kapacitor/wlog"
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 )
 
 // Server represents a test wrapper for run.Server.
@@ -382,6 +382,10 @@ type InfluxDB struct {
 
 func NewInfluxDB(callback queryFunc) *InfluxDB {
 	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ping" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		q := r.URL.Query().Get("q")
 		res := callback(q)
 		enc := json.NewEncoder(w)

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/cmd/kapacitord/run"
 	"github.com/influxdata/kapacitor/services/udf"
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/models"
 	"github.com/influxdb/influxdb/toml"

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -164,12 +164,12 @@ func TestServer_EnableTask(t *testing.T) {
 		t.Fatalf("unexpected TICKscript got %s exp %s", ti.TICKscript, tick)
 	}
 	dot := `digraph testTaskName {
-graph [label="Throughput: 0.00 points/s"];
+graph [throughput="0.00 points/s"];
 
-srcstream0 [label="srcstream0 0"];
-srcstream0 -> stream1 [label="0"];
+srcstream0 [avg_exec_time="0" ];
+srcstream0 -> stream1 [processed="0"];
 
-stream1 [label="stream1 0"];
+stream1 [avg_exec_time="0" ];
 }`
 	if ti.Dot != dot {
 		t.Fatalf("unexpected dot got\n%s exp\n%s", ti.Dot, dot)

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -162,9 +162,16 @@ func TestServer_EnableTask(t *testing.T) {
 	if ti.TICKscript != tick {
 		t.Fatalf("unexpected TICKscript got %s exp %s", ti.TICKscript, tick)
 	}
-	dot := "digraph testTaskName {\nsrcstream0 -> stream1 [label=\"0\"];\n}"
+	dot := `digraph testTaskName {
+graph [label="Throughput: 0.00 points/s"];
+
+srcstream0 [label="srcstream0 0"];
+srcstream0 -> stream1 [label="0"];
+
+stream1 [label="stream1 0"];
+}`
 	if ti.Dot != dot {
-		t.Fatalf("unexpected dot got %s exp %s", ti.Dot, dot)
+		t.Fatalf("unexpected dot got\n%s exp\n%s", ti.Dot, dot)
 	}
 }
 

--- a/edge.go
+++ b/edge.go
@@ -15,6 +15,8 @@ import (
 const (
 	statCollected = "collected"
 	statEmitted   = "emitted"
+
+	defaultEdgeBufferSize = 1000
 )
 
 var ErrAborted = errors.New("edged aborted")
@@ -42,7 +44,7 @@ type Edge struct {
 	groupStats map[models.GroupID]*edgeStat
 }
 
-func newEdge(taskName, parentName, childName string, t pipeline.EdgeType, logService LogService) *Edge {
+func newEdge(taskName, parentName, childName string, t pipeline.EdgeType, size int, logService LogService) *Edge {
 	tags := map[string]string{
 		"task":   taskName,
 		"parent": parentName,
@@ -62,11 +64,11 @@ func newEdge(taskName, parentName, childName string, t pipeline.EdgeType, logSer
 	e.logger = logService.NewLogger(fmt.Sprintf("[edge:%s] ", name), log.LstdFlags)
 	switch t {
 	case pipeline.StreamEdge:
-		e.stream = make(chan models.Point)
+		e.stream = make(chan models.Point, size)
 	case pipeline.BatchEdge:
-		e.batch = make(chan models.Batch)
+		e.batch = make(chan models.Batch, size)
 	case pipeline.ReduceEdge:
-		e.reduce = make(chan *MapResult)
+		e.reduce = make(chan *MapResult, size)
 	}
 	return e
 }

--- a/edge.go
+++ b/edge.go
@@ -2,12 +2,12 @@ package kapacitor
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"log"
 	"strconv"
 	"sync"
 
+	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 )
@@ -36,6 +36,7 @@ type Edge struct {
 
 	logger     *log.Logger
 	aborted    chan struct{}
+	statsKey   string
 	statMap    *expvar.Map
 	groupMu    sync.RWMutex
 	groupStats map[models.GroupID]*edgeStat
@@ -48,10 +49,11 @@ func newEdge(taskName, parentName, childName string, t pipeline.EdgeType, logSer
 		"child":  childName,
 		"type":   t.String(),
 	}
-	sm := NewStatistics("edges", tags)
+	key, sm := NewStatistics("edges", tags)
 	sm.Add(statCollected, 0)
 	sm.Add(statEmitted, 0)
 	e := &Edge{
+		statsKey:   key,
 		statMap:    sm,
 		aborted:    make(chan struct{}),
 		groupStats: make(map[models.GroupID]*edgeStat),
@@ -125,6 +127,7 @@ func (e *Edge) Close() {
 	if e.reduce != nil {
 		close(e.reduce)
 	}
+	DeleteStatistics(e.statsKey)
 }
 
 // Abort all next and collect calls.
@@ -151,7 +154,7 @@ func (e *Edge) NextPoint() (p models.Point, ok bool) {
 	case p, ok = <-e.stream:
 		if ok {
 			e.statMap.Add(statEmitted, 1)
-			e.incEmitted(p)
+			e.incEmitted(&p)
 		}
 	}
 	return
@@ -163,7 +166,7 @@ func (e *Edge) NextBatch() (b models.Batch, ok bool) {
 	case b, ok = <-e.batch:
 		if ok {
 			e.statMap.Add(statEmitted, 1)
-			e.incEmitted(b)
+			e.incEmitted(&b)
 		}
 	}
 	return
@@ -182,7 +185,7 @@ func (e *Edge) NextMaps() (m *MapResult, ok bool) {
 
 func (e *Edge) CollectPoint(p models.Point) error {
 	e.statMap.Add(statCollected, 1)
-	e.incCollected(p)
+	e.incCollected(&p)
 	select {
 	case <-e.aborted:
 		return ErrAborted
@@ -193,7 +196,7 @@ func (e *Edge) CollectPoint(p models.Point) error {
 
 func (e *Edge) CollectBatch(b models.Batch) error {
 	e.statMap.Add(statCollected, 1)
-	e.incCollected(b)
+	e.incCollected(&b)
 	select {
 	case <-e.aborted:
 		return ErrAborted

--- a/expvar/expvar.go
+++ b/expvar/expvar.go
@@ -1,0 +1,245 @@
+// This package is a fork of the golang expvar expvar.Var types.
+// Adding extra support for deleting and accessing raw typed values.
+package expvar
+
+import (
+	"bytes"
+	"expvar"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+// Int is a 64-bit integer variable that satisfies the expvar.Var interface.
+type Int struct {
+	i int64
+}
+
+func (v *Int) String() string {
+	return strconv.FormatInt(v.Get(), 10)
+}
+
+func (v *Int) Add(delta int64) {
+	atomic.AddInt64(&v.i, delta)
+}
+
+func (v *Int) Set(value int64) {
+	atomic.StoreInt64(&v.i, value)
+}
+
+func (v *Int) Get() int64 {
+	return atomic.LoadInt64(&v.i)
+}
+
+// Float is a 64-bit float variable that satisfies the expvar.Var interface.
+type Float struct {
+	f uint64
+}
+
+func (v *Float) String() string {
+	return strconv.FormatFloat(v.Get(), 'g', -1, 64)
+}
+
+func (v *Float) Get() float64 {
+	return math.Float64frombits(atomic.LoadUint64(&v.f))
+}
+
+// Add adds delta to v.
+func (v *Float) Add(delta float64) {
+	for {
+		cur := atomic.LoadUint64(&v.f)
+		curVal := math.Float64frombits(cur)
+		nxtVal := curVal + delta
+		nxt := math.Float64bits(nxtVal)
+		if atomic.CompareAndSwapUint64(&v.f, cur, nxt) {
+			return
+		}
+	}
+}
+
+// Set sets v to value.
+func (v *Float) Set(value float64) {
+	atomic.StoreUint64(&v.f, math.Float64bits(value))
+}
+
+// MaxFloat is a 64-bit float variable that satisfies the expvar.Var interface.
+// When setting a value it will only be set if it is greater than the current value.
+type MaxFloat struct {
+	f uint64
+}
+
+func (v *MaxFloat) String() string {
+	return strconv.FormatFloat(v.Get(), 'g', -1, 64)
+}
+
+func (v *MaxFloat) Get() float64 {
+	return math.Float64frombits(atomic.LoadUint64(&v.f))
+}
+
+// Set sets v to value.
+func (v *MaxFloat) Set(value float64) {
+	nxtBits := math.Float64bits(value)
+	for {
+		curBits := atomic.LoadUint64(&v.f)
+		cur := math.Float64frombits(curBits)
+		if value > cur {
+			if atomic.CompareAndSwapUint64(&v.f, curBits, nxtBits) {
+				return
+			}
+		} else {
+			return
+		}
+	}
+}
+
+// Map is a string-to-expvar.Var map variable that satisfies the expvar.Var interface.
+type Map struct {
+	mu   sync.RWMutex
+	m    map[string]expvar.Var
+	keys []string // sorted
+}
+
+func (v *Map) String() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "{")
+	first := true
+	v.doLocked(func(kv expvar.KeyValue) {
+		if !first {
+			fmt.Fprintf(&b, ", ")
+		}
+		fmt.Fprintf(&b, "%q: %v", kv.Key, kv.Value)
+		first = false
+	})
+	fmt.Fprintf(&b, "}")
+	return b.String()
+}
+
+func (v *Map) Init() *Map {
+	v.m = make(map[string]expvar.Var)
+	return v
+}
+
+// updateKeys updates the sorted list of keys in v.keys.
+// must be called with v.mu held.
+func (v *Map) updateKeys() {
+	if len(v.m) == len(v.keys) {
+		// No new key.
+		return
+	}
+	v.keys = v.keys[:0]
+	for k := range v.m {
+		v.keys = append(v.keys, k)
+	}
+	sort.Strings(v.keys)
+}
+
+func (v *Map) Get(key string) expvar.Var {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.m[key]
+}
+
+func (v *Map) Set(key string, av expvar.Var) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.m[key] = av
+	v.updateKeys()
+}
+
+func (v *Map) Delete(key string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	delete(v.m, key)
+	v.updateKeys()
+}
+
+func (v *Map) Add(key string, delta int64) {
+	v.mu.RLock()
+	av, ok := v.m[key]
+	v.mu.RUnlock()
+	if !ok {
+		// check again under the write lock
+		v.mu.Lock()
+		av, ok = v.m[key]
+		if !ok {
+			av = new(Int)
+			v.m[key] = av
+			v.updateKeys()
+		}
+		v.mu.Unlock()
+	}
+
+	// Add to Int; ignore otherwise.
+	if iv, ok := av.(*Int); ok {
+		iv.Add(delta)
+	}
+}
+
+// AddFloat adds delta to the *Float value stored under the given map key.
+func (v *Map) AddFloat(key string, delta float64) {
+	v.mu.RLock()
+	av, ok := v.m[key]
+	v.mu.RUnlock()
+	if !ok {
+		// check again under the write lock
+		v.mu.Lock()
+		av, ok = v.m[key]
+		if !ok {
+			av = new(Float)
+			v.m[key] = av
+			v.updateKeys()
+		}
+		v.mu.Unlock()
+	}
+
+	// Add to Float; ignore otherwise.
+	if iv, ok := av.(*Float); ok {
+		iv.Add(delta)
+	}
+}
+
+// Do calls f for each entry in the map.
+// The map is locked during the iteration,
+// but existing entries may be concurrently updated.
+func (v *Map) Do(f func(expvar.KeyValue)) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	v.doLocked(f)
+}
+
+// doLocked calls f for each entry in the map.
+// v.mu must be held for reads.
+func (v *Map) doLocked(f func(expvar.KeyValue)) {
+	for _, k := range v.keys {
+		f(expvar.KeyValue{k, v.m[k]})
+	}
+}
+
+// String is a string variable, and satisfies the expvar.Var interface.
+type String struct {
+	mu sync.RWMutex
+	s  string
+}
+
+func (v *String) String() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return strconv.Quote(v.s)
+}
+
+func (v *String) Set(value string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.s = value
+}
+
+func (v *String) Get() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.s
+}

--- a/global_stats.go
+++ b/global_stats.go
@@ -131,10 +131,10 @@ func GetStatsData() ([]StatsData, error) {
 	// Get all global statistics
 	expvar.Do(func(kv expvar.KeyValue) {
 		switch v := kv.Value.(type) {
-		case *kexpvar.Int:
-			globalData.Values[kv.Key] = v.Get()
-		case *kexpvar.Float:
-			globalData.Values[kv.Key] = v.Get()
+		case kexpvar.IntVar:
+			globalData.Values[kv.Key] = v.Int()
+		case kexpvar.FloatVar:
+			globalData.Values[kv.Key] = v.Float()
 		case *kexpvar.Map:
 			if kv.Key != Product {
 				panic("unexpected published top level expvar.Map with key " + kv.Key)
@@ -153,24 +153,22 @@ func GetStatsData() ([]StatsData, error) {
 		v.Do(func(subKV expvar.KeyValue) {
 			switch subKV.Key {
 			case "name":
-				data.Name = subKV.Value.(*kexpvar.String).Get()
+				data.Name = subKV.Value.(*kexpvar.String).StringValue()
 			case "tags":
 				// string-string tags map.
 				n := subKV.Value.(*kexpvar.Map)
 				n.Do(func(t expvar.KeyValue) {
-					data.Tags[t.Key] = t.Value.(*kexpvar.String).Get()
+					data.Tags[t.Key] = t.Value.(*kexpvar.String).StringValue()
 				})
 			case "values":
 				// string-interface map.
 				n := subKV.Value.(*kexpvar.Map)
 				n.Do(func(kv expvar.KeyValue) {
 					switch v := kv.Value.(type) {
-					case *kexpvar.Int:
-						data.Values[kv.Key] = v.Get()
-					case *kexpvar.Float:
-						data.Values[kv.Key] = v.Get()
-					case *kexpvar.MaxFloat:
-						data.Values[kv.Key] = v.Get()
+					case kexpvar.IntVar:
+						data.Values[kv.Key] = v.Int()
+					case kexpvar.FloatVar:
+						data.Values[kv.Key] = v.Float()
 					default:
 						panic(fmt.Sprintf("unknown expvar.Var type for stats %T", kv.Value))
 					}

--- a/global_stats.go
+++ b/global_stats.go
@@ -2,11 +2,11 @@ package kapacitor
 
 import (
 	"expvar"
+	"fmt"
 	"runtime"
-	"strconv"
-	"sync"
 	"time"
 
+	kexpvar "github.com/influxdata/kapacitor/expvar"
 	"github.com/twinj/uuid"
 )
 
@@ -30,9 +30,18 @@ const (
 
 var (
 	// Global expvars
-	NumTasks         = &expvar.Int{}
-	NumEnabledTasks  = &expvar.Int{}
-	NumSubscriptions = &expvar.Int{}
+	NumTasksVar         = &kexpvar.Int{}
+	NumEnabledTasksVar  = &kexpvar.Int{}
+	NumSubscriptionsVar = &kexpvar.Int{}
+
+	ClusterIDVar = &kexpvar.String{}
+	ServerIDVar  = &kexpvar.String{}
+	HostVar      = &kexpvar.String{}
+	ProductVar   = &kexpvar.String{}
+	VersionVar   = &kexpvar.String{}
+
+	// All internal stats are added as sub-maps to this top level map.
+	stats *kexpvar.Map
 )
 
 var (
@@ -41,78 +50,65 @@ var (
 
 func init() {
 	startTime = time.Now().UTC()
-	expvar.Publish(NumTasksVarName, NumTasks)
-	expvar.Publish(NumEnabledTasksVarName, NumEnabledTasks)
-	expvar.Publish(NumSubscriptionsVarName, NumSubscriptions)
-}
 
-// Gets an exported var and returns its unquoted string contents
-func GetStringVar(name string) string {
-	s, err := strconv.Unquote(expvar.Get(name).String())
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
+	expvar.Publish(NumTasksVarName, NumTasksVar)
+	expvar.Publish(NumEnabledTasksVarName, NumEnabledTasksVar)
+	expvar.Publish(NumSubscriptionsVarName, NumSubscriptionsVar)
 
-// Gets an exported var and returns its int value
-func GetIntVar(name string) int64 {
-	i, err := strconv.ParseInt(expvar.Get(name).String(), 10, 64)
-	if err != nil {
-		panic(err)
-	}
-	return i
-}
+	expvar.Publish(ClusterIDVarName, ClusterIDVar)
+	expvar.Publish(ServerIDVarName, ServerIDVar)
+	expvar.Publish(HostVarName, HostVar)
+	expvar.Publish(ProductVarName, ProductVar)
+	expvar.Publish(VersionVarName, VersionVar)
 
-// Gets an exported var and returns its float value
-func GetFloatVar(name string) float64 {
-	f, err := strconv.ParseFloat(expvar.Get(name).String(), 64)
-	if err != nil {
-		panic(err)
-	}
-	return f
+	// Initialze the global stats map
+	stats = &kexpvar.Map{}
+	stats.Init()
+	expvar.Publish(Product, stats)
 }
 
 func Uptime() time.Duration {
 	return time.Now().Sub(startTime)
 }
 
-var expvarMu sync.Mutex
-
 // NewStatistics creates an expvar-based map. Within there "name" is the Measurement name, "tags" are the tags,
 // and values are placed at the key "values".
 // The "values" map is returned so that statistics can be set.
-func NewStatistics(name string, tags map[string]string) *expvar.Map {
-	expvarMu.Lock()
-	defer expvarMu.Unlock()
-
+func NewStatistics(name string, tags map[string]string) (string, *kexpvar.Map) {
 	key := uuid.NewV4().String()
 
-	m := &expvar.Map{}
+	m := &kexpvar.Map{}
 	m.Init()
-	expvar.Publish(key, m)
 
 	// Set the name
-	nameVar := &expvar.String{}
+	nameVar := &kexpvar.String{}
 	nameVar.Set(name)
 	m.Set("name", nameVar)
 
 	// Set the tags
-	tagsVar := &expvar.Map{}
+	tagsVar := &kexpvar.Map{}
 	tagsVar.Init()
 	for k, v := range tags {
-		value := &expvar.String{}
+		value := &kexpvar.String{}
 		value.Set(v)
 		tagsVar.Set(k, value)
 	}
 	m.Set("tags", tagsVar)
 
 	// Create and set the values entry used for actual stats.
-	statMap := &expvar.Map{}
+	statMap := &kexpvar.Map{}
 	statMap.Init()
 	m.Set("values", statMap)
 
-	return statMap
+	// Set new statsMap on the top level map.
+	stats.Set(key, m)
+
+	return key, statMap
+}
+
+// Remove a statistics map.
+func DeleteStatistics(key string) {
+	stats.Delete(key)
 }
 
 type StatsData struct {
@@ -132,83 +128,68 @@ func GetStatsData() ([]StatsData, error) {
 
 	allData = append(allData, globalData)
 
+	// Get all global statistics
 	expvar.Do(func(kv expvar.KeyValue) {
-		var f interface{}
-		var err error
 		switch v := kv.Value.(type) {
-		case *expvar.Float:
-			f, err = strconv.ParseFloat(v.String(), 64)
-			if err == nil {
-				globalData.Values[kv.Key] = f
+		case *kexpvar.Int:
+			globalData.Values[kv.Key] = v.Get()
+		case *kexpvar.Float:
+			globalData.Values[kv.Key] = v.Get()
+		case *kexpvar.Map:
+			if kv.Key != Product {
+				panic("unexpected published top level expvar.Map with key " + kv.Key)
 			}
-		case *expvar.Int:
-			f, err = strconv.ParseInt(v.String(), 10, 64)
-			if err == nil {
-				globalData.Values[kv.Key] = f
-			}
-		case *expvar.Map:
-			data := StatsData{
-				Tags:   make(map[string]string),
-				Values: make(map[string]interface{}),
-			}
-
-			v.Do(func(subKV expvar.KeyValue) {
-				switch subKV.Key {
-				case "name":
-					// straight to string name.
-					u, err := strconv.Unquote(subKV.Value.String())
-					if err != nil {
-						return
-					}
-					data.Name = u
-				case "tags":
-					// string-string tags map.
-					n := subKV.Value.(*expvar.Map)
-					n.Do(func(t expvar.KeyValue) {
-						u, err := strconv.Unquote(t.Value.String())
-						if err != nil {
-							return
-						}
-						data.Tags[t.Key] = u
-					})
-				case "values":
-					// string-interface map.
-					n := subKV.Value.(*expvar.Map)
-					n.Do(func(kv expvar.KeyValue) {
-						var f interface{}
-						var err error
-						switch v := kv.Value.(type) {
-						case *expvar.Float:
-							f, err = strconv.ParseFloat(v.String(), 64)
-							if err != nil {
-								return
-							}
-						case *expvar.Int:
-							f, err = strconv.ParseInt(v.String(), 10, 64)
-							if err != nil {
-								return
-							}
-						default:
-							return
-						}
-						data.Values[kv.Key] = f
-					})
-				}
-			})
-
-			// If no field data, don't include it in the results
-			if len(data.Values) == 0 {
-				return
-			}
-
-			allData = append(allData, data)
 		}
+	})
+	// Get all other specific statistics
+	stats.Do(func(kv expvar.KeyValue) {
+		v := kv.Value.(*kexpvar.Map)
+
+		data := StatsData{
+			Tags:   make(map[string]string),
+			Values: make(map[string]interface{}),
+		}
+
+		v.Do(func(subKV expvar.KeyValue) {
+			switch subKV.Key {
+			case "name":
+				data.Name = subKV.Value.(*kexpvar.String).Get()
+			case "tags":
+				// string-string tags map.
+				n := subKV.Value.(*kexpvar.Map)
+				n.Do(func(t expvar.KeyValue) {
+					data.Tags[t.Key] = t.Value.(*kexpvar.String).Get()
+				})
+			case "values":
+				// string-interface map.
+				n := subKV.Value.(*kexpvar.Map)
+				n.Do(func(kv expvar.KeyValue) {
+					switch v := kv.Value.(type) {
+					case *kexpvar.Int:
+						data.Values[kv.Key] = v.Get()
+					case *kexpvar.Float:
+						data.Values[kv.Key] = v.Get()
+					case *kexpvar.MaxFloat:
+						data.Values[kv.Key] = v.Get()
+					default:
+						panic(fmt.Sprintf("unknown expvar.Var type for stats %T", kv.Value))
+					}
+				})
+			}
+		})
+
+		// If no field data, don't include it in the results
+		if len(data.Values) == 0 {
+			return
+		}
+
+		allData = append(allData, data)
 	})
 
 	// Add uptime to globalData
 	globalData.Values[UptimeVarName] = Uptime().Seconds()
 
-	// Add Go memstats.
+	// Add Go runtime stats.
 	data := StatsData{
 		Name: "runtime",
 	}

--- a/http_out.go
+++ b/http_out.go
@@ -83,13 +83,17 @@ func (h *HTTPOutNode) runOut([]byte) error {
 	switch h.Wants() {
 	case pipeline.StreamEdge:
 		for p, ok := h.ins[0].NextPoint(); ok; p, ok = h.ins[0].NextPoint() {
+			h.timer.Start()
 			row := models.PointToRow(p)
 			h.updateResultWithRow(p.Group, row)
+			h.timer.Stop()
 		}
 	case pipeline.BatchEdge:
 		for b, ok := h.ins[0].NextBatch(); ok; b, ok = h.ins[0].NextBatch() {
+			h.timer.Start()
 			row := models.BatchToRow(b)
 			h.updateResultWithRow(b.Group, row)
+			h.timer.Stop()
 		}
 	}
 	return nil

--- a/influxdb_out.go
+++ b/influxdb_out.go
@@ -2,28 +2,36 @@ package kapacitor
 
 import (
 	"log"
+	"sync"
+	"time"
 
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 )
 
 type InfluxDBOutNode struct {
 	node
-	i    *pipeline.InfluxDBOutNode
-	conn *client.Client
+	i  *pipeline.InfluxDBOutNode
+	wb *writeBuffer
 }
 
 func newInfluxDBOutNode(et *ExecutingTask, n *pipeline.InfluxDBOutNode, l *log.Logger) (*InfluxDBOutNode, error) {
 	in := &InfluxDBOutNode{
 		node: node{Node: n, et: et, logger: l},
 		i:    n,
+		wb:   newWriteBuffer(int(n.Buffer), n.FlushInterval),
 	}
 	in.node.runF = in.runOut
+	in.node.stopF = in.stopOut
+	in.wb.i = in
 	return in, nil
 }
 
 func (i *InfluxDBOutNode) runOut([]byte) error {
+	// Start the write buffer
+	i.wb.start()
+
 	switch i.Wants() {
 	case pipeline.StreamEdge:
 		for p, ok := i.ins[0].NextPoint(); ok; p, ok = i.ins[0].NextPoint() {
@@ -53,6 +61,11 @@ func (i *InfluxDBOutNode) runOut([]byte) error {
 	return nil
 }
 
+func (i *InfluxDBOutNode) stopOut() {
+	i.wb.flush()
+	i.wb.abort()
+}
+
 func (i *InfluxDBOutNode) write(db, rp string, batch models.Batch) error {
 	if i.i.Database != "" {
 		db = i.i.Database
@@ -65,39 +78,154 @@ func (i *InfluxDBOutNode) write(db, rp string, batch models.Batch) error {
 		name = batch.Name
 	}
 
-	if i.conn == nil {
-		var err error
-		i.conn, err = i.et.tm.InfluxDBService.NewClient()
+	var err error
+	points := make([]*client.Point, len(batch.Points))
+	for j, p := range batch.Points {
+		var tags models.Tags
+		if len(i.i.Tags) > 0 {
+			tags = make(models.Tags, len(p.Tags)+len(i.i.Tags))
+			for k, v := range p.Tags {
+				tags[k] = v
+			}
+			for k, v := range i.i.Tags {
+				tags[k] = v
+			}
+		} else {
+			tags = p.Tags
+		}
+
+		points[j], err = client.NewPoint(
+			name,
+			tags,
+			p.Fields,
+			p.Time,
+		)
 		if err != nil {
 			return err
 		}
 	}
-	points := make([]client.Point, len(batch.Points))
-	for j, p := range batch.Points {
-		points[j] = client.Point{
-			Measurement: name,
-			Tags:        p.Tags,
-			Time:        p.Time,
-			Fields:      p.Fields,
-			Precision:   i.i.Precision,
-		}
-	}
-	tags := make(map[string]string, len(i.i.Tags)+len(batch.Tags))
-	for k, v := range batch.Tags {
-		tags[k] = v
-	}
-	for k, v := range i.i.Tags {
-		tags[k] = v
-	}
-
-	bp := client.BatchPoints{
-		Points:           points,
+	bpc := client.BatchPointsConfig{
 		Database:         db,
 		RetentionPolicy:  rp,
 		WriteConsistency: i.i.WriteConsistency,
-		Tags:             tags,
 		Precision:        i.i.Precision,
 	}
-	_, err := i.conn.Write(bp)
-	return err
+	i.wb.enqueue(bpc, points)
+	return nil
+}
+
+type writeBuffer struct {
+	size          int
+	flushInterval time.Duration
+	errC          chan error
+	queue         chan queueEntry
+	buffer        map[client.BatchPointsConfig]client.BatchPoints
+
+	flushing chan struct{}
+	flushed  chan struct{}
+
+	stopping chan struct{}
+	wg       sync.WaitGroup
+	conn     client.Client
+
+	i *InfluxDBOutNode
+}
+
+type queueEntry struct {
+	bpc    client.BatchPointsConfig
+	points []*client.Point
+}
+
+func newWriteBuffer(size int, flushInterval time.Duration) *writeBuffer {
+	return &writeBuffer{
+		size:          size,
+		flushInterval: flushInterval,
+		flushing:      make(chan struct{}),
+		flushed:       make(chan struct{}),
+		queue:         make(chan queueEntry),
+		buffer:        make(map[client.BatchPointsConfig]client.BatchPoints),
+		stopping:      make(chan struct{}),
+	}
+}
+
+func (w *writeBuffer) enqueue(bpc client.BatchPointsConfig, points []*client.Point) {
+	qe := queueEntry{
+		bpc:    bpc,
+		points: points,
+	}
+	w.queue <- qe
+}
+
+func (w *writeBuffer) start() {
+	w.wg.Add(1)
+	go w.run()
+}
+
+func (w *writeBuffer) flush() {
+	w.flushing <- struct{}{}
+	<-w.flushed
+}
+
+func (w *writeBuffer) abort() {
+	close(w.stopping)
+	w.wg.Wait()
+}
+
+func (w *writeBuffer) run() {
+	defer w.wg.Done()
+	var err error
+	for {
+		select {
+		case qe := <-w.queue:
+			// Read incoming points off queue
+			bp, ok := w.buffer[qe.bpc]
+			if !ok {
+				bp, err = client.NewBatchPoints(qe.bpc)
+				if err != nil {
+					w.i.logger.Println("E! failed to write points to InfluxDB:", err)
+					break
+				}
+				w.buffer[qe.bpc] = bp
+			}
+			bp.AddPoints(qe.points)
+			// Check if we hit buffer size
+			if len(bp.Points()) >= w.size {
+				err = w.write(bp)
+				if err != nil {
+					w.i.logger.Println("E! failed to write points to InfluxDB:", err)
+				}
+				delete(w.buffer, qe.bpc)
+			}
+		case <-w.flushing:
+			// Explicit flush called
+			w.writeAll()
+			w.flushed <- struct{}{}
+		case <-time.After(w.flushInterval):
+			// Flush all points after timeout
+			w.writeAll()
+		case <-w.stopping:
+			return
+		}
+	}
+}
+
+func (w *writeBuffer) writeAll() {
+	for bpc, bp := range w.buffer {
+		err := w.write(bp)
+		if err != nil {
+			w.i.logger.Println("E! failed to write points to InfluxDB:", err)
+		}
+		delete(w.buffer, bpc)
+	}
+}
+
+func (w *writeBuffer) write(bp client.BatchPoints) error {
+	var err error
+	if w.conn == nil {
+		w.conn, err = w.i.et.tm.InfluxDBService.NewClient()
+		if err != nil {
+			return err
+		}
+	}
+	return w.conn.Write(bp)
 }

--- a/influxdb_out.go
+++ b/influxdb_out.go
@@ -27,6 +27,7 @@ func (i *InfluxDBOutNode) runOut([]byte) error {
 	switch i.Wants() {
 	case pipeline.StreamEdge:
 		for p, ok := i.ins[0].NextPoint(); ok; p, ok = i.ins[0].NextPoint() {
+			i.timer.Start()
 			batch := models.Batch{
 				Name:   p.Name,
 				Group:  p.Group,
@@ -37,13 +38,16 @@ func (i *InfluxDBOutNode) runOut([]byte) error {
 			if err != nil {
 				return err
 			}
+			i.timer.Stop()
 		}
 	case pipeline.BatchEdge:
 		for b, ok := i.ins[0].NextBatch(); ok; b, ok = i.ins[0].NextBatch() {
+			i.timer.Start()
 			err := i.write("", "", b)
 			if err != nil {
 				return err
 			}
+			i.timer.Stop()
 		}
 	}
 	return nil

--- a/influxdb_out.go
+++ b/influxdb_out.go
@@ -26,7 +26,6 @@ func newInfluxDBOutNode(et *ExecutingTask, n *pipeline.InfluxDBOutNode, l *log.L
 		i:    n,
 		wb:   newWriteBuffer(int(n.Buffer), n.FlushInterval),
 	}
-	l.Println("D! fi: ", in.wb.flushInterval)
 	in.node.runF = in.runOut
 	in.node.stopF = in.stopOut
 	in.wb.i = in
@@ -34,6 +33,7 @@ func newInfluxDBOutNode(et *ExecutingTask, n *pipeline.InfluxDBOutNode, l *log.L
 }
 
 func (i *InfluxDBOutNode) runOut([]byte) error {
+	i.statMap.Add(statsInfluxDBPointsWritten, 0)
 	// Start the write buffer
 	i.wb.start()
 

--- a/integrations/helpers_test.go
+++ b/integrations/helpers_test.go
@@ -6,14 +6,13 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"reflect"
 	"time"
 
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/wlog"
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 	"github.com/influxdb/influxdb/influxql"
 )
 
@@ -28,11 +27,9 @@ func NewMockInfluxDBService(h http.Handler) *MockInfluxDBService {
 	}
 }
 
-func (m *MockInfluxDBService) NewClient() (*client.Client, error) {
-	u, _ := url.Parse(m.ts.URL)
-	return client.NewClient(client.Config{
-		URL:       *u,
-		Precision: "s",
+func (m *MockInfluxDBService) NewClient() (client.Client, error) {
+	return client.NewHTTPClient(client.HTTPConfig{
+		Addr: m.ts.URL,
 	})
 
 }

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -2634,6 +2634,10 @@ stream
 	var precision string
 
 	influxdb := NewMockInfluxDBService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ping" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		//Respond
 		var data client.Response
 		w.WriteHeader(http.StatusOK)

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -2483,21 +2483,7 @@ stream
 		.post('` + ts.URL + `')
 `
 
-	clock, et, replayErr, tm := testStreamer(t, "TestStream_AlertSigma", script, nil)
-	defer tm.Close()
-
-	// Move time forward
-	clock.Set(clock.Zero().Add(13 * time.Second))
-	// Wait till the replay has finished
-	if e := <-replayErr; e != nil {
-		t.Error(e)
-	}
-	// We don't want anymore data for the task
-	tm.DelFork(et.Task.Name)
-	// Wait till the task is finished
-	if e := et.Err(); e != nil {
-		t.Error(e)
-	}
+	testStreamerNoOutput(t, "TestStream_AlertSigma", script, 13*time.Second)
 
 	if requestCount != 2 {
 		t.Errorf("got %v exp %v", requestCount, 2)

--- a/join.go
+++ b/join.go
@@ -99,22 +99,6 @@ func (j *JoinNode) runJoin([]byte) error {
 	return nil
 }
 
-func (j *JoinNode) nodeExecTime() time.Duration {
-	j.mu.RLock()
-	defer j.mu.RUnlock()
-	sum := 0.0
-	total := 0.0
-	for _, group := range j.groups {
-		avg, count := group.timer.AverageTime()
-		sum += float64(avg) * float64(count)
-		total += float64(count)
-	}
-	if total == 0 {
-		return 0
-	}
-	return time.Duration(sum / total)
-}
-
 // safely get the group for the point or create one if it doesn't exist.
 func (j *JoinNode) getGroup(p models.PointInterface) *group {
 	j.mu.Lock()
@@ -151,7 +135,7 @@ func newGroup(i int, j *JoinNode) *group {
 		head:   make([]time.Time, i),
 		j:      j,
 		points: make(chan srcPoint),
-		timer:  j.et.tm.TimingService.NewTimer(),
+		timer:  j.et.tm.TimingService.NewTimer(j.avgExecVar),
 	}
 }
 

--- a/models/batch.go
+++ b/models/batch.go
@@ -2,11 +2,12 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
 
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 	"github.com/influxdb/influxdb/models"
 )
 
@@ -99,8 +100,8 @@ func BatchToRow(b Batch) (row *models.Row) {
 }
 
 func ResultToBatches(res client.Result) ([]Batch, error) {
-	if res.Err != nil {
-		return nil, res.Err
+	if res.Err != "" {
+		return nil, errors.New(res.Err)
 	}
 	batches := make([]Batch, len(res.Series))
 	for i, series := range res.Series {

--- a/node.go
+++ b/node.go
@@ -148,7 +148,7 @@ func (n *node) addChild(c Node) (*Edge, error) {
 	}
 	n.children = append(n.children, c)
 
-	edge := newEdge(n.et.Task.Name, n.Name(), c.Name(), n.Provides(), n.et.tm.LogService)
+	edge := newEdge(n.et.Task.Name, n.Name(), c.Name(), n.Provides(), defaultEdgeBufferSize, n.et.tm.LogService)
 	if edge == nil {
 		return nil, fmt.Errorf("unknown edge type %s", n.Provides())
 	}

--- a/pipeline/influxdb_out.go
+++ b/pipeline/influxdb_out.go
@@ -1,5 +1,10 @@
 package pipeline
 
+import "time"
+
+const DefaultBufferSize = 1000
+const DefaultFlushInterval = time.Second * 10
+
 // Writes the data to InfluxDB as it is received.
 //
 // Example:
@@ -27,6 +32,12 @@ type InfluxDBOutNode struct {
 	WriteConsistency string
 	// The precision to use when writing the data.
 	Precision string
+	// Number of points to buffer when writing to InfluxDB.
+	// Default: 1000
+	Buffer int64
+	// Write points to InfluxDB after interval even if buffer is not full.
+	// Default: 10s
+	FlushInterval time.Duration
 	// Static set of tags to add to all data points before writing them.
 	//tick:ignore
 	Tags map[string]string
@@ -39,7 +50,9 @@ func newInfluxDBOutNode(wants EdgeType) *InfluxDBOutNode {
 			wants:    wants,
 			provides: NoEdge,
 		},
-		Tags: make(map[string]string),
+		Tags:          make(map[string]string),
+		Buffer:        DefaultBufferSize,
+		FlushInterval: DefaultFlushInterval,
 	}
 }
 

--- a/sample.go
+++ b/sample.go
@@ -36,25 +36,33 @@ func (s *SampleNode) runSample([]byte) error {
 	switch s.Wants() {
 	case pipeline.StreamEdge:
 		for p, ok := s.ins[0].NextPoint(); ok; p, ok = s.ins[0].NextPoint() {
+			s.timer.Start()
 			if s.shouldKeep(p.Group, p.Time) {
+				s.timer.Pause()
 				for _, child := range s.outs {
 					err := child.CollectPoint(p)
 					if err != nil {
 						return err
 					}
 				}
+				s.timer.Resume()
 			}
+			s.timer.Stop()
 		}
 	case pipeline.BatchEdge:
 		for b, ok := s.ins[0].NextBatch(); ok; b, ok = s.ins[0].NextBatch() {
+			s.timer.Start()
 			if s.shouldKeep(b.Group, b.TMax) {
+				s.timer.Pause()
 				for _, child := range s.outs {
 					err := child.CollectBatch(b)
 					if err != nil {
 						return err
 					}
 				}
+				s.timer.Resume()
 			}
+			s.timer.Stop()
 		}
 	}
 	return nil

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -284,7 +284,7 @@ func (s *Service) linkSubscriptions() error {
 		}
 	}
 
-	kapacitor.NumSubscriptions.Set(numSubscriptions)
+	kapacitor.NumSubscriptionsVar.Set(numSubscriptions)
 	return nil
 }
 

--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/influxdata/kapacitor/clock"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/services/httpd"
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/twinj/uuid"
 )
@@ -42,7 +42,7 @@ type Service struct {
 		DelRoutes([]httpd.Route)
 	}
 	InfluxDBService interface {
-		NewClient() (*client.Client, error)
+		NewClient() (client.Client, error)
 	}
 	TaskMaster interface {
 		NewFork(name string, dbrps []kapacitor.DBRP) (*kapacitor.Edge, error)
@@ -695,8 +695,8 @@ func (r *Service) doRecordBatch(rid uuid.UUID, t *kapacitor.Task, start, stop ti
 			if err != nil {
 				return err
 			}
-			if resp.Err != nil {
-				return resp.Err
+			if err := resp.Error(); err != nil {
+				return err
 			}
 			for _, res := range resp.Results {
 				batches, err := models.ResultToBatches(res)
@@ -740,8 +740,8 @@ func (r *Service) doRecordQuery(rid uuid.UUID, q string, tt kapacitor.TaskType) 
 	if err != nil {
 		return err
 	}
-	if resp.Err != nil {
-		return resp.Err
+	if err := resp.Error(); err != nil {
+		return err
 	}
 	// Open appropriate writer
 	var w io.Writer

--- a/services/reporting/service.go
+++ b/services/reporting/service.go
@@ -47,10 +47,10 @@ func (s *Service) Open() error {
 	}
 
 	// Populate published vars
-	s.clusterID = kapacitor.GetStringVar(kapacitor.ClusterIDVarName)
-	s.serverID = kapacitor.GetStringVar(kapacitor.ServerIDVarName)
-	s.hostname = kapacitor.GetStringVar(kapacitor.HostVarName)
-	s.version = kapacitor.GetStringVar(kapacitor.VersionVarName)
+	s.clusterID = kapacitor.ClusterIDVar.Get()
+	s.serverID = kapacitor.ServerIDVar.Get()
+	s.hostname = kapacitor.HostVar.Get()
+	s.version = kapacitor.VersionVar.Get()
 	s.product = kapacitor.Product
 
 	// Populate anonymous tags
@@ -104,9 +104,9 @@ func (s *Service) sendUsageReport() error {
 	// Add values
 	data.Values[kapacitor.ClusterIDVarName] = s.clusterID
 	data.Values[kapacitor.ServerIDVarName] = s.serverID
-	data.Values[kapacitor.NumTasksVarName] = kapacitor.GetIntVar(kapacitor.NumTasksVarName)
-	data.Values[kapacitor.NumEnabledTasksVarName] = kapacitor.GetIntVar(kapacitor.NumEnabledTasksVarName)
-	data.Values[kapacitor.NumSubscriptionsVarName] = kapacitor.GetIntVar(kapacitor.NumSubscriptionsVarName)
+	data.Values[kapacitor.NumTasksVarName] = kapacitor.NumTasksVar.Get()
+	data.Values[kapacitor.NumEnabledTasksVarName] = kapacitor.NumEnabledTasksVar.Get()
+	data.Values[kapacitor.NumSubscriptionsVarName] = kapacitor.NumSubscriptionsVar.Get()
 	data.Values[kapacitor.UptimeVarName] = kapacitor.Uptime().Seconds()
 
 	usage := client.Usage{

--- a/services/reporting/service.go
+++ b/services/reporting/service.go
@@ -47,10 +47,10 @@ func (s *Service) Open() error {
 	}
 
 	// Populate published vars
-	s.clusterID = kapacitor.ClusterIDVar.Get()
-	s.serverID = kapacitor.ServerIDVar.Get()
-	s.hostname = kapacitor.HostVar.Get()
-	s.version = kapacitor.VersionVar.Get()
+	s.clusterID = kapacitor.ClusterIDVar.StringValue()
+	s.serverID = kapacitor.ServerIDVar.StringValue()
+	s.hostname = kapacitor.HostVar.StringValue()
+	s.version = kapacitor.VersionVar.StringValue()
 	s.product = kapacitor.Product
 
 	// Populate anonymous tags
@@ -104,9 +104,9 @@ func (s *Service) sendUsageReport() error {
 	// Add values
 	data.Values[kapacitor.ClusterIDVarName] = s.clusterID
 	data.Values[kapacitor.ServerIDVarName] = s.serverID
-	data.Values[kapacitor.NumTasksVarName] = kapacitor.NumTasksVar.Get()
-	data.Values[kapacitor.NumEnabledTasksVarName] = kapacitor.NumEnabledTasksVar.Get()
-	data.Values[kapacitor.NumSubscriptionsVarName] = kapacitor.NumSubscriptionsVar.Get()
+	data.Values[kapacitor.NumTasksVarName] = kapacitor.NumTasksVar.Int()
+	data.Values[kapacitor.NumEnabledTasksVarName] = kapacitor.NumEnabledTasksVar.Int()
+	data.Values[kapacitor.NumSubscriptionsVarName] = kapacitor.NumSubscriptionsVar.Int()
 	data.Values[kapacitor.UptimeVarName] = kapacitor.Uptime().Seconds()
 
 	usage := client.Usage{

--- a/services/stats/config.go
+++ b/services/stats/config.go
@@ -7,23 +7,29 @@ import (
 )
 
 const (
-	DefaultDatabse         = "_kapacitor"
-	DefaultRetentionPolicy = "default"
-	DefaultStatsInterval   = toml.Duration(10 * time.Second)
+	DefaultDatabse                 = "_kapacitor"
+	DefaultRetentionPolicy         = "default"
+	DefaultStatsInterval           = toml.Duration(10 * time.Second)
+	DefaultTimingSampleRate        = 0.10
+	DefaultTimingMovingAverageSize = 1000
 )
 
 type Config struct {
-	Enabled         bool          `toml:"enabled"`
-	StatsInterval   toml.Duration `toml:"stats-interval"`
-	Database        string        `toml:"database"`
-	RetentionPolicy string        `toml:"retention-policy"`
+	Enabled                 bool          `toml:"enabled"`
+	StatsInterval           toml.Duration `toml:"stats-interval"`
+	Database                string        `toml:"database"`
+	RetentionPolicy         string        `toml:"retention-policy"`
+	TimingSampleRate        float64       `toml:"timing-sample-rate"`
+	TimingMovingAverageSize int           `toml:"timing-movavg-size"`
 }
 
 func NewConfig() Config {
 	return Config{
-		Enabled:         true,
-		Database:        DefaultDatabse,
-		RetentionPolicy: DefaultRetentionPolicy,
-		StatsInterval:   DefaultStatsInterval,
+		Enabled:                 true,
+		Database:                DefaultDatabse,
+		RetentionPolicy:         DefaultRetentionPolicy,
+		StatsInterval:           DefaultStatsInterval,
+		TimingSampleRate:        DefaultTimingSampleRate,
+		TimingMovingAverageSize: DefaultTimingMovingAverageSize,
 	}
 }

--- a/services/stats/service.go
+++ b/services/stats/service.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/models"
+	"github.com/influxdata/kapacitor/timer"
 )
 
 // Sends internal stats back into the Kapacitor stream.
@@ -46,6 +47,9 @@ type Service struct {
 	db       string
 	rp       string
 
+	timingSampleRate    float64
+	timingMovingAvgSize int
+
 	open    bool
 	closing chan struct{}
 	mu      sync.Mutex
@@ -56,10 +60,12 @@ type Service struct {
 
 func NewService(c Config, l *log.Logger) *Service {
 	return &Service{
-		interval: time.Duration(c.StatsInterval),
-		db:       c.Database,
-		rp:       c.RetentionPolicy,
-		logger:   l,
+		interval:            time.Duration(c.StatsInterval),
+		db:                  c.Database,
+		rp:                  c.RetentionPolicy,
+		timingSampleRate:    c.TimingSampleRate,
+		timingMovingAvgSize: c.TimingMovingAverageSize,
+		logger:              l,
 	}
 }
 
@@ -125,4 +131,8 @@ func (s *Service) reportStats() {
 		}
 		s.stream.CollectPoint(p)
 	}
+}
+
+func (s *Service) NewTimer() timer.Timer {
+	return timer.New(s.timingSampleRate, s.timingMovingAvgSize)
 }

--- a/services/stats/service.go
+++ b/services/stats/service.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/influxdata/kapacitor"
-	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/timer"
 )
@@ -134,6 +133,6 @@ func (s *Service) reportStats() {
 	}
 }
 
-func (s *Service) NewTimer(avgVar *expvar.MaxFloat) timer.Timer {
+func (s *Service) NewTimer(avgVar timer.Setter) timer.Timer {
 	return timer.New(s.timingSampleRate, s.timingMovingAvgSize, avgVar)
 }

--- a/services/stats/service.go
+++ b/services/stats/service.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/influxdata/kapacitor"
+	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/timer"
 )
@@ -133,6 +134,6 @@ func (s *Service) reportStats() {
 	}
 }
 
-func (s *Service) NewTimer() timer.Timer {
-	return timer.New(s.timingSampleRate, s.timingMovingAvgSize)
+func (s *Service) NewTimer(avgVar *expvar.MaxFloat) timer.Timer {
+	return timer.New(s.timingSampleRate, s.timingMovingAvgSize, avgVar)
 }

--- a/services/task_store/service.go
+++ b/services/task_store/service.go
@@ -177,8 +177,8 @@ func (ts *Service) Open() error {
 	}
 
 	// Set expvars
-	kapacitor.NumTasks.Set(numTasks)
-	kapacitor.NumEnabledTasks.Set(numEnabledTasks)
+	kapacitor.NumTasksVar.Set(numTasks)
+	kapacitor.NumEnabledTasksVar.Set(numEnabledTasks)
 	return nil
 }
 
@@ -484,7 +484,7 @@ func (ts *Service) Save(task *rawTask) error {
 			return err
 		}
 		if !exists {
-			kapacitor.NumTasks.Add(1)
+			kapacitor.NumTasksVar.Add(1)
 		}
 		return nil
 	})
@@ -500,7 +500,7 @@ func (ts *Service) Delete(name string) error {
 			exists := tb.Get([]byte(name)) != nil
 			if exists {
 				tb.Delete([]byte(name))
-				kapacitor.NumTasks.Add(-1)
+				kapacitor.NumTasksVar.Add(-1)
 			}
 		}
 		eb := tx.Bucket(enabledBucket)
@@ -573,7 +573,7 @@ func (ts *Service) Enable(name string) error {
 			return err
 		}
 		if !enabled {
-			kapacitor.NumEnabledTasks.Add(1)
+			kapacitor.NumEnabledTasksVar.Add(1)
 		}
 		return nil
 	})
@@ -654,7 +654,7 @@ func (ts *Service) Disable(name string) error {
 			if err != nil {
 				return err
 			}
-			kapacitor.NumEnabledTasks.Add(-1)
+			kapacitor.NumEnabledTasksVar.Add(-1)
 		}
 		return nil
 	})

--- a/shift.go
+++ b/shift.go
@@ -33,7 +33,9 @@ func (s *ShiftNode) runShift([]byte) error {
 	switch s.Wants() {
 	case pipeline.StreamEdge:
 		for p, ok := s.ins[0].NextPoint(); ok; p, ok = s.ins[0].NextPoint() {
+			s.timer.Start()
 			p.Time = p.Time.Add(s.shift)
+			s.timer.Stop()
 			for _, child := range s.outs {
 				err := child.CollectPoint(p)
 				if err != nil {
@@ -43,10 +45,12 @@ func (s *ShiftNode) runShift([]byte) error {
 		}
 	case pipeline.BatchEdge:
 		for b, ok := s.ins[0].NextBatch(); ok; b, ok = s.ins[0].NextBatch() {
+			s.timer.Start()
 			b.TMax = b.TMax.Add(s.shift)
 			for i, p := range b.Points {
 				b.Points[i].Time = p.Time.Add(s.shift)
 			}
+			s.timer.Stop()
 			for _, child := range s.outs {
 				err := child.CollectBatch(b)
 				if err != nil {

--- a/stats.go
+++ b/stats.go
@@ -46,6 +46,7 @@ func (s *StatsNode) runStats([]byte) error {
 		case <-s.closing:
 			return nil
 		case now := <-ticker.C:
+			s.timer.Start()
 			point.Time = now.UTC()
 			stats := s.en.nodeStatsByGroup()
 			for group, stat := range stats {
@@ -53,13 +54,16 @@ func (s *StatsNode) runStats([]byte) error {
 				point.Group = group
 				point.Dimensions = stat.Dimensions
 				point.Tags = stat.Tags
+				s.timer.Pause()
 				for _, out := range s.outs {
 					err := out.CollectPoint(point)
 					if err != nil {
 						return err
 					}
 				}
+				s.timer.Resume()
 			}
+			s.timer.Stop()
 		}
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -67,18 +67,22 @@ func newStreamNode(et *ExecutingTask, n *pipeline.StreamNode, l *log.Logger) (*S
 
 func (s *StreamNode) runStream([]byte) error {
 	for pt, ok := s.ins[0].NextPoint(); ok; pt, ok = s.ins[0].NextPoint() {
+		s.timer.Start()
 		if s.matches(pt) {
 			if s.s.Truncate != 0 {
 				pt.Time = pt.Time.Truncate(s.s.Truncate)
 			}
 			pt = setGroupOnPoint(pt, s.allDimensions, s.dimensions)
+			s.timer.Pause()
 			for _, child := range s.outs {
 				err := child.CollectPoint(pt)
 				if err != nil {
 					return err
 				}
 			}
+			s.timer.Resume()
 		}
+		s.timer.Stop()
 	}
 	return nil
 }

--- a/task.go
+++ b/task.go
@@ -310,7 +310,7 @@ func (et *ExecutingTask) EDot() []byte {
 	))
 
 	et.walk(func(n Node) error {
-		n.edot(&buf, n.nodeExecTime())
+		n.edot(&buf)
 		return nil
 	})
 	buf.Write([]byte("}"))

--- a/task.go
+++ b/task.go
@@ -194,9 +194,7 @@ func (et *ExecutingTask) start(ins []*Edge, snapshot *TaskSnapshot) error {
 }
 
 func (et *ExecutingTask) stop() (err error) {
-	if et.Task.SnapshotInterval > 0 {
-		close(et.stopping)
-	}
+	close(et.stopping)
 	et.walk(func(n Node) error {
 		n.stop()
 		e := n.Err()

--- a/task.go
+++ b/task.go
@@ -71,11 +71,15 @@ type ExecutingTask struct {
 	source  Node
 	outputs map[string]Output
 	// node lookup from pipeline.ID -> Node
-	lookup          map[pipeline.ID]Node
-	nodes           []Node
-	stopSnapshotter chan struct{}
-	wg              sync.WaitGroup
-	logger          *log.Logger
+	lookup   map[pipeline.ID]Node
+	nodes    []Node
+	stopping chan struct{}
+	wg       sync.WaitGroup
+	logger   *log.Logger
+
+	// Mutex for throughput var
+	tmu        sync.RWMutex
+	throughput float64
 }
 
 // Create a new  task from a defined kapacitor.
@@ -178,17 +182,20 @@ func (et *ExecutingTask) start(ins []*Edge, snapshot *TaskSnapshot) error {
 	if err != nil {
 		return err
 	}
+	et.stopping = make(chan struct{})
 	if et.Task.SnapshotInterval > 0 {
 		et.wg.Add(1)
-		et.stopSnapshotter = make(chan struct{})
 		go et.runSnapshotter()
 	}
+	// Start calcThroughput
+	et.wg.Add(1)
+	go et.calcThroughput()
 	return nil
 }
 
 func (et *ExecutingTask) stop() (err error) {
 	if et.Task.SnapshotInterval > 0 {
-		close(et.stopSnapshotter)
+		close(et.stopping)
 	}
 	et.walk(func(n Node) error {
 		n.stop()
@@ -292,13 +299,57 @@ func (et *ExecutingTask) EDot() []byte {
 	buf.Write([]byte("digraph "))
 	buf.Write([]byte(et.Task.Name))
 	buf.Write([]byte(" {\n"))
+	// Write graph attributes
+	unit := "points"
+	if et.Task.Type == BatchTask {
+		unit = "batches"
+	}
+	buf.Write([]byte(
+		fmt.Sprintf("graph [label=\"Throughput: %0.2f %s/s\"];\n",
+			et.getThroughput(),
+			unit,
+		),
+	))
+
 	et.walk(func(n Node) error {
-		n.edot(&buf)
+		n.edot(&buf, n.nodeExecTime())
 		return nil
 	})
 	buf.Write([]byte("}"))
 
 	return buf.Bytes()
+}
+
+// Return the current throughput value.
+func (et *ExecutingTask) getThroughput() float64 {
+	et.tmu.RLock()
+	defer et.tmu.RUnlock()
+	return et.throughput
+}
+
+func (et *ExecutingTask) calcThroughput() {
+	defer et.wg.Done()
+	var previous int64
+	last := time.Now()
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			current := et.source.collectedCount()
+			now := time.Now()
+			elapsed := float64(now.Sub(last)) / float64(time.Second)
+
+			et.tmu.Lock()
+			et.throughput = float64(current-previous) / elapsed
+			et.tmu.Unlock()
+
+			last = now
+			previous = current
+
+		case <-et.stopping:
+			return
+		}
+	}
 }
 
 // Create a  node from a given pipeline node.
@@ -378,7 +429,7 @@ func (et *ExecutingTask) runSnapshotter() {
 	// Wait random duration to splay snapshot events across interval
 	select {
 	case <-time.After(time.Duration(rand.Float64() * float64(et.Task.SnapshotInterval))):
-	case <-et.stopSnapshotter:
+	case <-et.stopping:
 		return
 	}
 	ticker := time.NewTicker(et.Task.SnapshotInterval)
@@ -402,7 +453,7 @@ func (et *ExecutingTask) runSnapshotter() {
 					et.logger.Println("E! failed to save task snapshot", et.Task.Name, err)
 				}
 			}
-		case <-et.stopSnapshotter:
+		case <-et.stopping:
 			return
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -290,7 +290,7 @@ func (et *ExecutingTask) registerOutput(name string, o Output) {
 
 // Return a graphviz .dot formatted byte array.
 // Label edges with relavant execution information.
-func (et *ExecutingTask) EDot() []byte {
+func (et *ExecutingTask) EDot(labels bool) []byte {
 
 	var buf bytes.Buffer
 
@@ -302,15 +302,24 @@ func (et *ExecutingTask) EDot() []byte {
 	if et.Task.Type == BatchTask {
 		unit = "batches"
 	}
-	buf.Write([]byte(
-		fmt.Sprintf("graph [label=\"Throughput: %0.2f %s/s\"];\n",
-			et.getThroughput(),
-			unit,
-		),
-	))
+	if labels {
+		buf.Write([]byte(
+			fmt.Sprintf("graph [label=\"Throughput: %0.2f %s/s\"];\n",
+				et.getThroughput(),
+				unit,
+			),
+		))
+	} else {
+		buf.Write([]byte(
+			fmt.Sprintf("graph [throughput=\"%0.2f %s/s\"];\n",
+				et.getThroughput(),
+				unit,
+			),
+		))
+	}
 
 	et.walk(func(n Node) error {
-		n.edot(&buf)
+		n.edot(&buf, labels)
 		return nil
 	})
 	buf.Write([]byte("}"))

--- a/task_master.go
+++ b/task_master.go
@@ -305,7 +305,7 @@ func (tm *TaskMaster) StartTask(t *Task) (*ExecutingTask, error) {
 		}
 		ins = make([]*Edge, count)
 		for i := 0; i < count; i++ {
-			in := newEdge(t.Name, "batch", fmt.Sprintf("batch%d", i), pipeline.BatchEdge, tm.LogService)
+			in := newEdge(t.Name, "batch", fmt.Sprintf("batch%d", i), pipeline.BatchEdge, defaultEdgeBufferSize, tm.LogService)
 			ins[i] = in
 			tm.batches[t.Name] = append(tm.batches[t.Name], in)
 		}
@@ -386,7 +386,7 @@ func (tm *TaskMaster) stream(name string) (StreamCollector, error) {
 	if tm.closed {
 		return nil, ErrTaskMasterClosed
 	}
-	in := newEdge("TASK_MASTER", name, "stream", pipeline.StreamEdge, tm.LogService)
+	in := newEdge("TASK_MASTER", name, "stream", pipeline.StreamEdge, defaultEdgeBufferSize, tm.LogService)
 	tm.drained = false
 	tm.wg.Add(1)
 	go tm.runForking(in)
@@ -447,7 +447,7 @@ func (tm *TaskMaster) newFork(taskName string, dbrps []DBRP) (*Edge, error) {
 	if tm.closed {
 		return nil, ErrTaskMasterClosed
 	}
-	e := newEdge(taskName, "stream", "stream0", pipeline.StreamEdge, tm.LogService)
+	e := newEdge(taskName, "stream", "srcstream0", pipeline.StreamEdge, defaultEdgeBufferSize, tm.LogService)
 	tm.forks[taskName] = fork{
 		Edge:  e,
 		dbrps: CreateDBRPMap(dbrps),

--- a/task_master.go
+++ b/task_master.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 	"github.com/influxdata/kapacitor/services/httpd"
@@ -92,7 +91,7 @@ type TaskMaster struct {
 		Alert(title, text string) error
 	}
 	TimingService interface {
-		NewTimer(*expvar.MaxFloat) timer.Timer
+		NewTimer(timer.Setter) timer.Timer
 	}
 	LogService LogService
 
@@ -366,12 +365,12 @@ func (tm *TaskMaster) IsExecuting(name string) bool {
 	return executing
 }
 
-func (tm *TaskMaster) ExecutingDot(name string) string {
+func (tm *TaskMaster) ExecutingDot(name string, labels bool) string {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
 	et, executing := tm.tasks[name]
 	if executing {
-		return string(et.EDot())
+		return string(et.EDot(labels))
 	}
 	return ""
 }
@@ -483,6 +482,6 @@ func (tm *TaskMaster) SnapshotTask(name string) (*TaskSnapshot, error) {
 
 type noOpTimingService struct{}
 
-func (noOpTimingService) NewTimer(*expvar.MaxFloat) timer.Timer {
+func (noOpTimingService) NewTimer(timer.Setter) timer.Timer {
 	return timer.NewNoOp()
 }

--- a/task_master.go
+++ b/task_master.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 	"github.com/influxdata/kapacitor/services/httpd"
@@ -91,7 +92,7 @@ type TaskMaster struct {
 		Alert(title, text string) error
 	}
 	TimingService interface {
-		NewTimer() timer.Timer
+		NewTimer(*expvar.MaxFloat) timer.Timer
 	}
 	LogService LogService
 
@@ -482,6 +483,6 @@ func (tm *TaskMaster) SnapshotTask(name string) (*TaskSnapshot, error) {
 
 type noOpTimingService struct{}
 
-func (noOpTimingService) NewTimer() timer.Timer {
+func (noOpTimingService) NewTimer(*expvar.MaxFloat) timer.Timer {
 	return timer.NewNoOp()
 }

--- a/task_master.go
+++ b/task_master.go
@@ -12,7 +12,7 @@ import (
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/tick"
 	"github.com/influxdata/kapacitor/timer"
-	"github.com/influxdb/influxdb/client"
+	client "github.com/influxdb/influxdb/client/v2"
 	"github.com/influxdb/influxdb/cluster"
 )
 
@@ -44,7 +44,7 @@ type TaskMaster struct {
 	UDFService UDFService
 
 	InfluxDBService interface {
-		NewClient() (*client.Client, error)
+		NewClient() (client.Client, error)
 	}
 	SMTPService interface {
 		Global() bool

--- a/timer/noop.go
+++ b/timer/noop.go
@@ -1,0 +1,16 @@
+package timer
+
+import "time"
+
+type noop struct {
+}
+
+func (noop) Start()                            {}
+func (noop) Pause()                            {}
+func (noop) Resume()                           {}
+func (noop) Stop()                             {}
+func (noop) AverageTime() (time.Duration, int) { return 0, 1 }
+
+func NewNoOp() Timer {
+	return noop{}
+}

--- a/timer/noop.go
+++ b/timer/noop.go
@@ -1,15 +1,12 @@
 package timer
 
-import "time"
-
 type noop struct {
 }
 
-func (noop) Start()                            {}
-func (noop) Pause()                            {}
-func (noop) Resume()                           {}
-func (noop) Stop()                             {}
-func (noop) AverageTime() (time.Duration, int) { return 0, 1 }
+func (noop) Start()  {}
+func (noop) Pause()  {}
+func (noop) Resume() {}
+func (noop) Stop()   {}
 
 func NewNoOp() Timer {
 	return noop{}

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -1,0 +1,144 @@
+package timer
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type Timer interface {
+	// Start the timer
+	// Timer must be stopped, which is the state of a new timer.
+	Start()
+	// Pause the timer.
+	// Timer must be started.
+	Pause()
+	// Resumed the timer.
+	// Timer must be paused.
+	Resume()
+	// Stop the timer.
+	// Timer must be started.
+	Stop()
+	// Return average of timings and number of
+	// timings used to compute the average.
+	AverageTime() (time.Duration, int)
+}
+
+type timerState int
+
+const (
+	Stopped timerState = iota
+	Started
+	Paused
+)
+
+// Perform basic timings of sections of code.
+// Keeps a running average of timing values.
+type timer struct {
+	sampleRate float64
+	start      time.Time
+	current    time.Duration
+	avg        *movavg
+	state      timerState
+}
+
+func New(sampleRate float64, movingAverageSize int) Timer {
+	return &timer{
+		sampleRate: sampleRate,
+		avg:        newMovAvg(movingAverageSize),
+	}
+}
+
+// Start timer.
+func (t *timer) Start() {
+	if t.state != Stopped {
+		panic("invalid timer state")
+	}
+	if rand.Float64() < t.sampleRate {
+		t.state = Started
+		t.start = time.Now()
+	}
+}
+
+// Pause current timing event.
+func (t *timer) Pause() {
+	if t.state != Started {
+		return
+	}
+	t.current += time.Now().Sub(t.start)
+	t.state = Paused
+}
+
+// Resumed paused timer.
+func (t *timer) Resume() {
+	if t.state != Paused {
+		return
+	}
+	t.start = time.Now()
+	t.state = Started
+}
+
+// Stop and record time of event.
+// The moving average is updated at this point.
+func (t *timer) Stop() {
+	if t.state != Started {
+		return
+	}
+	t.current += time.Now().Sub(t.start)
+	t.avg.update(float64(t.current))
+	t.current = 0
+	t.state = Stopped
+}
+
+// Return the average time in nanoseconds and
+// the number of timings used to compute the average.
+func (t *timer) AverageTime() (time.Duration, int) {
+	avg, count := t.avg.average()
+	return time.Duration(avg), count
+}
+
+// Maintains a moving average of values
+type movavg struct {
+	size    int
+	history []float64
+	idx     int
+	count   int
+	avg     float64
+	mu      sync.RWMutex
+}
+
+func newMovAvg(size int) *movavg {
+	return &movavg{
+		size:    size,
+		history: make([]float64, size),
+		idx:     -1,
+	}
+}
+
+func (m *movavg) update(value float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := float64(m.count)
+	if n == 0 {
+		m.count = 1
+		m.avg = value
+		return
+	}
+
+	m.avg += (value - m.avg) / n
+	m.idx = (m.idx + 1) % m.size
+
+	if m.count == m.size {
+		old := m.history[m.idx]
+		m.avg = (n*m.avg - old) / (n - 1)
+	} else {
+		m.count++
+	}
+	m.history[m.idx] = value
+}
+
+func (m *movavg) average() (float64, int) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.avg, m.count
+}

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -1,0 +1,155 @@
+package timer
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestMovAvg(t *testing.T) {
+	count := 100
+	ma := newMovAvg(count)
+	for i := 0; i < count; i++ {
+		avg := ma.update(1)
+		if got, exp := avg, 1.0; got != exp {
+			t.Fatalf("unexpected movavg: got %f, exp %f", got, exp)
+		}
+	}
+	c := float64(count)
+	for i := 0; i < count; i++ {
+		avg := ma.update(2)
+		f := float64(i + 1)
+		if got, exp := avg, ((c-f)+2.0*f)/c; math.Abs(got-exp) > 1e-8 {
+			t.Fatalf("unexpected movavg i: %d got %f, exp %f", i, got, exp)
+		}
+	}
+}
+
+func TestMovAvgAccuracy(t *testing.T) {
+	count := 10000
+
+	avg := func(data []float64) float64 {
+		sum := 0.0
+		for _, v := range data {
+			sum += v
+		}
+		return sum / float64(len(data))
+	}
+
+	r := rand.New(rand.NewSource(42))
+
+	data := make([]float64, count)
+	for i := 0; i < count; i++ {
+		data[i] = r.Float64()
+	}
+	expAvg := avg(data)
+	ma := newMovAvg(count)
+	gotAvg := 0.0
+	for _, v := range data {
+		gotAvg = ma.update(v)
+	}
+
+	if math.Abs(gotAvg-expAvg) > 1e-8 {
+		t.Errorf("unexpected average value: got %f exp %f", gotAvg, expAvg)
+	}
+
+	size := count / 10
+	ma = newMovAvg(size)
+
+	expAvg = avg(data[count-size:])
+	gotAvg = 0.0
+	for _, v := range data {
+		gotAvg = ma.update(v)
+	}
+	if math.Abs(gotAvg-expAvg) > 1e-8 {
+		t.Errorf("unexpected moving average value: got %f exp %f", gotAvg, expAvg)
+	}
+}
+
+func BenchmarkMovAvgUpdate(b *testing.B) {
+	ma := newMovAvg(1000)
+	for i := 0; i < b.N; i++ {
+		ma.update(float64(i))
+	}
+}
+
+type setter struct {
+	value float64
+}
+
+func (s *setter) Set(v float64) {
+	s.value = v
+}
+
+func TestSampling(t *testing.T) {
+	sr := 0.1
+	size := 10000
+	rand.Seed(0)
+
+	s := &setter{}
+	tmr := New(sr, size, s).(*timer)
+
+	for i := 0; i < size; i++ {
+		tmr.Start()
+		tmr.Stop()
+	}
+
+	count := sr * float64(size)
+	err := 0.1
+	if math.Abs(float64(tmr.avg.count)-count) > err*count {
+		t.Errorf("unexpected numbers of samples taken got: %d exp: %d", tmr.avg.count, count)
+	}
+
+}
+
+func BenchmarkTimerStartStopWorst(b *testing.B) {
+	// Use 100% sample rate worst case
+	sr := 1.0
+	size := 1000
+	s := &setter{}
+	tmr := New(sr, size, s).(*timer)
+	for i := 0; i < b.N; i++ {
+		tmr.Start()
+		tmr.Stop()
+	}
+}
+
+func BenchmarkTimerStartPauseResumeStopWorst(b *testing.B) {
+	// Use 100% sample rate worst case
+	sr := 1.0
+	size := 1000
+	s := &setter{}
+	tmr := New(sr, size, s).(*timer)
+	for i := 0; i < b.N; i++ {
+		tmr.Start()
+		tmr.Pause()
+		tmr.Resume()
+		tmr.Stop()
+	}
+}
+
+func BenchmarkTimerStartStopBest(b *testing.B) {
+	// Use 0% sample rate best case
+	sr := 0.0
+	size := 1000
+	s := &setter{}
+	tmr := New(sr, size, s).(*timer)
+	for i := 0; i < b.N; i++ {
+		tmr.Start()
+		tmr.Stop()
+	}
+}
+
+func BenchmarkTimerStartPauseResumeStopBest(b *testing.B) {
+	// Use 0% sample rate base case
+	sr := 0.0
+	size := 1000
+	s := &setter{}
+	tmr := New(sr, size, s).(*timer)
+	for i := 0; i < b.N; i++ {
+		tmr.Start()
+		tmr.Pause()
+		tmr.Resume()
+		tmr.Stop()
+	}
+}

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -97,7 +97,7 @@ func TestSampling(t *testing.T) {
 	count := sr * float64(size)
 	err := 0.1
 	if math.Abs(float64(tmr.avg.count)-count) > err*count {
-		t.Errorf("unexpected numbers of samples taken got: %d exp: %d", tmr.avg.count, count)
+		t.Errorf("unexpected numbers of samples taken got: %d exp: %d", int(tmr.avg.count), int(count))
 	}
 
 }

--- a/udf.go
+++ b/udf.go
@@ -109,19 +109,23 @@ func (u *UDFNode) runUDF(snapshot []byte) (err error) {
 		switch u.Wants() {
 		case pipeline.StreamEdge:
 			for p, ok := u.ins[0].NextPoint(); ok; p, ok = u.ins[0].NextPoint() {
+				u.timer.Start()
 				select {
 				case u.process.PointIn <- p:
 				case <-u.aborted:
 					return
 				}
+				u.timer.Stop()
 			}
 		case pipeline.BatchEdge:
 			for b, ok := u.ins[0].NextBatch(); ok; b, ok = u.ins[0].NextBatch() {
+				u.timer.Start()
 				select {
 				case u.process.BatchIn <- b:
 				case <-u.aborted:
 					return
 				}
+				u.timer.Stop()
 			}
 		}
 	}()

--- a/udf/agent/examples/moving_avg/moving_avg.go
+++ b/udf/agent/examples/moving_avg/moving_avg.go
@@ -110,7 +110,7 @@ func (a *avgHandler) Snaphost() (*udf.SnapshotResponse, error) {
 func (a *avgHandler) Restore(req *udf.RestoreRequest) (*udf.RestoreResponse, error) {
 	buf := bytes.NewReader(req.Snapshot)
 	dec := gob.NewDecoder(buf)
-	err := dec.Decode(a.state)
+	err := dec.Decode(&a.state)
 	msg := ""
 	if err != nil {
 		msg = err.Error()

--- a/udf/agent/examples/moving_avg/moving_avg.py
+++ b/udf/agent/examples/moving_avg/moving_avg.py
@@ -99,7 +99,7 @@ class AvgHandler(Handler):
 
     def snapshot(self):
         data = {}
-        for group, state in self._state:
+        for group, state in self._state.iteritems():
             data[group] = state.snapshot()
 
         response = udf_pb2.Response()
@@ -112,7 +112,7 @@ class AvgHandler(Handler):
         msg = ''
         try:
             data = json.loads(restore_req.snapshot)
-            for group, snapshot in data:
+            for group, snapshot in data.iteritems():
                 self._state[group] = AvgHandler.state(0)
                 self._state[group].restore(snapshot)
             success = True

--- a/union.go
+++ b/union.go
@@ -2,15 +2,21 @@ package kapacitor
 
 import (
 	"log"
+	"time"
 
+	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 	"github.com/influxdata/kapacitor/timer"
 )
 
 type UnionNode struct {
 	node
-	u      *pipeline.UnionNode
-	timers []timer.Timer
+	u *pipeline.UnionNode
+
+	// Buffer of points/batches from each parent
+	sources [][]models.PointInterface
+
+	rename string
 }
 
 // Create a new  UnionNode which combines all parent data streams into a single stream.
@@ -25,52 +31,141 @@ func newUnionNode(et *ExecutingTask, n *pipeline.UnionNode, l *log.Logger) (*Uni
 }
 
 func (u *UnionNode) runUnion([]byte) error {
-	rename := u.u.Rename
-	if rename == "" {
+	union := make(chan srcPoint)
+	u.rename = u.u.Rename
+	if u.rename == "" {
 		//the calling node is always the last node
-		rename = u.parents[len(u.parents)-1].Name()
+		u.rename = u.parents[len(u.parents)-1].Name()
 	}
+	// Spawn goroutine for each parent
 	errors := make(chan error, len(u.ins))
-	for _, in := range u.ins {
+	for i, in := range u.ins {
 		t := u.et.tm.TimingService.NewTimer(u.avgExecVar)
-		u.timers = append(u.timers, t)
-		go func(e *Edge, t timer.Timer) {
-			switch u.Wants() {
-			case pipeline.StreamEdge:
-				for p, ok := e.NextPoint(); ok; p, ok = e.NextPoint() {
-					t.Start()
-					p.Name = rename
-					t.Stop()
-					for _, out := range u.outs {
-						err := out.CollectPoint(p)
-						if err != nil {
-							errors <- err
-							return
-						}
-					}
-				}
-			case pipeline.BatchEdge:
-				for b, ok := e.NextBatch(); ok; b, ok = e.NextBatch() {
-					t.Start()
-					b.Name = rename
-					t.Stop()
-					for _, out := range u.outs {
-						err := out.CollectBatch(b)
-						if err != nil {
-							errors <- err
-							return
-						}
-					}
+		go func(index int, e *Edge, t timer.Timer) {
+			for p, ok := e.Next(); ok; p, ok = e.Next() {
+				union <- srcPoint{
+					src: index,
+					p:   p,
 				}
 			}
 			errors <- nil
-		}(in, t)
+		}(i, in, t)
 	}
 
-	for range u.ins {
-		err := <-errors
-		if err != nil {
+	// Channel for returning the first if any errors, from parent goroutines.
+	errC := make(chan error, 1)
+
+	go func() {
+		for range u.ins {
+			err := <-errors
+			if err != nil {
+				errC <- err
+				return
+			}
+		}
+		// Close the union channel once all parents are done writing
+		close(union)
+	}()
+
+	//
+	// Emit values received from parents ordered by time.
+	//
+
+	// Keep buffer of values from parents so they can be ordered.
+	u.sources = make([][]models.PointInterface, len(u.ins))
+
+	for {
+		select {
+		case err := <-errC:
+			// One of the parents errored out, return the error.
 			return err
+		case source, ok := <-union:
+			if !ok {
+				// We are done, emit all buffered points
+				for {
+					more, err := u.emitNext(true)
+					if err != nil {
+						return err
+					}
+					if !more {
+						return nil
+					}
+				}
+			}
+			// Add newest point to buffer
+			u.sources[source.src] = append(u.sources[source.src], source.p)
+
+			// Emit the next values
+			_, err := u.emitNext(false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (u *UnionNode) emitNext(drain bool) (more bool, err error) {
+	more = true
+
+	// Find low water mark
+	var mark time.Time
+	markSet := false
+	for _, values := range u.sources {
+		if len(values) > 0 {
+			if !markSet || values[0].PointTime().Before(mark) {
+				mark = values[0].PointTime()
+				markSet = true
+			}
+		} else if !drain {
+			// We can't continue processing until we have
+			// at least one value buffered from each parent.
+			// Unless we are draining the buffer than we can continue.
+			return
+		}
+	}
+
+	// Emit all values that are at or below the mark.
+	remaining := 0
+	for i, values := range u.sources {
+		var j int
+		l := len(values)
+		for j = 0; j < l; j++ {
+			if !values[j].PointTime().After(mark) {
+				err = u.emit(values[j])
+				if err != nil {
+					return
+				}
+			} else {
+				break
+			}
+		}
+		// Drop values that were emitted
+		u.sources[i] = values[j:]
+		remaining += len(u.sources[i])
+	}
+	more = remaining > 0
+	return
+}
+
+func (u *UnionNode) emit(v models.PointInterface) error {
+	switch u.Provides() {
+	case pipeline.StreamEdge:
+		p := v.(models.Point)
+		p.Name = u.rename
+		for _, child := range u.outs {
+			err := child.CollectPoint(p)
+			if err != nil {
+				return err
+			}
+		}
+	case pipeline.BatchEdge:
+		b := v.(models.Batch)
+		b.Name = u.rename
+		for _, child := range u.outs {
+			err := child.CollectBatch(b)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/union.go
+++ b/union.go
@@ -2,7 +2,6 @@ package kapacitor
 
 import (
 	"log"
-	"time"
 
 	"github.com/influxdata/kapacitor/pipeline"
 	"github.com/influxdata/kapacitor/timer"
@@ -33,7 +32,7 @@ func (u *UnionNode) runUnion([]byte) error {
 	}
 	errors := make(chan error, len(u.ins))
 	for _, in := range u.ins {
-		t := u.et.tm.TimingService.NewTimer()
+		t := u.et.tm.TimingService.NewTimer(u.avgExecVar)
 		u.timers = append(u.timers, t)
 		go func(e *Edge, t timer.Timer) {
 			switch u.Wants() {
@@ -75,18 +74,4 @@ func (u *UnionNode) runUnion([]byte) error {
 		}
 	}
 	return nil
-}
-
-func (u *UnionNode) nodeExecTime() time.Duration {
-	sum := 0.0
-	total := 0.0
-	for _, t := range u.timers {
-		avg, count := t.AverageTime()
-		sum += float64(avg) * float64(count)
-		total += float64(count)
-	}
-	if total == 0 {
-		return 0
-	}
-	return time.Duration(sum / total)
 }

--- a/union.go
+++ b/union.go
@@ -80,6 +80,7 @@ func (u *UnionNode) runUnion([]byte) error {
 			// One of the parents errored out, return the error.
 			return err
 		case source, ok := <-union:
+			u.timer.Start()
 			if !ok {
 				// We are done, emit all buffered points
 				for {
@@ -100,6 +101,7 @@ func (u *UnionNode) runUnion([]byte) error {
 			if err != nil {
 				return err
 			}
+			u.timer.Stop()
 		}
 	}
 }
@@ -148,6 +150,8 @@ func (u *UnionNode) emitNext(drain bool) (more bool, err error) {
 }
 
 func (u *UnionNode) emit(v models.PointInterface) error {
+	u.timer.Pause()
+	defer u.timer.Resume()
 	switch u.Provides() {
 	case pipeline.StreamEdge:
 		p := v.(models.Point)

--- a/vendor/github.com/influxdb/influxdb/client/v2/client.go
+++ b/vendor/github.com/influxdb/influxdb/client/v2/client.go
@@ -1,4 +1,4 @@
-package client
+package client // import "github.com/influxdata/influxdb/client/v2"
 
 import (
 	"bytes"
@@ -21,6 +21,7 @@ const (
 	UDPPayloadSize = 512
 )
 
+// HTTPConfig is the config data needed to create an HTTP Client
 type HTTPConfig struct {
 	// Addr should be of the form "http://host:port"
 	// or "http://[ipv6-host%zone]:port".
@@ -47,6 +48,7 @@ type HTTPConfig struct {
 	TLSConfig *tls.Config
 }
 
+// UDPConfig is the config data needed to create a UDP Client
 type UDPConfig struct {
 	// Addr should be of the form "host:port"
 	// or "[ipv6-host%zone]:port".
@@ -57,6 +59,7 @@ type UDPConfig struct {
 	PayloadSize int
 }
 
+// BatchPointsConfig is the config data needed to create an instance of the BatchPoints struct
 type BatchPointsConfig struct {
 	// Precision is the write precision of the points, defaults to "ns"
 	Precision string
@@ -73,6 +76,9 @@ type BatchPointsConfig struct {
 
 // Client is a client interface for writing & querying the database
 type Client interface {
+	// Ping checks that status of cluster
+	Ping(timeout time.Duration) (time.Duration, string, error)
+
 	// Write takes a BatchPoints object and writes all Points to InfluxDB.
 	Write(bp BatchPoints) error
 
@@ -84,7 +90,7 @@ type Client interface {
 	Close() error
 }
 
-// NewClient creates a client interface from the given config.
+// NewHTTPClient creates a client interface from the given config.
 func NewHTTPClient(conf HTTPConfig) (Client, error) {
 	if conf.UserAgent == "" {
 		conf.UserAgent = "InfluxDBClient"
@@ -119,6 +125,50 @@ func NewHTTPClient(conf HTTPConfig) (Client, error) {
 	}, nil
 }
 
+// Ping will check to see if the server is up with an optional timeout on waiting for leader.
+// Ping returns how long the request took, the version of the server it connected to, and an error if one occurred.
+func (c *client) Ping(timeout time.Duration) (time.Duration, string, error) {
+	now := time.Now()
+	u := c.url
+	u.Path = "ping"
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return 0, "", err
+	}
+
+	req.Header.Set("User-Agent", c.useragent)
+
+	if c.username != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	if timeout > 0 {
+		params := req.URL.Query()
+		params.Set("wait_for_leader", fmt.Sprintf("%.0fs", timeout.Seconds()))
+		req.URL.RawQuery = params.Encode()
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, "", err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		var err = fmt.Errorf(string(body))
+		return 0, "", err
+	}
+
+	version := resp.Header.Get("X-Influxdb-Version")
+	return time.Since(now), version, nil
+}
+
 // Close releases the client's resources.
 func (c *client) Close() error {
 	return nil
@@ -149,6 +199,12 @@ func NewUDPClient(conf UDPConfig) (Client, error) {
 	}, nil
 }
 
+// Ping will check to see if the server is up with an optional timeout on waiting for leader.
+// Ping returns how long the request took, the version of the server it connected to, and an error if one occurred.
+func (uc *udpclient) Ping(timeout time.Duration) (time.Duration, string, error) {
+	return 0, "", nil
+}
+
 // Close releases the udpclient's resources.
 func (uc *udpclient) Close() error {
 	return uc.conn.Close()
@@ -173,6 +229,8 @@ type udpclient struct {
 type BatchPoints interface {
 	// AddPoint adds the given point to the Batch of points
 	AddPoint(p *Point)
+	// AddPoints adds the given points to the Batch of points
+	AddPoints(ps []*Point)
 	// Points lists the points in the Batch
 	Points() []*Point
 
@@ -226,6 +284,10 @@ func (bp *batchpoints) AddPoint(p *Point) {
 	bp.points = append(bp.points, p)
 }
 
+func (bp *batchpoints) AddPoints(ps []*Point) {
+	bp.points = append(bp.points, ps...)
+}
+
 func (bp *batchpoints) Points() []*Point {
 	return bp.points
 }
@@ -266,6 +328,7 @@ func (bp *batchpoints) SetRetentionPolicy(rp string) {
 	bp.retentionPolicy = rp
 }
 
+// Point represents a single data point
 type Point struct {
 	pt models.Point
 }
@@ -309,7 +372,7 @@ func (p *Point) Name() string {
 	return p.pt.Name()
 }
 
-// Name returns the tags associated with the point
+// Tags returns the tags associated with the point
 func (p *Point) Tags() map[string]string {
 	return p.pt.Tags()
 }


### PR DESCRIPTION
Fixes #215 

This PR exposes two metrics to the user about throughput and execution time:

1. The throughput in batches or points per second per taks is calculated depending on task type
2. The average execution time per node is calculated. 

These values are exposed via the Kapacitor `show` command and in the internal statistics Kapacitor emits. As a result it is possible to graph throughput and execution times or other stats a node exposes.
