### PR TITLE
Add a validate phase that allows more validation at definition time

### DIFF
--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -61,6 +61,9 @@ type Node interface {
 	// The type of output the node provides.
 	Provides() EdgeType
 
+	// Check that the definition of the node is consistent
+	validate() error
+
 	// Helper methods for walking DAG
 	tMark() bool
 	setTMark(b bool)
@@ -165,6 +168,10 @@ func (n *node) Wants() EdgeType {
 // tick:ignore
 func (n *node) Provides() EdgeType {
 	return n.provides
+}
+
+func (n *node) validate() error {
+	return nil
 }
 
 func (n *node) dot(buf *bytes.Buffer) {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -60,6 +60,12 @@ func CreatePipeline(script string, sourceEdge EdgeType, scope *tick.Scope, deadm
 			return nil, fmt.Errorf("source edge type must be either Stream or Batch not %s", sourceEdge)
 		}
 	}
+	if err = p.Walk(
+		func(n Node) error {
+			return n.validate()
+		}); err != nil {
+		return nil, err
+	}
 	return p, nil
 }
 


### PR DESCRIPTION
With this change, more validation can be pushed from runtime to definition time.

See the current implementation of #431 for an example of how it is used.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>