### PR TITLE
Add support for a paste operator in join.as() prefix specifications.

### DIFF
--- a/join.go
+++ b/join.go
@@ -467,11 +467,11 @@ func (js *joinset) JoinIntoPoint() (models.Point, bool) {
 			switch js.fill {
 			case influxql.NullFill:
 				for k := range js.First().PointFields() {
-					fields[js.prefixes[i]+"."+k] = nil
+					fields[js.outName(i, k)] = nil
 				}
 			case influxql.NumberFill:
 				for k := range js.First().PointFields() {
-					fields[js.prefixes[i]+"."+k] = js.fillValue
+					fields[js.outName(i, k)] = js.fillValue
 				}
 			default:
 				// inner join no valid point possible
@@ -479,7 +479,7 @@ func (js *joinset) JoinIntoPoint() (models.Point, bool) {
 			}
 		} else {
 			for k, v := range p.PointFields() {
-				fields[js.prefixes[i]+"."+k] = v
+				fields[js.outName(i, k)] = v
 			}
 		}
 	}
@@ -554,11 +554,11 @@ func (js *joinset) JoinIntoBatch() (models.Batch, bool) {
 				switch js.fill {
 				case influxql.NullFill:
 					for _, k := range fieldNames {
-						fields[js.prefixes[i]+"."+k] = nil
+						fields[js.outName(i, k)] = nil
 					}
 				case influxql.NumberFill:
 					for _, k := range fieldNames {
-						fields[js.prefixes[i]+"."+k] = js.fillValue
+						fields[js.outName(i, k)] = js.fillValue
 					}
 				default:
 					// inner join no valid point possible
@@ -566,7 +566,7 @@ func (js *joinset) JoinIntoBatch() (models.Batch, bool) {
 				}
 			} else {
 				for k, v := range bp.Fields {
-					fields[js.prefixes[i]+"."+k] = v
+					fields[js.outName(i, k)] = v
 				}
 			}
 		}
@@ -578,6 +578,10 @@ func (js *joinset) JoinIntoBatch() (models.Batch, bool) {
 		newBatch.Points = append(newBatch.Points, bp)
 	}
 	return newBatch, true
+}
+
+func (js *joinset) outName(i int, k string) string {
+	return js.prefixes[i] + "." + k
 }
 
 type durationVar struct {

--- a/join.go
+++ b/join.go
@@ -364,7 +364,15 @@ func (g *group) emitAll() error {
 }
 
 // emit a single joined set
-func (g *group) emitJoinedSet(set *joinset) error {
+func (g *group) emitJoinedSet(set *joinset) (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			var ok bool
+			if err, ok = p.(error); !ok {
+				panic(p)
+			}
+		}
+	}()
 	if set.name == "" {
 		set.name = set.First().PointName()
 	}

--- a/pipeline/join.go
+++ b/pipeline/join.go
@@ -137,25 +137,17 @@ func (j *JoinNode) validate() error {
 		return fmt.Errorf("a call to join.as() is required to specify the output stream prefixes.")
 	}
 
-	if len(j.Names) != len(j.Parents()) {
+	if len(j.Names) > len(j.Parents()) {
 		return fmt.Errorf("number of prefixes specified by join.as() must match the number of joined streams")
+	} else if len(j.Names) < len(j.Parents()) {
+		tmp := make([]string, len(j.Parents()))
+		copy(tmp, j.Names)
+		j.Names = tmp
 	}
-
 	for _, name := range j.Names {
-		if len(name) == 0 {
-			return fmt.Errorf("must provide a prefix name for the join node, see .as() property method")
-		}
 		if strings.ContainsRune(name, '.') {
 			return fmt.Errorf("cannot use name %s as field prefix, it contains a '.' character", name)
 		}
 	}
-	names := make(map[string]bool, len(j.Names))
-	for _, name := range j.Names {
-		if names[name] {
-			return fmt.Errorf("cannot use the same prefix name see .as() property method")
-		}
-		names[name] = true
-	}
-
 	return nil
 }


### PR DESCRIPTION
Per the discussion in #435, the join.as() method now:

- is optional, if the field names of all input streams are unique
- supports the use of a trailing '#' paste operator in prefix specifications.
- supports duplicate prefixes, provided that the resulting field names are unique

An output column derived from field k of input stream i is now named as follows:

```
if the ith prefix is empty or not specified:
    k
if the ith prefix contains a trailing '#'
   prefix[i][0:len(len(prefix[i])-1]+k
otherwise
  prefix[i]+"."+k
```
An error is detected at runtime if the output of a join node constructed using these rules would result in points with duplicate field names.

All existing, valid Tick scripts should operate per the current behaviour. Some Tick scripts that were invalid are now valid.