### PR TITLE
Sensu fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ With #144 you can now join streams with differing group by dimensions.
 - [#213](https://github.com/influxdata/kapacitor/issues/231): Add SourceStreamNode so that yuou must always first call `.from` on the `stream` object before filtering it, so as to not create confusing to understand TICKscripts.
 - [#255](https://github.com/influxdata/kapacitor/issues/255): Add OPTIONS handler for task delete method so it can be preflighted.
 - [#258](https://github.com/influxdata/kapacitor/issues/258): Fix UDP internal metrics, change subscriptions to use clusterID.
+- [#240](https://github.com/influxdata/kapacitor/issues/240): BREAKING: Fix issues with Sensu integration. The breaking change is that the config no longer takes a `url` but rather a `host` option since the communication is raw TCP rather HTTP.
 
 ## v0.10.1 [2016-02-08]
 

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -199,8 +199,8 @@ data_dir = "/var/lib/kapacitor"
 [sensu]
   # Configure Sensu.
   enabled = false
-  # The Sensu URL.
-  url = "http://sensu:3030"
+  # The Sensu Client host:port address.
+  addr = "sensu-client:3030"
   # Default JIT source.
   source = "Kapacitor"
 

--- a/services/sensu/config.go
+++ b/services/sensu/config.go
@@ -1,16 +1,14 @@
 package sensu
 
-import (
-	"net/url"
-)
+import "errors"
 
 const DefaultSource = "Kapacitor"
 
 type Config struct {
 	// Whether Sensu integration is enabled.
 	Enabled bool `toml:"enabled"`
-	// The Sensu URL.
-	URL string `toml:"url"`
+	// The Sensu client host:port address.
+	Addr string `toml:"addr"`
 	// The JIT sensu source name of the alert.
 	Source string `toml:"source"`
 }
@@ -22,9 +20,8 @@ func NewConfig() Config {
 }
 
 func (c Config) Validate() error {
-	_, err := url.Parse(c.URL)
-	if err != nil {
-		return err
+	if c.Enabled && c.Addr == "" {
+		return errors.New("must specify sensu client address")
 	}
 	return nil
 }


### PR DESCRIPTION
@brettdh I believe I have addressed all the issues. ATM it is not easy to use docker to create a sensu client for full integration testing. The unit tests have been updated to use a raw TCP socket and the code has been tested against a real Sensu client and is behaving correctly. 

Note in addition to the sensu changes a small change was added to the alert node to count triggered alerts.