### PR TITLE
Allow /root/go/src to be cached during docker build

### DIFF
--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -60,6 +60,7 @@ RUN mkdir -p $PROJECT_DIR
 WORKDIR $PROJECT_DIR
 
 VOLUME $PROJECT_DIR
+VOLUME /root/go/src
 
 # Configure local git
 RUN git config --global user.email "support@influxdb.com"

--- a/build.sh
+++ b/build.sh
@@ -7,14 +7,23 @@ set -e
 DIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 cd $DIR
 
-
 # Build new docker image
 docker build -f Dockerfile_build_ubuntu64 -t influxdata/kapacitor-builder $DIR
+if test "${KAPACITOR_USE_BUILD_CACHE}" = "true"; then
+	# create a container that owns the /root/go/src volume used as a cache of go dependency downloads
+	# ignore failures, since this usually means the container already exists.
+	docker run --entrypoint=/bin/true --name kapacitor-builder-cache influxdata/kapacitor-builder 2>/dev/null &&
+	VOLUME_OPTIONS=--volumes-from kapacitor-builder-cache || true
+else
+	VOLUME_OPTIONS=
+fi
+
 echo "Running build.py"
 # Run docker
 docker run --rm \
     -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
     -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+    ${VOLUME_OPTIONS} \
     -v $DIR:/root/go/src/github.com/influxdata/kapacitor \
     influxdata/kapacitor-builder \
     "$@"


### PR DESCRIPTION
The docker build is rather punishing on 4G bandwidth consumption.

This change allow the user to cache the /root/go/src if they so choose, but
default to not using such a cache.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>