### PR TITLE
Decouple global setting from state-changes-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ to this:
 Various improvements to joining features have been implemented.
 With #144 you can now join streams with differing group by dimensions.
 
+If you previously configured Email, Slack or HipChat globally now you must also set the `state-changes-only` option to true as well if you want to preserve the original behavior.
+For example:
+
+```
+[slack]
+   enable = true
+   global = true
+   state-changes-only = true
+```
 
 ### Features
 - [#236](https://github.com/influxdata/kapacitor/issues/236): Implement batched group by
@@ -92,6 +101,7 @@ With #144 you can now join streams with differing group by dimensions.
 - [#289](https://github.com/influxdata/kapacitor/issues/289): Add better error handling to batch node.
 - [#142](https://github.com/influxdata/kapacitor/issues/142): Fixes bug when defining multiple influxdb hosts.
 - [#333](https://github.com/influxdata/kapacitor/issues/333): Fixes hang when replaying with .stats node. Fixes issues with batch and stats.
+- [#340](https://github.com/influxdata/kapacitor/issues/340): BREAKING: Decouples global setting for alert handlers from the state changes only setting.
 
 ## v0.10.1 [2016-02-08]
 

--- a/alert.go
+++ b/alert.go
@@ -146,8 +146,10 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 	if len(n.EmailHandlers) == 0 && (et.tm.SMTPService != nil && et.tm.SMTPService.Global()) {
 		an.handlers = append(an.handlers, func(ad *AlertData) { an.handleEmail(&pipeline.EmailHandler{}, ad) })
 	}
-	// If email has been configured globally only send state changes.
-	if et.tm.SMTPService != nil && et.tm.SMTPService.Global() {
+	// If email has been configured with state changes only set it.
+	if et.tm.SMTPService != nil &&
+		et.tm.SMTPService.Global() &&
+		et.tm.SMTPService.StateChangesOnly() {
 		n.IsStateChangesOnly = true
 	}
 
@@ -192,8 +194,10 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 	if len(n.SlackHandlers) == 0 && (et.tm.SlackService != nil && et.tm.SlackService.Global()) {
 		an.handlers = append(an.handlers, func(ad *AlertData) { an.handleSlack(&pipeline.SlackHandler{}, ad) })
 	}
-	// If slack has been configured globally only send state changes.
-	if et.tm.SlackService != nil && et.tm.SlackService.Global() {
+	// If slack has been configured with state changes only set it.
+	if et.tm.SlackService != nil &&
+		et.tm.SlackService.Global() &&
+		et.tm.SlackService.StateChangesOnly() {
 		n.IsStateChangesOnly = true
 	}
 
@@ -204,8 +208,10 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 	if len(n.HipChatHandlers) == 0 && (et.tm.HipChatService != nil && et.tm.HipChatService.Global()) {
 		an.handlers = append(an.handlers, func(ad *AlertData) { an.handleHipChat(&pipeline.HipChatHandler{}, ad) })
 	}
-	// If HipChat has been configured globally only send state changes.
-	if et.tm.HipChatService != nil && et.tm.HipChatService.Global() {
+	// If HipChat has been configured with state changes only set it.
+	if et.tm.HipChatService != nil &&
+		et.tm.HipChatService.Global() &&
+		et.tm.HipChatService.StateChangesOnly() {
 		n.IsStateChangesOnly = true
 	}
 

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -124,6 +124,14 @@ data_dir = "/var/lib/kapacitor"
   # Close idle connections after timeout
   idle-timeout = "30s"
 
+  # If true the all alerts will be sent via Email
+  # without explicity marking them in the TICKscript.
+  global = false
+  # Only applies if global is true.
+  # Sets all alerts in state-changes-only mode,
+  # meaning alerts will only be sent if the alert state changes.
+  state-changes-only = false
+
 [opsgenie]
     # Configure OpsGenie with your API key and default routing key.
     enabled = false
@@ -182,6 +190,10 @@ data_dir = "/var/lib/kapacitor"
   # If true the all alerts will be sent to Slack
   # without explicity marking them in the TICKscript.
   global = false
+  # Only applies if global is true.
+  # Sets all alerts in state-changes-only mode,
+  # meaning alerts will only be sent if the alert state changes.
+  state-changes-only = false
 
 [hipchat]
   # Configure HipChat.
@@ -199,6 +211,10 @@ data_dir = "/var/lib/kapacitor"
   # If true then all alerts will be sent to HipChat
   # without explicitly marking them in the TICKscript.
   global = false
+  # Only applies if global is true.
+  # Sets all alerts in state-changes-only mode,
+  # meaning alerts will only be sent if the alert state changes.
+  state-changes-only = false
 
 [alerta]
   # Configure Alerta.

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -367,6 +367,7 @@ type PostHandler struct {
 //       to = ["oncall@example.com"]
 //       # Set global to true so all alert trigger emails.
 //       global = true
+//       state-changes-only =  true
 //
 // Example:
 //    stream...
@@ -374,7 +375,6 @@ type PostHandler struct {
 //
 // Send email to 'oncall@example.com' from 'kapacitor@example.com'
 //
-// **NOTE**: The global option for email also implies stateChangesOnly is set on all alerts.
 // tick:property
 func (a *AlertNode) Email(to ...string) *EmailHandler {
 	em := &EmailHandler{
@@ -596,14 +596,13 @@ type PagerDutyHandler struct {
 //      room = "Test Room"
 //      token = "9hiWoDOZ9IbmHsOTeST123ABciWTIqXQVFDo63h9"
 //      global = true
+//      state-changes-only = true
 //
 // Example:
 //    stream...
 //         .alert()
 //
 // Send alert to HipChat using default room 'Test Room'.
-// **NOTE**: The global option for HipChat also implies stateChangesOnly is set on all alerts.
-// Also, the room can either be the room id (numerical) or the room name.
 // tick:property
 func (a *AlertNode) HipChat() *HipChatHandler {
 	hipchat := &HipChatHandler{
@@ -797,14 +796,13 @@ type SensuHandler struct {
 //      url = "https://hooks.slack.com/services/xxxxxxxxx/xxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxx"
 //      channel = "#general"
 //      global = true
+//      state-changes-only = true
 //
 // Example:
 //    stream...
 //         .alert()
 //
 // Send alert to Slack using default channel '#general'.
-// **NOTE**: The global option for Slack also implies stateChangesOnly is set on all alerts.
-// tick:property
 func (a *AlertNode) Slack() *SlackHandler {
 	slack := &SlackHandler{
 		AlertNode: a,

--- a/services/hipchat/config.go
+++ b/services/hipchat/config.go
@@ -12,6 +12,9 @@ type Config struct {
 	Room string `toml:"room"`
 	// Whether all alerts should automatically post to HipChat
 	Global bool `toml:"global"`
+	// Whether all alerts should automatically use stateChangesOnly mode.
+	// Only applies if global is also set.
+	StateChangesOnly bool `toml:"state-changes-only"`
 }
 
 func NewConfig() Config {

--- a/services/hipchat/service.go
+++ b/services/hipchat/service.go
@@ -14,20 +14,22 @@ import (
 )
 
 type Service struct {
-	room   string
-	token  string
-	url    string
-	global bool
-	logger *log.Logger
+	room             string
+	token            string
+	url              string
+	global           bool
+	stateChangesOnly bool
+	logger           *log.Logger
 }
 
 func NewService(c Config, l *log.Logger) *Service {
 	return &Service{
-		room:   c.Room,
-		token:  c.Token,
-		url:    c.URL,
-		global: c.Global,
-		logger: l,
+		room:             c.Room,
+		token:            c.Token,
+		url:              c.URL,
+		global:           c.Global,
+		stateChangesOnly: c.StateChangesOnly,
+		logger:           l,
 	}
 }
 
@@ -41,6 +43,10 @@ func (s *Service) Close() error {
 
 func (s *Service) Global() bool {
 	return s.global
+}
+
+func (s *Service) StateChangesOnly() bool {
+	return s.stateChangesOnly
 }
 
 func (s *Service) Alert(room, token, message string, level kapacitor.AlertLevel) error {

--- a/services/slack/config.go
+++ b/services/slack/config.go
@@ -9,6 +9,9 @@ type Config struct {
 	Channel string `toml:"channel"`
 	// Whether all alerts should automatically post to slack
 	Global bool `toml:"global"`
+	// Whether all alerts should automatically use stateChangesOnly mode.
+	// Only applies if global is also set.
+	StateChangesOnly bool `toml:"state-changes-only"`
 }
 
 func NewConfig() Config {

--- a/services/slack/service.go
+++ b/services/slack/service.go
@@ -13,18 +13,20 @@ import (
 )
 
 type Service struct {
-	channel string
-	url     string
-	global  bool
-	logger  *log.Logger
+	channel          string
+	url              string
+	global           bool
+	stateChangesOnly bool
+	logger           *log.Logger
 }
 
 func NewService(c Config, l *log.Logger) *Service {
 	return &Service{
-		channel: c.Channel,
-		url:     c.URL,
-		global:  c.Global,
-		logger:  l,
+		channel:          c.Channel,
+		url:              c.URL,
+		global:           c.Global,
+		stateChangesOnly: c.StateChangesOnly,
+		logger:           l,
 	}
 }
 
@@ -38,6 +40,9 @@ func (s *Service) Close() error {
 
 func (s *Service) Global() bool {
 	return s.global
+}
+func (s *Service) StateChangesOnly() bool {
+	return s.stateChangesOnly
 }
 
 // slack attachment info

--- a/services/smtp/config.go
+++ b/services/smtp/config.go
@@ -16,6 +16,9 @@ type Config struct {
 	NoVerify bool `toml:"no-verify"`
 	// Whether all alerts should trigger an email.
 	Global bool `toml:"global"`
+	// Whether all alerts should automatically use stateChangesOnly mode.
+	// Only applies if global is also set.
+	StateChangesOnly bool `toml:"state-changes-only"`
 	// From address
 	From string `toml:"from"`
 	// Default To addresses

--- a/services/smtp/service.go
+++ b/services/smtp/service.go
@@ -48,6 +48,10 @@ func (s *Service) Global() bool {
 	return s.c.Global
 }
 
+func (s *Service) StateChangesOnly() bool {
+	return s.c.StateChangesOnly
+}
+
 func (s *Service) runMailer() {
 	defer s.wg.Done()
 	var d *gomail.Dialer

--- a/task_master.go
+++ b/task_master.go
@@ -49,6 +49,7 @@ type TaskMaster struct {
 	}
 	SMTPService interface {
 		Global() bool
+		StateChangesOnly() bool
 		SendMail(to []string, subject string, msg string) error
 	}
 	OpsGenieService interface {
@@ -65,10 +66,12 @@ type TaskMaster struct {
 	}
 	SlackService interface {
 		Global() bool
+		StateChangesOnly() bool
 		Alert(channel, message string, level AlertLevel) error
 	}
 	HipChatService interface {
 		Global() bool
+		StateChangesOnly() bool
 		Alert(room, token, message string, level AlertLevel) error
 	}
 	AlertaService interface {


### PR DESCRIPTION
Fixes #340 Now instead of global = true for an alert handler also setting stateChangesOnly there is an explicit settting `state-changes-only` that must also be set. 

This help to remove the confusion caused by the side effect of setting global = true for Email, Slack or HipChat.

Fixes #332