### PR TITLE
[WIP] add support for recording tags to kapacitor

### DIFF
--- a/client/v1/client_test.go
+++ b/client/v1/client_test.go
@@ -67,21 +67,21 @@ func Test_ReportsErrors(t *testing.T) {
 		{
 			name: "RecordStream",
 			fnc: func(c *client.Client) error {
-				_, err := c.RecordStream("", 0)
+				_, err := c.RecordStream("", 0, "")
 				return err
 			},
 		},
 		{
 			name: "RecordBatch",
 			fnc: func(c *client.Client) error {
-				_, err := c.RecordBatch("", "", time.Time{}, time.Time{}, 0)
+				_, err := c.RecordBatch("", "", time.Time{}, time.Time{}, 0, "")
 				return err
 			},
 		},
 		{
 			name: "RecordQuery",
 			fnc: func(c *client.Client) error {
-				_, err := c.RecordQuery("", "", "")
+				_, err := c.RecordQuery("", "", "", "")
 				return err
 			},
 		},
@@ -456,7 +456,7 @@ func Test_Record(t *testing.T) {
 		{
 			name: "RecordStream",
 			fnc: func(c *client.Client) (string, error) {
-				return c.RecordStream("taskname", time.Minute)
+				return c.RecordStream("taskname", time.Minute, "")
 			},
 			checkRequest: func(r *http.Request) bool {
 				return r.URL.Query().Get("type") == "stream" &&
@@ -473,6 +473,7 @@ func Test_Record(t *testing.T) {
 					time.Date(2016, 3, 31, 10, 24, 55, 526388889, time.UTC),
 					time.Date(2016, 3, 31, 11, 24, 55, 526388889, time.UTC),
 					time.Hour*5,
+					"",
 				)
 			},
 			checkRequest: func(r *http.Request) bool {
@@ -487,7 +488,7 @@ func Test_Record(t *testing.T) {
 		{
 			name: "RecordQuery",
 			fnc: func(c *client.Client) (string, error) {
-				return c.RecordQuery("queryStr", "stream", "cluster")
+				return c.RecordQuery("queryStr", "stream", "cluster", "")
 			},
 			checkRequest: func(r *http.Request) bool {
 				return r.URL.Query().Get("type") == "query" &&

--- a/cmd/kapacitord/run/config.go
+++ b/cmd/kapacitord/run/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/influxdata/kapacitor/services/slack"
 	"github.com/influxdata/kapacitor/services/smtp"
 	"github.com/influxdata/kapacitor/services/stats"
+	"github.com/influxdata/kapacitor/services/tag_store"
 	"github.com/influxdata/kapacitor/services/talk"
 	"github.com/influxdata/kapacitor/services/task_store"
 	"github.com/influxdata/kapacitor/services/udf"
@@ -40,6 +41,7 @@ import (
 type Config struct {
 	HTTP     httpd.Config      `toml:"http"`
 	Replay   replay.Config     `toml:"replay"`
+	Tag      tag_store.Config  `toml:"tag"`
 	Task     task_store.Config `toml:"task"`
 	InfluxDB []influxdb.Config `toml:"influxdb"`
 	Logging  logging.Config    `toml:"logging"`
@@ -78,6 +80,7 @@ func NewConfig() *Config {
 	c.HTTP = httpd.NewConfig()
 	c.Replay = replay.NewConfig()
 	c.Task = task_store.NewConfig()
+	c.Tag = tag_store.NewConfig()
 	c.Logging = logging.NewConfig()
 
 	c.Collectd = collectd.NewConfig()
@@ -132,6 +135,7 @@ func NewDemoConfig() (*Config, error) {
 
 	c.Replay.Dir = filepath.Join(homeDir, ".kapacitor", c.Replay.Dir)
 	c.Task.Dir = filepath.Join(homeDir, ".kapacitor", c.Task.Dir)
+	c.Tag.Dir = filepath.Join(homeDir, ".kapacitor", c.Tag.Dir)
 	c.DataDir = filepath.Join(homeDir, ".kapacitor", c.DataDir)
 
 	return c, nil
@@ -150,6 +154,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 	err = c.Task.Validate()
+	if err != nil {
+		return err
+	}
+	err = c.Tag.Validate()
 	if err != nil {
 		return err
 	}

--- a/cmd/kapacitord/run/server_helper_test.go
+++ b/cmd/kapacitord/run/server_helper_test.go
@@ -157,6 +157,7 @@ func NewConfig() *run.Config {
 	c.Reporting.Enabled = false
 	c.Replay.Dir = MustTempFile()
 	c.Task.Dir = MustTempFile()
+	c.Tag.Dir = MustTempFile()
 	c.DataDir = MustTempFile()
 	c.HTTP.BindAddress = "127.0.0.1:0"
 	c.InfluxDB[0].Enabled = false

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -626,7 +626,7 @@ test value=1 0000000012
 	rid := make(chan string, 1)
 	started := make(chan struct{})
 	go func() {
-		id, err := cli.RecordStream(name, 10*time.Second)
+		id, err := cli.RecordStream(name, 10*time.Second, "")
 		close(started)
 		_, err = cli.Recording(id)
 		if err != nil {
@@ -747,7 +747,7 @@ func TestServer_RecordReplayBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id, err := cli.RecordBatch(name, "", time.Time{}, time.Time{}, time.Second*8)
+	id, err := cli.RecordBatch(name, "", time.Time{}, time.Time{}, time.Second*8, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/tag_store/config.go
+++ b/services/tag_store/config.go
@@ -1,0 +1,22 @@
+package tag_store
+
+import (
+	"fmt"
+)
+
+type Config struct {
+	Dir string `toml:"dir"`
+}
+
+func NewConfig() Config {
+	return Config{
+		Dir: "./tags",
+	}
+}
+
+func (c Config) Validate() error {
+	if c.Dir == "" {
+		return fmt.Errorf("must specify tag_store dir")
+	}
+	return nil
+}

--- a/services/tag_store/service.go
+++ b/services/tag_store/service.go
@@ -1,0 +1,352 @@
+package tag_store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"regexp"
+
+	"github.com/boltdb/bolt"
+	"github.com/influxdata/kapacitor/services/httpd"
+)
+
+const tagDB = "tag.db"
+
+var (
+	tagsBucket       = []byte("tags")
+	recordingsBucket = []byte("recordings")
+)
+
+type Tag struct {
+	Tag string `json:"tag"`
+	ID  string `json:"id"`
+}
+
+type Service struct {
+	dbpath       string
+	db           *bolt.DB
+	routes       []httpd.Route
+	HTTPDService interface {
+		AddRoutes([]httpd.Route) error
+		DelRoutes([]httpd.Route)
+	}
+	logger *log.Logger
+}
+
+func NewService(conf Config, l *log.Logger) *Service {
+	return &Service{
+		dbpath: path.Join(conf.Dir, tagDB),
+		logger: l,
+	}
+}
+
+func (ts *Service) Open() (err error) {
+	defer func() {
+		if err != nil && ts.db != nil {
+			ts.db.Close()
+			ts.db = nil
+		}
+	}()
+
+	err = os.MkdirAll(path.Dir(ts.dbpath), 0755)
+	if err != nil {
+		return err
+	}
+
+	// Open db
+	db, err := bolt.Open(ts.dbpath, 0600, nil)
+	if err != nil {
+		return err
+	}
+	ts.db = db
+
+	if err := ts.db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(recordingsBucket); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(tagsBucket); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Define API routes
+	ts.routes = []httpd.Route{
+		{
+			Name:        "tag-list",
+			Method:      "GET",
+			Pattern:     "/tags",
+			HandlerFunc: ts.handleTags,
+		},
+		{
+			Name:        "tag-save",
+			Method:      "POST",
+			Pattern:     "/tag",
+			HandlerFunc: ts.handleCreate,
+		},
+		{
+			Name:        "tag-delete",
+			Method:      "DELETE",
+			Pattern:     "/tag",
+			HandlerFunc: ts.handleDelete,
+		},
+		{
+			// Satisfy CORS checks.
+			Name:        "tag-options",
+			Method:      "OPTIONS",
+			Pattern:     "/tag",
+			HandlerFunc: httpd.ServeOptions,
+		},
+	}
+	err = ts.HTTPDService.AddRoutes(ts.routes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ts *Service) Close() error {
+	ts.HTTPDService.DelRoutes(ts.routes)
+	if ts.db != nil {
+		return ts.db.Close()
+	}
+	return nil
+}
+
+func (ts *Service) handleDelete(w http.ResponseWriter, r *http.Request) {
+	tag := r.URL.Query().Get("tag")
+
+	err := ts.DeleteTag(tag)
+	if err != nil {
+		ts.logger.Printf("E! delete tags '%s' failed: %v", tag, err)
+		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (ts *Service) handleTags(w http.ResponseWriter, r *http.Request) {
+	tags, err := ts.ListTags()
+	if err != nil {
+		ts.logger.Printf("E! tags failed: %v", err)
+		httpd.HttpError(w, err.Error(), true, http.StatusInternalServerError)
+		return
+	}
+
+	type response struct {
+		Tags []Tag `json:"tags"`
+	}
+
+	w.Write(httpd.MarshalJSON(response{tags}, true))
+}
+
+func (ts *Service) handleCreate(w http.ResponseWriter, r *http.Request) {
+	tag := r.URL.Query().Get("tag")
+	id := r.URL.Query().Get("id")
+
+	err := ts.CreateOrUpdateTag(tag, id)
+	if err != nil {
+		ts.logger.Printf("E! create tag '%s' failed: %v", tag, err)
+		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// 6af4b71c-0fc4-483d-9518-f52f7ba14403
+
+var uuid_pattern = regexp.MustCompile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+var tag_chars = regexp.MustCompile("^[A-Za-z0-9_+.-]+$")
+
+// ErrNotFound is returned if a matching key is not found
+var ErrNotFound = errors.New("not found")
+
+func read(b *bolt.Bucket, k string, o interface{}) error {
+	if bytes := b.Get([]byte(k)); bytes == nil {
+		return ErrNotFound
+	} else {
+		if err := json.Unmarshal(bytes, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func write(b *bolt.Bucket, k string, o interface{}) error {
+	if bytes, err := json.Marshal(o); err != nil {
+		return err
+	} else {
+		return b.Put([]byte(k), bytes)
+	}
+}
+
+func remove(s []string, v string) []string {
+	j := 0
+	for _, e := range s {
+		if e != v {
+			s[j] = v
+			j++
+		}
+	}
+	return s[0:j]
+}
+
+// deletes the association from the implied recording (if any) to the specified tag
+//
+// note that the association from the tag to the recording is left unmodified.
+func (ts *Service) deleteAssociation(tags *bolt.Bucket, recordings *bolt.Bucket, tag string) error {
+	var existing string
+	if err := read(tags, tag, &existing); err == nil {
+		oldAssociation := []string{}
+		if read(recordings, existing, &oldAssociation); err == nil {
+			oldAssociation := remove(oldAssociation, tag)
+			if len(oldAssociation) == 0 {
+				if err := recordings.Delete([]byte(existing)); err != nil {
+					return err
+				}
+			} else {
+				if err := write(recordings, existing, oldAssociation); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Create or update a tag to refer to the specified id.
+func (ts *Service) CreateOrUpdateTag(tag string, tagOrId string) error {
+
+	if err := ts.ValidateTagSyntax(tag); err != nil {
+		return err
+	}
+
+	if resolved, err := ts.ResolveTag(tagOrId); err != nil {
+		return err
+	} else {
+		return ts.db.Update(func(tx *bolt.Tx) error {
+			tags := tx.Bucket(tagsBucket)
+			recordings := tx.Bucket(recordingsBucket)
+
+			// if the tag already exists, then delete the existing
+			// association
+
+			if err := ts.deleteAssociation(tags, recordings, tag); err != nil {
+				return nil
+			}
+
+			newAssociation := []string{}
+			if read(recordings, resolved, &newAssociation); err == nil {
+				// avoid duplicates
+				remove(newAssociation, tag)
+			}
+			newAssociation = append(newAssociation, tag)
+
+			if err := write(recordings, resolved, newAssociation); err != nil {
+				return err
+			}
+			return write(tags, tag, resolved)
+		})
+	}
+}
+
+func (ts *Service) ValidateTagSyntax(tag string) error {
+	if uuid_pattern.MatchString(tag) {
+		return fmt.Errorf("tags may not be of the same form as recording ids")
+	}
+
+	if !tag_chars.MatchString(tag) {
+		return fmt.Errorf("tags may be comprised of the characters A-Z, a-z, 0-9, _, +, - or .")
+	}
+
+	return nil
+}
+
+// Resolve a string containing a tag or id into an id.
+func (ts *Service) ResolveTag(tagOrId string) (string, error) {
+	if uuid_pattern.MatchString(tagOrId) {
+		return tagOrId, nil
+	} else {
+		var id string
+		err := ts.db.View(func(tx *bolt.Tx) error {
+			tags := tx.Bucket(tagsBucket)
+			return read(tags, tagOrId, &id)
+		})
+		if err == nil {
+			return id, nil
+		} else {
+			return tagOrId, err
+		}
+	}
+}
+
+// Delete a tag.
+func (ts *Service) DeleteTag(tag string) error {
+	return ts.db.Update(func(tx *bolt.Tx) error {
+		tags := tx.Bucket(tagsBucket)
+		recordings := tx.Bucket(recordingsBucket)
+
+		// if the tag already exists, then delete the existing
+		// association
+
+		if err := ts.deleteAssociation(tags, recordings, tag); err != nil {
+			return nil
+		}
+		return tags.Delete([]byte(tag))
+	})
+}
+
+// Delete a recording with the specified id and all related tags.
+func (ts *Service) DeleteRecording(rid string) error {
+	return ts.db.Update(func(tx *bolt.Tx) error {
+		tags := tx.Bucket(tagsBucket)
+		recordings := tx.Bucket(recordingsBucket)
+		tagNames := []string{}
+		if err := read(recordings, rid, &tagNames); err != nil {
+			return err
+		}
+		for _, t := range tagNames {
+			if err := tags.Delete([]byte(t)); err != nil {
+				return err
+			}
+		}
+		return recordings.Delete([]byte(rid))
+	})
+}
+
+// List all the defined tags that match the specified pattern.
+func (ts *Service) ListTags() ([]Tag, error) {
+	result := []Tag{}
+	if err := ts.db.View(func(tx *bolt.Tx) error {
+		tags := tx.Bucket(tagsBucket)
+		if err := tags.ForEach(func(k []byte, v []byte) error {
+			result = append(result, Tag{Tag: string(k), ID: string(v)})
+			return nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// List all the tags for the specified recording id.
+func (ts *Service) FindTagsByRecordingId(id string) ([]string, error) {
+	result := []string{}
+	if err := ts.db.View(func(tx *bolt.Tx) error {
+		recordings := tx.Bucket(recordingsBucket)
+		return read(recordings, id, &result)
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}


### PR DESCRIPTION
This PR is a work in progress. It is being published now to allow feedback to be gathered as I am working on it. Expect many re-rolls and rebasing until it becomes feature complete.

- [x] sketch proposed changes to kapacitor command
- [x] extend types in cli package to support transport of tag related data
- [x] add routes to server to support tags
- [ ] provide Replay service with a TagStore service
- [ ] implement tag routes
- [ ] implement a TagStore backed by Bolt DB

**Open questions**
- should the creation of tags that look exactly like a recording id be restricted? Leaning towards yes.
- should re-use of an existing tag for a different recording be prevented?  Leaning towards no.
