### PR TITLE
Enable/Disable by glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ format a TICKscript file according to a common standard.
 - [#299](https://github.com/influxdata/kapacitor/issues/299): Changes TICKscript chaining method operators and adds `tickfmt` binary.
 - [#389](https://github.com/influxdata/kapacitor/pull/389): Adds benchmarks to Kapacitor for basic use cases.
 - [#390](https://github.com/influxdata/kapacitor/issues/390): BREAKING: Remove old `.mapReduce` functions.
+- [#381](https://github.com/influxdata/kapacitor/pull/381): Adding enable/disable/delete/reload tasks by glob.
 
 
 ### Bugfixes

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -639,6 +639,16 @@ func enableUsage() {
 	var u = `Usage: kapacitor enable [task name...]
 
 	Enable and start a task running from the live data.
+
+For example:
+
+    You can enable by specific task name.
+
+    $ kapacitor enable cpu_alert
+
+		Or, you can enable by glob:
+
+    $ kapacitor enable *_alert
 `
 	fmt.Fprintln(os.Stderr, u)
 }
@@ -678,6 +688,16 @@ func disableUsage() {
 	var u = `Usage: kapacitor disable [task name...]
 
 	Disable and stop a task running.
+
+For example:
+
+    You can disable by specific task name.
+
+    $ kapacitor disable cpu_alert
+
+		Or, you can disable by glob:
+
+    $ kapacitor disable *_alert
 `
 	fmt.Fprintln(os.Stderr, u)
 }
@@ -717,6 +737,16 @@ func reloadUsage() {
 	var u = `Usage: kapacitor reload [task name...]
 
 	Disable then enable a running task.
+
+For example:
+
+    You can reload by specific task name.
+
+    $ kapacitor reload cpu_alert
+
+		Or, you can reload by glob:
+
+    $ kapacitor reload *_alert
 `
 	fmt.Fprintln(os.Stderr, u)
 }
@@ -874,7 +904,20 @@ func deleteUsage() {
 
 	Delete a task or recording.
 
-	If a task is enabled it will be disabled and then deleted.
+	If a task is enabled it will be disabled and then deleted,
+For example:
+
+		You can delete task:
+
+    $ kapacitor delete tasks my_task
+
+		Or you can delete tasks by glob:
+
+    $ kapacitor delete tasks *_alert 
+
+		You can delete recordings:
+
+    $ kapacitor delete recordings b0a2ba8a-aeeb-45ec-bef9-1a2939963586 
 `
 	fmt.Fprintln(os.Stderr, u)
 }


### PR DESCRIPTION
Issue - #337 

- Add FindTasks method for fetching all rawTask[] by a predicate
- Enabling/Disabling by glob

For example:
`> kapacitor enable "window_*"` 
Will enable all tasks that starts with "window_"
The same for disable

**Notes:**
- I think this would be nice for delete as well
- The enable is not efficient as possible - I am accessing boltdb for each task, I can change it, but I think it will hurt the readability
- If at least one task is failed to enable/disable I am stopping and returning an error - are we ok about this behaviour? 