### PR TITLE
Factor out the protobuf dependency into a shell script.

### DIFF
--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -18,21 +18,9 @@ RUN apt-get update && apt-get install -y \
     curl
 
 # Install protobuf3
-ENV PROTO_VERSION 3.0.0-beta-2
-# Download and compile protoc
-RUN wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz && \
-    tar xf v${PROTO_VERSION}.tar.gz && \
-    rm -f v${PROTO_VERSION}.tar.gz && \
-    cd protobuf-${PROTO_VERSION} && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr && \
-    make -j $(nproc) && \
-    make check && \
-    make install
-
-# Install Python Protobuf3
-RUN cd protobuf-${PROTO_VERSION}/python && \
-    python setup.py install;
+ADD install-deps.sh /tmp/
+RUN INSTALL_PREFIX=/usr /tmp/install-deps.sh
+RUN rm /tmp/install-deps.sh
 
 # Install go
 ENV GOPATH /root/go

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -28,22 +28,9 @@ RUN apt-get update && apt-get install -y \
 RUN gem install fpm
 
 # Install protobuf3
-ENV PROTO_VERSION 3.0.0-beta-2
-# Download and compile protoc
-RUN wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz && \
-    tar xf v${PROTO_VERSION}.tar.gz && \
-    rm -f v${PROTO_VERSION}.tar.gz && \
-    cd protobuf-${PROTO_VERSION} && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr && \
-    make -j $(nproc) && \
-    make check && \
-    make install
-
-# Install Python Protobuf3
-RUN cd protobuf-${PROTO_VERSION}/python && \
-    python setup.py install;
-
+ADD install-deps.sh /tmp/
+RUN INSTALL_PREFIX=/usr /tmp/install-deps.sh
+RUN rm /tmp/install-deps.sh
 
 # Install go
 ENV GOPATH /root/go

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -18,21 +18,9 @@ RUN apt-get update && apt-get install -y \
     curl
 
 # Install protobuf3
-ENV PROTO_VERSION 3.0.0-beta-2
-# Download and compile protoc
-RUN wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz && \
-    tar xf v${PROTO_VERSION}.tar.gz && \
-    rm -f v${PROTO_VERSION}.tar.gz && \
-    cd protobuf-${PROTO_VERSION} && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr && \
-    make -j $(nproc) && \
-    make check && \
-    make install
-
-# Install Python Protobuf3
-RUN cd protobuf-${PROTO_VERSION}/python && \
-    python setup.py install;
+ADD install-deps.sh /tmp/
+RUN INSTALL_PREFIX=/usr /tmp/install-deps.sh
+RUN rm /tmp/install-deps.sh
 
 # Setup env
 ENV GOPATH /root/go

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -838,6 +838,8 @@ func TestServer_RecordReplayBatch(t *testing.T) {
 	}
 }
 
+// If this test fails due to missing python dependencies, run 'INSTALL_PREFIX=/usr/local ./install-deps.sh' from the root directory of the
+// kapacitor project.
 func TestServer_UDFStreamAgents(t *testing.T) {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# this script installs the python dependencies required to
+# run the kapacitor tests locally.
+
+set -e
+
+INSTALL_PREFIX=${INSTALL_PREFIX:-/usr/local}
+PROTO_VERSION=3.0.0-beta-2
+# Download and compile protoc
+wget https://github.com/google/protobuf/archive/v${PROTO_VERSION}.tar.gz
+tar xf v${PROTO_VERSION}.tar.gz
+rm -f v${PROTO_VERSION}.tar.gz
+pushd protobuf-${PROTO_VERSION}
+./autogen.sh
+./configure --prefix=${INSTALL_PREFIX}
+
+if ! which nproc >/dev/null 2>&1; then
+	nproc() {
+		echo 1
+	}
+fi
+
+make -j $(nproc)
+make check
+make install
+popd
+
+# Install Python Protobuf3
+cd protobuf-${PROTO_VERSION}/python
+python setup.py install;


### PR DESCRIPTION
The kapacitor unit tests don't run locally unless the protobuf
dependencies are installed locally.

Since the required glue is somewhat non-trivial, factor the glue
out from the Dockerfiles and change the docker files to use the same
glue.

Add a comment to the test to indicate how to fix the missing dependencies
issue.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>