### PR TITLE
Removing defer in hot code - incCollected and incEmitted

### DIFF
--- a/edge.go
+++ b/edge.go
@@ -189,10 +189,13 @@ func (e *Edge) CollectBatch(b models.Batch) error {
 
 // Increment the emitted count of the group for this edge.
 func (e *Edge) incEmitted(group models.GroupID, tags models.Tags, dims []string) {
+	// we are "manually" calling Unlock() and not using defer, becasue this method is called
+	// in hot locations (NextPoint/CollectPoint) and defer have some performance penatly
 	e.groupMu.Lock()
-	defer e.groupMu.Unlock()
+
 	if stats, ok := e.groupStats[group]; ok {
-		stats.emitted += 1
+		stats.emitted++
+		e.groupMu.Unlock()
 	} else {
 		stats = &edgeStat{
 			emitted: 1,
@@ -200,15 +203,19 @@ func (e *Edge) incEmitted(group models.GroupID, tags models.Tags, dims []string)
 			dims:    dims,
 		}
 		e.groupStats[group] = stats
+		e.groupMu.Unlock()
 	}
 }
 
 // Increment the collected count of the group for this edge.
 func (e *Edge) incCollected(group models.GroupID, tags models.Tags, dims []string) {
+	// we are "manually" calling Unlock() and not using defer, becasue this method is called
+	// in hot locations (NextPoint/CollectPoint) and defer have some performance penatly
 	e.groupMu.Lock()
-	defer e.groupMu.Unlock()
+
 	if stats, ok := e.groupStats[group]; ok {
-		stats.collected += 1
+		stats.collected++
+		e.groupMu.Unlock()
 	} else {
 		stats = &edgeStat{
 			collected: 1,
@@ -216,5 +223,6 @@ func (e *Edge) incCollected(group models.GroupID, tags models.Tags, dims []strin
 			dims:      dims,
 		}
 		e.groupStats[group] = stats
+		e.groupMu.Unlock()
 	}
 }


### PR DESCRIPTION
After a bit profiling I see that incEmitted and incCollected is still hot, I saw that defer takes most of the time, after reading a bit it looks that defer has a bit of overhead and in small functions/hot code isn't recommended (should be checked in benchmark before checking, this is not a rule)

Reference: http://lk4d4.darth.io/posts/defer/

Diff between master and this branch with defaultEdgeBufferSize = 0:
```
benchmark                              old ns/op        new ns/op        delta
Benchmark_T1000_P5000_Matches-4        10894368013      10491354400      -3.70%
Benchmark_T1000_P5000_NoMatches-4      11772957621      13642020015      +15.88%
Benchmark_T100_P5000_Matches-4         1149160968       773756805        -32.67%
Benchmark_T100_P5000_NoMatches-4       1193448589       805973738        -32.47%
Benchmark_T10_P5000_Matches-4          189739122        152311075        -19.73%
Benchmark_T10_P5000_NoMatches-4        155396278        169503289        +9.08%
Benchmark_T10_P500_CountTask-4         20287106         19785667         -2.47%
Benchmark_T10_P50000_CountTask-4       1832485835       1939993342       +5.87%
Benchmark_T1000_P500-4                 2034353343       1965323760       -3.39%
Benchmark_T1000_P50000_CountTask-4     197003231081     200399565739     +1.72%

benchmark                              old allocs     new allocs     delta
Benchmark_T1000_P5000_Matches-4        69144          69130          -0.02%
Benchmark_T1000_P5000_NoMatches-4      69146          69132          -0.02%
Benchmark_T100_P5000_Matches-4         56523          56490          -0.06%
Benchmark_T100_P5000_NoMatches-4       56548          56496          -0.09%
Benchmark_T10_P5000_Matches-4          55226          55211          -0.03%
Benchmark_T10_P5000_NoMatches-4        55219          55212          -0.01%
Benchmark_T10_P500_CountTask-4         10940          10940          +0.00%
Benchmark_T10_P50000_CountTask-4       1154692        1154689        -0.00%
Benchmark_T1000_P500-4                 542557         542934         +0.07%
Benchmark_T1000_P50000_CountTask-4     61019034       61024719       +0.01%

benchmark                              old bytes      new bytes      delta
Benchmark_T1000_P5000_Matches-4        4477632        4475088        -0.06%
Benchmark_T1000_P5000_NoMatches-4      4476112        4476880        +0.02%
Benchmark_T100_P5000_Matches-4         3668616        3666392        -0.06%
Benchmark_T100_P5000_NoMatches-4       3671944        3666944        -0.14%
Benchmark_T10_P5000_Matches-4          3585190        3584180        -0.03%
Benchmark_T10_P5000_NoMatches-4        3584604        3584320        -0.01%
Benchmark_T10_P500_CountTask-4         1624756        1624821        +0.00%
Benchmark_T10_P50000_CountTask-4       114281120      114279504      -0.00%
Benchmark_T1000_P500-4                 128125336      128148064      +0.02%
Benchmark_T1000_P50000_CountTask-4     7625275048     7625637432     +0.00%
```