### PR TITLE
Update BatchNode to allow double GroupBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ format a TICKscript file according to a common standard.
 - [#387](https://github.com/influxdata/kapacitor/issues/387): Add `.quiet()` option to EvalNode so errors can be suppressed if expected.
 - [#400](https://github.com/influxdata/kapacitor/issues/400): All query/connection errors are counted and reported in BatchNode stats.
 - [#412](https://github.com/influxdata/kapacitor/pull/412): Fix issues with batch queries dropping points because of nil fields.
+- [#413](https://github.com/influxdata/kapacitor/pull/413): Allow disambiguation between ".groupBy" and "|groupBy".
 
 
 ## v0.11.0 [2016-03-22]

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1,8 +1,6 @@
 package pipeline
 
-import (
-	"github.com/influxdata/kapacitor/tick"
-)
+import "github.com/influxdata/kapacitor/tick"
 
 // Number of previous states to remember when computing flapping percentage.
 const defaultFlapHistory = 21

--- a/pipeline/batch.go
+++ b/pipeline/batch.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"bytes"
 	"time"
+
+	"github.com/influxdata/kapacitor/tick"
 )
 
 // A node that handles creating several child BatchNodes.
@@ -72,6 +74,9 @@ func (b *SourceBatchNode) dot(buf *bytes.Buffer) {
 type BatchNode struct {
 	chainnode
 
+	// self describer
+	describer *tick.ReflectionDescriber
+
 	// The query text
 	//tick:ignore
 	QueryStr string
@@ -125,9 +130,11 @@ type BatchNode struct {
 }
 
 func newBatchNode() *BatchNode {
-	return &BatchNode{
+	b := &BatchNode{
 		chainnode: newBasicChainNode("batch", BatchEdge, BatchEdge),
 	}
+	b.describer, _ = tick.NewReflectionDescriber(b)
+	return b
 }
 
 // Group the data by a set of dimensions.
@@ -154,4 +161,42 @@ func (b *BatchNode) GroupBy(d ...interface{}) *BatchNode {
 func (b *BatchNode) Align() *BatchNode {
 	b.AlignFlag = true
 	return b
+}
+
+// Tick Describer methods
+
+//tick:ignore
+func (b *BatchNode) Desc() string {
+	return b.describer.Desc()
+}
+
+//tick:ignore
+func (b *BatchNode) HasChainMethod(name string) bool {
+	if name == "groupBy" {
+		return true
+	}
+	return b.describer.HasChainMethod(name)
+}
+
+//tick:ignore
+func (b *BatchNode) CallChainMethod(name string, args ...interface{}) (interface{}, error) {
+	if name == "groupBy" {
+		return b.chainnode.GroupBy(args...), nil
+	}
+	return b.describer.CallChainMethod(name, args...)
+}
+
+//tick:ignore
+func (b *BatchNode) HasProperty(name string) bool {
+	return b.describer.HasProperty(name)
+}
+
+//tick:ignore
+func (b *BatchNode) Property(name string) interface{} {
+	return b.describer.Property(name)
+}
+
+//tick:ignore
+func (b *BatchNode) SetProperty(name string, args ...interface{}) (interface{}, error) {
+	return b.describer.SetProperty(name, args...)
 }


### PR DESCRIPTION
Now with the new syntax and special cases this is now a valid TICKscript.

```javascript
batch
	|query('''
		SELECT mean("value")
		FROM "telegraf"."default".cpu_usage_idle
		WHERE "host" = 'serverA' AND "cpu" != 'cpu-total'
''')
		.period(10s)
		.every(10s)
		.groupBy(time(2s), 'cpu')
	|groupBy()
	|max('mean')
	|httpOut('TestBatch_SimpleMR')
```
