### PR TITLE
No defer in inc perf

### DIFF
--- a/edge.go
+++ b/edge.go
@@ -190,9 +190,9 @@ func (e *Edge) CollectBatch(b models.Batch) error {
 // Increment the emitted count of the group for this edge.
 func (e *Edge) incEmitted(group models.GroupID, tags models.Tags, dims []string) {
 	e.groupMu.Lock()
-	defer e.groupMu.Unlock()
 	if stats, ok := e.groupStats[group]; ok {
-		stats.emitted += 1
+		stats.emitted++
+		e.groupMu.Unlock()
 	} else {
 		stats = &edgeStat{
 			emitted: 1,
@@ -200,15 +200,16 @@ func (e *Edge) incEmitted(group models.GroupID, tags models.Tags, dims []string)
 			dims:    dims,
 		}
 		e.groupStats[group] = stats
+		e.groupMu.Unlock()
 	}
 }
 
 // Increment the collected count of the group for this edge.
 func (e *Edge) incCollected(group models.GroupID, tags models.Tags, dims []string) {
 	e.groupMu.Lock()
-	defer e.groupMu.Unlock()
 	if stats, ok := e.groupStats[group]; ok {
-		stats.collected += 1
+		stats.collected++
+		e.groupMu.Unlock()
 	} else {
 		stats = &edgeStat{
 			collected: 1,
@@ -216,5 +217,6 @@ func (e *Edge) incCollected(group models.GroupID, tags models.Tags, dims []strin
 			dims:      dims,
 		}
 		e.groupStats[group] = stats
+		e.groupMu.Unlock()
 	}
 }

--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -265,7 +265,7 @@ func (r *Service) handleRecord(w http.ResponseWriter, req *http.Request) {
 		}
 
 		doF = func() error {
-			err := r.doRecordStream(rid, dur, t.DBRPs, started)
+			err := r.doRecordStream(rid, dur, t.DBRPs, t.Measurements(), started)
 			if err != nil {
 				close(started)
 			}
@@ -606,9 +606,8 @@ func (s streamWriter) Close() error {
 }
 
 // Record the stream for a duration
-func (r *Service) doRecordStream(rid uuid.UUID, dur time.Duration, dbrps []kapacitor.DBRP, started chan struct{}) error {
-	// TODO(yosi): Fix this!
-	e, err := r.TaskMaster.NewFork(rid.String(), dbrps, make([]string, 0))
+func (r *Service) doRecordStream(rid uuid.UUID, dur time.Duration, dbrps []kapacitor.DBRP, measurements []string, started chan struct{}) error {
+	e, err := r.TaskMaster.NewFork(rid.String(), dbrps, measurements)
 	if err != nil {
 		return err
 	}

--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -46,7 +46,7 @@ type Service struct {
 		NewNamedClient(name string) (client.Client, error)
 	}
 	TaskMaster interface {
-		NewFork(name string, dbrps []kapacitor.DBRP) (*kapacitor.Edge, error)
+		NewFork(name string, dbrps []kapacitor.DBRP, measurements []string) (*kapacitor.Edge, error)
 		DelFork(name string)
 		New() *kapacitor.TaskMaster
 		Stream(name string) (kapacitor.StreamCollector, error)
@@ -607,7 +607,8 @@ func (s streamWriter) Close() error {
 
 // Record the stream for a duration
 func (r *Service) doRecordStream(rid uuid.UUID, dur time.Duration, dbrps []kapacitor.DBRP, started chan struct{}) error {
-	e, err := r.TaskMaster.NewFork(rid.String(), dbrps)
+	// TODO(yosi): Fix this!
+	e, err := r.TaskMaster.NewFork(rid.String(), dbrps, make([]string, 0))
 	if err != nil {
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -44,6 +44,14 @@ func CreateDBRPMap(dbrps []DBRP) map[DBRP]bool {
 	return dbMap
 }
 
+func CreateMeasurementsMap(measurements []string) map[string]bool {
+	measurementsMap := make(map[string]bool, len(measurements))
+	for _, measurement := range measurements {
+		measurementsMap[measurement] = true
+	}
+	return measurementsMap
+}
+
 func (d DBRP) String() string {
 	return fmt.Sprintf("%q.%q", d.Database, d.RetentionPolicy)
 }

--- a/task.go
+++ b/task.go
@@ -44,14 +44,6 @@ func CreateDBRPMap(dbrps []DBRP) map[DBRP]bool {
 	return dbMap
 }
 
-func CreateMeasurementsMap(measurements []string) map[string]bool {
-	measurementsMap := make(map[string]bool, len(measurements))
-	for _, measurement := range measurements {
-		measurementsMap[measurement] = true
-	}
-	return measurementsMap
-}
-
 func (d DBRP) String() string {
 	return fmt.Sprintf("%q.%q", d.Database, d.RetentionPolicy)
 }

--- a/task.go
+++ b/task.go
@@ -61,6 +61,21 @@ func (t *Task) Dot() []byte {
 	return t.Pipeline.Dot(t.Name)
 }
 
+// returns all the measurements from a StreamNode
+func (t *Task) Measurements() []string {
+	measurements := make([]string, 0)
+
+	t.Pipeline.Walk(func(node pipeline.Node) error {
+		switch streamNode := node.(type) {
+		case *pipeline.StreamNode:
+			measurements = append(measurements, streamNode.Measurement)
+		}
+		return nil
+	})
+
+	return measurements
+}
+
 // ----------------------------------
 // ExecutingTask
 

--- a/task_master.go
+++ b/task_master.go
@@ -428,13 +428,27 @@ func (tm *TaskMaster) forkPoint(p models.Point) {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
 
+	// Create the fork keys - which is (db, rp, measurement)
 	key := forkKey{
 		Database:        p.Database,
 		RetentionPolicy: p.RetentionPolicy,
 		Measurement:     p.Name,
 	}
 
+	// If we have empty measurement in this db,rp we need to send it all
+	// the points
+	emptyMeasurementKey := forkKey{
+		Database:        p.Database,
+		RetentionPolicy: p.RetentionPolicy,
+		Measurement:     "",
+	}
+
+	// Merge the results to the forks map
 	for _, edge := range tm.forks[key] {
+		edge.CollectPoint(p)
+	}
+
+	for _, edge := range tm.forks[emptyMeasurementKey] {
 		edge.CollectPoint(p)
 	}
 }


### PR DESCRIPTION
After a bit profiling I see that incEmitted and incCollected is still hot, I saw that defer takes most of the time, after reading a bit it looks that defer has a bit of overhead and in small functions/hot code isn't recommended (should be checked in benchmark before checking, this is not a rule)

```
benchmark                              old ns/op        new ns/op        delta
Benchmark_T1000_P5000_Matches-4        10894368013      9009168906       -17.30%
Benchmark_T1000_P5000_NoMatches-4      11772957621      31820886         -99.73%
Benchmark_T100_P5000_Matches-4         1149160968       684346858        -40.45%
Benchmark_T100_P5000_NoMatches-4       1193448589       25386986         -97.87%
Benchmark_T10_P5000_Matches-4          189739122        127694632        -32.70%
Benchmark_T10_P5000_NoMatches-4        155396278        23437142         -84.92%
Benchmark_T10_P500_CountTask-4         20287106         18338299         -9.61%
Benchmark_T10_P50000_CountTask-4       1832485835       1721740236       -6.04%
Benchmark_T1000_P500-4                 2034353343       1993059158       -2.03%
Benchmark_T1000_P50000_CountTask-4     197003231081     202667675345     +2.88%

benchmark                              old allocs     new allocs     delta
Benchmark_T1000_P5000_Matches-4        69144          69126          -0.03%
Benchmark_T1000_P5000_NoMatches-4      69146          65069          -5.90%
Benchmark_T100_P5000_Matches-4         56523          56502          -0.04%
Benchmark_T100_P5000_NoMatches-4       56548          56075          -0.84%
Benchmark_T10_P5000_Matches-4          55226          55212          -0.03%
Benchmark_T10_P5000_NoMatches-4        55219          55165          -0.10%
Benchmark_T10_P500_CountTask-4         10940          10936          -0.04%
Benchmark_T10_P50000_CountTask-4       1154692        1154676        -0.00%
Benchmark_T1000_P500-4                 542557         543978         +0.26%
Benchmark_T1000_P50000_CountTask-4     61019034       61027137       +0.01%

benchmark                              old bytes      new bytes      delta
Benchmark_T1000_P5000_Matches-4        4477632        4474896        -0.06%
Benchmark_T1000_P5000_NoMatches-4      4476112        3959169        -11.55%
Benchmark_T100_P5000_Matches-4         3668616        3667368        -0.03%
Benchmark_T100_P5000_NoMatches-4       3671944        3614036        -1.58%
Benchmark_T10_P5000_Matches-4          3585190        3584450        -0.02%
Benchmark_T10_P5000_NoMatches-4        3584604        3578712        -0.16%
Benchmark_T10_P500_CountTask-4         1624756        1624493        -0.02%
Benchmark_T10_P50000_CountTask-4       114281120      114280304      -0.00%
Benchmark_T1000_P500-4                 128125336      128215768      +0.07%
Benchmark_T1000_P50000_CountTask-4     7625275048     7625790528     +0.01%
```
_Diff between master and this branch, defaultEdgeBufferSize = 0_