### PR TITLE
Fork by measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [#360](https://github.com/influxdata/kapacitor/pull/360): Forking tasks by measurement in order to improve performance
+
 ### Bugfixes
 
 ## v0.12.0 [2016-04-04]

--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -46,7 +46,7 @@ type Service struct {
 		NewNamedClient(name string) (client.Client, error)
 	}
 	TaskMaster interface {
-		NewFork(name string, dbrps []kapacitor.DBRP) (*kapacitor.Edge, error)
+		NewFork(name string, dbrps []kapacitor.DBRP, measurements []string) (*kapacitor.Edge, error)
 		DelFork(name string)
 		New() *kapacitor.TaskMaster
 		Stream(name string) (kapacitor.StreamCollector, error)
@@ -265,7 +265,7 @@ func (r *Service) handleRecord(w http.ResponseWriter, req *http.Request) {
 		}
 
 		doF = func() error {
-			err := r.doRecordStream(rid, dur, t.DBRPs, started)
+			err := r.doRecordStream(rid, dur, t.DBRPs, t.Measurements(), started)
 			if err != nil {
 				close(started)
 			}
@@ -606,8 +606,8 @@ func (s streamWriter) Close() error {
 }
 
 // Record the stream for a duration
-func (r *Service) doRecordStream(rid uuid.UUID, dur time.Duration, dbrps []kapacitor.DBRP, started chan struct{}) error {
-	e, err := r.TaskMaster.NewFork(rid.String(), dbrps)
+func (r *Service) doRecordStream(rid uuid.UUID, dur time.Duration, dbrps []kapacitor.DBRP, measurements []string, started chan struct{}) error {
+	e, err := r.TaskMaster.NewFork(rid.String(), dbrps, measurements)
 	if err != nil {
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -61,6 +61,21 @@ func (t *Task) Dot() []byte {
 	return t.Pipeline.Dot(t.Name)
 }
 
+// returns all the measurements from a StreamNode
+func (t *Task) Measurements() []string {
+	measurements := make([]string, 0)
+
+	t.Pipeline.Walk(func(node pipeline.Node) error {
+		switch streamNode := node.(type) {
+		case *pipeline.StreamNode:
+			measurements = append(measurements, streamNode.Measurement)
+		}
+		return nil
+	})
+
+	return measurements
+}
+
 // ----------------------------------
 // ExecutingTask
 

--- a/task_master.go
+++ b/task_master.go
@@ -101,8 +101,16 @@ type TaskMaster struct {
 
 	// Incoming streams
 	writePointsIn StreamCollector
+
 	// Forks of incoming streams
-	forks map[string]fork
+	// We are mapping from (db, rp, measurement) to map of task names to their edges
+	// The outer map (from dbrp&measurement) is for fast access on forkPoint
+	// While the inner map is for handling fork deletions better (see taskToForkKeys)
+	forks map[forkKey]map[string]*Edge
+
+	// Task to fork keys is map to help in deletes, in deletes
+	// we have only the task name, and they are called after the task is deleted from TaskMaster.tasks
+	taskToForkKeys map[string][]forkKey
 
 	// Set of incoming batches
 	batches map[string][]BatchCollector
@@ -118,22 +126,23 @@ type TaskMaster struct {
 	wg      sync.WaitGroup
 }
 
-// A fork of the main data stream filtered by a set of DBRPs
-type fork struct {
-	Edge  *Edge
-	dbrps map[DBRP]bool
+type forkKey struct {
+	Database        string
+	RetentionPolicy string
+	Measurement     string
 }
 
 // Create a new Executor with a given clock.
 func NewTaskMaster(l LogService) *TaskMaster {
 	return &TaskMaster{
-		forks:         make(map[string]fork),
-		batches:       make(map[string][]BatchCollector),
-		tasks:         make(map[string]*ExecutingTask),
-		LogService:    l,
-		logger:        l.NewLogger("[task_master] ", log.LstdFlags),
-		closed:        true,
-		TimingService: noOpTimingService{},
+		forks:          make(map[forkKey]map[string]*Edge),
+		taskToForkKeys: make(map[string][]forkKey),
+		batches:        make(map[string][]BatchCollector),
+		tasks:          make(map[string]*ExecutingTask),
+		LogService:     l,
+		logger:         l.NewLogger("[task_master] ", log.LstdFlags),
+		closed:         true,
+		TimingService:  noOpTimingService{},
 	}
 }
 
@@ -202,7 +211,9 @@ func (tm *TaskMaster) Drain() {
 	tm.waitForForks()
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
-	for name := range tm.forks {
+
+	// TODO(yosia): handle this thing ;)
+	for name, _ := range tm.taskToForkKeys {
 		tm.delFork(name)
 	}
 }
@@ -295,7 +306,7 @@ func (tm *TaskMaster) StartTask(t *Task) (*ExecutingTask, error) {
 	var ins []*Edge
 	switch et.Task.Type {
 	case StreamTask:
-		e, err := tm.newFork(et.Task.Name, et.Task.DBRPs)
+		e, err := tm.newFork(et.Task.Name, et.Task.DBRPs, et.Task.Measurements())
 		if err != nil {
 			return nil, err
 		}
@@ -416,14 +427,29 @@ func (tm *TaskMaster) runForking(in *Edge) {
 func (tm *TaskMaster) forkPoint(p models.Point) {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
-	for _, fork := range tm.forks {
-		dbrp := DBRP{
-			Database:        p.Database,
-			RetentionPolicy: p.RetentionPolicy,
-		}
-		if fork.dbrps[dbrp] {
-			fork.Edge.CollectPoint(p)
-		}
+
+	// Create the fork keys - which is (db, rp, measurement)
+	key := forkKey{
+		Database:        p.Database,
+		RetentionPolicy: p.RetentionPolicy,
+		Measurement:     p.Name,
+	}
+
+	// If we have empty measurement in this db,rp we need to send it all
+	// the points
+	emptyMeasurementKey := forkKey{
+		Database:        p.Database,
+		RetentionPolicy: p.RetentionPolicy,
+		Measurement:     "",
+	}
+
+	// Merge the results to the forks map
+	for _, edge := range tm.forks[key] {
+		edge.CollectPoint(p)
+	}
+
+	for _, edge := range tm.forks[emptyMeasurementKey] {
+		edge.CollectPoint(p)
 	}
 }
 
@@ -449,22 +475,54 @@ func (tm *TaskMaster) WritePoints(database, retentionPolicy string, consistencyL
 	return nil
 }
 
-func (tm *TaskMaster) NewFork(taskName string, dbrps []DBRP) (*Edge, error) {
+func (tm *TaskMaster) NewFork(taskName string, dbrps []DBRP, measurements []string) (*Edge, error) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
-	return tm.newFork(taskName, dbrps)
+	return tm.newFork(taskName, dbrps, measurements)
+}
+
+func forkKeys(dbrps []DBRP, measurements []string) []forkKey {
+	keys := make([]forkKey, 0)
+
+	for _, dbrp := range dbrps {
+		for _, measurement := range measurements {
+			key := forkKey{
+				RetentionPolicy: dbrp.RetentionPolicy,
+				Database:        dbrp.Database,
+				Measurement:     measurement,
+			}
+
+			keys = append(keys, key)
+		}
+	}
+
+	return keys
 }
 
 // internal newFork, must have acquired lock before calling.
-func (tm *TaskMaster) newFork(taskName string, dbrps []DBRP) (*Edge, error) {
+func (tm *TaskMaster) newFork(taskName string, dbrps []DBRP, measurements []string) (*Edge, error) {
 	if tm.closed {
 		return nil, ErrTaskMasterClosed
 	}
+
 	e := newEdge(taskName, "stream", "srcstream0", pipeline.StreamEdge, defaultEdgeBufferSize, tm.LogService)
-	tm.forks[taskName] = fork{
-		Edge:  e,
-		dbrps: CreateDBRPMap(dbrps),
+
+	for _, key := range forkKeys(dbrps, measurements) {
+		tm.taskToForkKeys[taskName] = append(tm.taskToForkKeys[taskName], key)
+
+		// Add the task to the tasksMap if it dosen't exists
+		tasksMap, ok := tm.forks[key]
+		if !ok {
+			tasksMap = make(map[string]*Edge, 0)
+		}
+
+		// Add the edge to task map
+		tasksMap[taskName] = e
+
+		// update the task map in the forks
+		tm.forks[key] = tasksMap
 	}
+
 	return e, nil
 }
 
@@ -476,11 +534,31 @@ func (tm *TaskMaster) DelFork(name string) {
 
 // internal delFork function, must have lock to call
 func (tm *TaskMaster) delFork(name string) {
-	fork := tm.forks[name]
-	delete(tm.forks, name)
-	if fork.Edge != nil {
-		fork.Edge.Close()
+
+	// mark if we already closed the edge because the edge is replicated
+	// by it's fork keys (db,rp,measurement)
+	isEdgeClosed := false
+
+	// Find the fork keys
+	for _, key := range tm.taskToForkKeys[name] {
+
+		// check if the edge exists
+		edge, ok := tm.forks[key][name]
+		if ok {
+
+			// Only close the edge if we are already didn't closed it
+			if edge != nil && !isEdgeClosed {
+				isEdgeClosed = true
+				edge.Close()
+			}
+
+			// remove the task in fork map
+			delete(tm.forks[key], name)
+		}
 	}
+
+	// remove mapping from task name to it's keys
+	delete(tm.taskToForkKeys, name)
 }
 
 func (tm *TaskMaster) SnapshotTask(name string) (*TaskSnapshot, error) {


### PR DESCRIPTION
Hi,

This pull request greatly improves performance on the write benchmarks.
I did this performance improvements, in 5 steps:

_All of benchmark ran on my Macbook Pro (13-inch, Late 2011) with Intel Core i5 (2.4Ghz), 8gb memory and 120gb SSD_

### Filtering by measurement
To the fork struct I added measurements map from string to bool and compared it in the forkPoint.
And got the next improvement:
```
benchmark                                            old ns/op      new ns/op      delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     8633314476     57042          -100.00%
Benchmark_Write_MeasurementNameMatches_1000-4        7915678886     8229547562     +3.97%
Benchmark_Write_MeasurementNameNotMatches_100-4      37434          22472          -39.97%
Benchmark_Write_MeasurementNameMatches_100-4         38474          41502          +7.87%
Benchmark_Write_MeasurementNameNotMatches_10-4       22950          23601          +2.84%
Benchmark_Write_MeasurementNameMatches_10-4          23109          24814          +7.38%

benchmark                                            old allocs     new allocs     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     57450          50             -99.91%
Benchmark_Write_MeasurementNameMatches_1000-4        57426          57424          -0.00%
Benchmark_Write_MeasurementNameNotMatches_100-4      49             49             +0.00%
Benchmark_Write_MeasurementNameMatches_100-4         49             49             +0.00%
Benchmark_Write_MeasurementNameNotMatches_10-4       49             49             +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          49             49             +0.00%

benchmark                                            old bytes     new bytes     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     4264608       3950          -99.91%
Benchmark_Write_MeasurementNameMatches_1000-4        4261568       4261440       -0.00%
Benchmark_Write_MeasurementNameNotMatches_100-4      3889          3837          -1.34%
Benchmark_Write_MeasurementNameMatches_100-4         3889          3889          +0.00%
Benchmark_Write_MeasurementNameNotMatches_10-4       3838          3838          +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          3838          3839          +0.03%
```
_This performance numbers are compared to the baseline - benchmarks run on the master_

### Changing equality order
I tried to change check of:
```go
if fork.dbrps[dbrp] && fork.measurements[p.Name] {
   // ...
}
```
To first check the measurement and then dbrp, and got the next results:
```
benchmark                                            old ns/op      new ns/op      delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     57042          29203          -48.80%
Benchmark_Write_MeasurementNameMatches_1000-4        8229547562     8787711023     +6.78%
Benchmark_Write_MeasurementNameNotMatches_100-4      22472          36940          +64.38%
Benchmark_Write_MeasurementNameMatches_100-4         41502          55299          +33.24%
Benchmark_Write_MeasurementNameNotMatches_10-4       23601          36820          +56.01%
Benchmark_Write_MeasurementNameMatches_10-4          24814          44957          +81.18%

benchmark                                            old allocs     new allocs     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     50             49             -2.00%
Benchmark_Write_MeasurementNameMatches_1000-4        57424          57438          +0.02%
Benchmark_Write_MeasurementNameNotMatches_100-4      49             49             +0.00%
Benchmark_Write_MeasurementNameMatches_100-4         49             50             +2.04%
Benchmark_Write_MeasurementNameNotMatches_10-4       49             49             +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          49             49             +0.00%

benchmark                                            old bytes     new bytes     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     3950          3837          -2.86%
Benchmark_Write_MeasurementNameMatches_1000-4        4261440       4262336       +0.02%
Benchmark_Write_MeasurementNameNotMatches_100-4      3837          3888          +1.33%
Benchmark_Write_MeasurementNameMatches_100-4         3889          3953          +1.65%
Benchmark_Write_MeasurementNameNotMatches_10-4       3838          3838          +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          3839          3838          -0.03%
```
_This is compared between the first step and the second_
As you can see the performance got better for Benchmark_Write_MeasurementNameNotMatches_1000-4 but worse for the benchmarks (+33 to +64)

### Change the fork structure - map from dbrp&measurement to edges
I am skipping the forth step which is to take "dbrp" struct assignment in forkPoint out of the loop, and going to the biggest perf improvement.

Instead of checking all forks if they match criteria I pivoted it to map from the criteria (db,rp,measurement) to edges.



And we get this huge improvement:
```
benchmark                                            old ns/op      new ns/op      delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     29203          20774          -28.86%
Benchmark_Write_MeasurementNameMatches_1000-4        8787711023     5675405636     -35.42%
Benchmark_Write_MeasurementNameNotMatches_100-4      36940          21771          -41.06%
Benchmark_Write_MeasurementNameMatches_100-4         55299          36193          -34.55%
Benchmark_Write_MeasurementNameNotMatches_10-4       36820          23315          -36.68%
Benchmark_Write_MeasurementNameMatches_10-4          44957          24562          -45.37%

benchmark                                            old allocs     new allocs     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     49             48             -2.04%
Benchmark_Write_MeasurementNameMatches_1000-4        57438          57436          -0.00%
Benchmark_Write_MeasurementNameNotMatches_100-4      49             48             -2.04%
Benchmark_Write_MeasurementNameMatches_100-4         50             49             -2.00%
Benchmark_Write_MeasurementNameNotMatches_10-4       49             49             +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          49             49             +0.00%

benchmark                                            old bytes     new bytes     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     3837          3800          -0.96%
Benchmark_Write_MeasurementNameMatches_1000-4        4262336       4262208       -0.00%
Benchmark_Write_MeasurementNameNotMatches_100-4      3888          3800          -2.26%
Benchmark_Write_MeasurementNameMatches_100-4         3953          3888          -1.64%
Benchmark_Write_MeasurementNameNotMatches_10-4       3838          3838          +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          3838          3839          +0.03%
```
_The baseline is 'Changing equality order'_

Another sign of performance improvement, while running "Benchmark_Write_MeasurementNameNotMatches_1000-4" on the master my 4 cores are 99% steady after this improvement only 2 cores are 59% ~ and the other 2 cores are  9%

## Final Results
And the overall benchmark results, where the baseline is the master benchmark results and the new perf is the current status of this branch:
```
benchmark                                            old ns/op      new ns/op      delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     8633314476     23139          -100.00%
Benchmark_Write_MeasurementNameMatches_1000-4        7915678886     6381307112     -19.38%
Benchmark_Write_MeasurementNameNotMatches_100-4      37434          23787          -36.46%
Benchmark_Write_MeasurementNameMatches_100-4         38474          34923          -9.23%
Benchmark_Write_MeasurementNameNotMatches_10-4       22950          24076          +4.91%
Benchmark_Write_MeasurementNameMatches_10-4          23109          25433          +10.06%

benchmark                                            old allocs     new allocs     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     57450          48             -99.92%
Benchmark_Write_MeasurementNameMatches_1000-4        57426          57442          +0.03%
Benchmark_Write_MeasurementNameNotMatches_100-4      49             48             -2.04%
Benchmark_Write_MeasurementNameMatches_100-4         49             49             +0.00%
Benchmark_Write_MeasurementNameNotMatches_10-4       49             49             +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          49             49             +0.00%

benchmark                                            old bytes     new bytes     delta
Benchmark_Write_MeasurementNameNotMatches_1000-4     4264608       3799          -99.91%
Benchmark_Write_MeasurementNameMatches_1000-4        4261568       4262592       +0.02%
Benchmark_Write_MeasurementNameNotMatches_100-4      3889          3800          -2.29%
Benchmark_Write_MeasurementNameMatches_100-4         3889          3889          +0.00%
Benchmark_Write_MeasurementNameNotMatches_10-4       3838          3838          +0.00%
Benchmark_Write_MeasurementNameMatches_10-4          3838          3838          +0.00%
```

## Drawbacks
This benchmark come with one drawback, the creation and deletion of a task will be slower (I have no benchmarks, but we are doing more - we no longer have o(1)  complexity) and the deletion is harder to read thanks to "Change the fork structure - map from dbrp&measurement to edges".

I am open to suggestions on how to improve the delFork method for better readability.
