### PR TITLE
Buffer pooling in alert templates

### DIFF
--- a/integrations/benchmark_test.go
+++ b/integrations/benchmark_test.go
@@ -41,6 +41,16 @@ const (
 	|count('value')
 	|log()
 `
+
+	alertM1Task = `stream
+	|from()
+		.measurement('m1')
+	|alert()
+	 .id('{{ .Name }}_{{ .TaskName }}')
+		.info(lambda: "value" > 10)
+		.warn(lambda: "value" > 20)
+		.crit(lambda: "value" > 30)
+`
 )
 
 //----------------------------
@@ -91,6 +101,24 @@ func Benchmark_T1000_P500(b *testing.B) {
 // Many tasks, many points
 func Benchmark_T1000_P50000_CountTask(b *testing.B) {
 	Bench(b, 1000, 50000, "dbname", "rpname", "m1", countM1Task)
+}
+
+//----------------------------
+// Alert Task Benchmarks
+
+// Few tasks, few points
+func Benchmark_T10_P500_AlertTask(b *testing.B) {
+	Bench(b, 10, 500, "dbname", "rpname", "m1", alertM1Task)
+}
+
+// Few tasks, many points
+func Benchmark_T10_P50000_AlertTask(b *testing.B) {
+	Bench(b, 10, 50000, "dbname", "rpname", "m1", alertM1Task)
+}
+
+// Many tasks, few points
+func Benchmark_T1000_P500_AlertTask(b *testing.B) {
+	Bench(b, 1000, 500, "dbname", "rpname", "m1", alertM1Task)
 }
 
 // Generic Benchmark method


### PR DESCRIPTION
Hi,

I added benchmarks for alert node and found a quick performance boost,
After memory profiling, I found that we are allocating new buffer for the templates of id,message and details, so I wrapped this in a buffer pool, and got a performance improvement:

```
benchmark                            old ns/op       new ns/op       delta
Benchmark_T10_P500_AlertTask-4       210263431       159024737       -24.37%
Benchmark_T10_P50000_AlertTask-4     18718435131     15589249575     -16.72%
Benchmark_T1000_P500_AlertTask-4     21833771619     20820186700     -4.64%

benchmark                            old allocs     new allocs     delta
Benchmark_T10_P500_AlertTask-4       490648         467352         -4.75%
Benchmark_T10_P50000_AlertTask-4     50044467       47560324       -4.96%
Benchmark_T1000_P500_AlertTask-4     48492207       46626729       -3.85%

benchmark                            old bytes      new bytes      delta
Benchmark_T10_P500_AlertTask-4       36155296       33162568       -8.28%
Benchmark_T10_P50000_AlertTask-4     3686308856     3347320896     -9.20%
Benchmark_T1000_P500_AlertTask-4     3604462496     3463221064     -3.92%
```
_Compared to master_