### PR TITLE
fix panic if as() is inconsistent with join()

### DIFF
--- a/join.go
+++ b/join.go
@@ -3,7 +3,6 @@ package kapacitor
 import (
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"time"
 
@@ -35,22 +34,6 @@ type JoinNode struct {
 
 // Create a new JoinNode, which takes pairs from parent streams combines them into a single point.
 func newJoinNode(et *ExecutingTask, n *pipeline.JoinNode, l *log.Logger) (*JoinNode, error) {
-	for _, name := range n.Names {
-		if len(name) == 0 {
-			return nil, fmt.Errorf("must provide a prefix name for the join node, see .as() property method")
-		}
-		if strings.ContainsRune(name, '.') {
-			return nil, fmt.Errorf("cannot use name %s as field prefix, it contains a '.' character", name)
-		}
-	}
-	names := make(map[string]bool, len(n.Names))
-	for _, name := range n.Names {
-		if names[name] {
-			return nil, fmt.Errorf("cannot use the same prefix name see .as() property method")
-		}
-		names[name] = true
-	}
-
 	jn := &JoinNode{
 		j:                    n,
 		node:                 node{Node: n, et: et, logger: l},
@@ -80,6 +63,7 @@ func newJoinNode(et *ExecutingTask, n *pipeline.JoinNode, l *log.Logger) (*JoinN
 }
 
 func (j *JoinNode) runJoin([]byte) error {
+
 	j.groups = make(map[models.GroupID]*group)
 
 	groupErrs := make(chan error, 1)

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -61,6 +61,9 @@ type Node interface {
 	// The type of output the node provides.
 	Provides() EdgeType
 
+	// Check that the definition of the node is consistent
+	validate() error
+
 	// Helper methods for walking DAG
 	tMark() bool
 	setTMark(b bool)
@@ -165,6 +168,10 @@ func (n *node) Wants() EdgeType {
 // tick:ignore
 func (n *node) Provides() EdgeType {
 	return n.provides
+}
+
+func (n *node) validate() error {
+	return nil
 }
 
 func (n *node) dot(buf *bytes.Buffer) {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -60,6 +60,12 @@ func CreatePipeline(script string, sourceEdge EdgeType, scope *tick.Scope, deadm
 			return nil, fmt.Errorf("source edge type must be either Stream or Batch not %s", sourceEdge)
 		}
 	}
+	if err = p.Walk(
+		func(n Node) error {
+			return n.validate()
+		}); err != nil {
+		return nil, err
+	}
 	return p, nil
 }
 


### PR DESCRIPTION
Previously, if the arguments passed to as() were not consistent with
the number of arms of a join() node, an index out of range panic
would occur at runtime.

Now, we fail during definition of the tick script if the number of
arguments to the as() method is inconsistent or if the as() method was omitted completely.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>