### PR TITLE
PagerDuty Enhancement

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -646,6 +646,7 @@ func (a *AlertNode) handlePagerDuty(pd *pipeline.PagerDutyHandler, ad *AlertData
 	err := a.et.tm.PagerDutyService.Alert(
 		ad.ID,
 		ad.Message,
+		ad.Level,
 		ad.Data,
 	)
 	if err != nil {

--- a/task_master.go
+++ b/task_master.go
@@ -60,7 +60,7 @@ type TaskMaster struct {
 	}
 	PagerDutyService interface {
 		Global() bool
-		Alert(incidentKey, desc string, details interface{}) error
+		Alert(incidentKey, desc string, level AlertLevel, details interface{}) error
 	}
 	SlackService interface {
 		Global() bool


### PR DESCRIPTION
Improvements to the PagerDuty service integration:
- Adds the concept of alert levels that correspond to the PagerDuty `trigger` and `resolved` events
- Includes the alert ID in the PagerDuty requests, instead of opening a new incident with every alert

Fixes #288 