### PR TITLE
Change TICKscript to left-associative operator precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Example UDF config for a socket based UDF.
 ### Bugfixes
 
 - [#441](https://github.com/influxdata/kapacitor/issues/441): Fix panic in UDF code.
+- [#429](https://github.com/influxdata/kapacitor/issues/429): BREAKING: Change TICKscript parser to be left-associative on equal precedence operators. For example previously this statement `(1+2-3*4/5)` was evaluated as `(1+(2-(3*(4/5))))`
+    which is not the typical/expected behavior. Now using left-associative parsing the statement is evaluated as `((1+2)-((3*4)/5))`.
 
 ## v0.12.0 [2016-04-04]
 

--- a/tick/TICKscript.md
+++ b/tick/TICKscript.md
@@ -66,15 +66,15 @@ Expression   = identifier { Chain } | Function { Chain } | Primary .
 Chain        = "@" Function | "|" Function { Chain } | "." Function { Chain} | "." identifier { Chain } .
 Function     = identifier "(" Parameters ")" .
 Parameters   = { Parameter "," } [ Parameter ] .
-Parameter    = Expression | "lambda:" LambdaExpr | Primary .
-Primary      = "(" LambdaExpr ")" | number_lit | string_lit |
+Parameter    = Expression | "lambda:" BinaryExpr | Primary .
+Primary      = "(" BinaryExpr ")" | number_lit | string_lit |
                 boolean_lit | duration_lit | regex_lit | star_lit |
                 LFunc | identifier | Reference | "-" Primary | "!" Primary .
 Reference    = `"` { unicode_char } `"` .
-LambdaExpr   =  Primary operator_lit Primary .
+BinaryExpr   =  Primary  { operator_lit Primary} .
 LFunc        = identifier "(" LParameters ")"
 LParameters  = { LParameter "," } [ LParameter ] .
-LParameter   = LambdaExpr |  Primary .
+LParameter   = BinaryExpr |  Primary .
 
 ```
 

--- a/tick/parser_test.go
+++ b/tick/parser_test.go
@@ -782,6 +782,127 @@ func TestParseStatements(t *testing.T) {
 		},
 		{
 			script: `global(lambda: 
+	// Test Left-Associative operators
+	// should parse as ((1+2)-(3*4)/5)
+	(1 + 2 - 3 * 4 / 5)
+)
+`,
+			Root: &ListNode{
+				position: position{
+					pos:  0,
+					line: 1,
+					char: 1,
+				},
+				Nodes: []Node{
+					&FunctionNode{
+						position: position{
+							pos:  0,
+							line: 1,
+							char: 1,
+						},
+						Func: "global",
+						Type: globalFunc,
+						Args: []Node{
+							&LambdaNode{
+								position: position{
+									pos:  7,
+									line: 1,
+									char: 8,
+								},
+								Node: &BinaryNode{
+									position: position{
+										pos:  96,
+										line: 4,
+										char: 9,
+									},
+									Operator: TokenMinus,
+									Parens:   true,
+									Left: &BinaryNode{
+										position: position{
+											pos:  92,
+											line: 4,
+											char: 5,
+										},
+										Operator: TokenPlus,
+										Left: &NumberNode{
+											position: position{
+												pos:  90,
+												line: 4,
+												char: 3,
+											},
+											IsInt: true,
+											Int64: 1,
+										},
+										Right: &NumberNode{
+											position: position{
+												pos:  94,
+												line: 4,
+												char: 7,
+											},
+											IsInt: true,
+											Int64: 2,
+										},
+									},
+									Right: &BinaryNode{
+										position: position{
+											pos:  104,
+											line: 4,
+											char: 17,
+										},
+										Operator: TokenDiv,
+										Left: &BinaryNode{
+											position: position{
+												pos:  100,
+												line: 4,
+												char: 13,
+											},
+											Operator: TokenMult,
+											Left: &NumberNode{
+												position: position{
+													pos:  98,
+													line: 4,
+													char: 11,
+												},
+												IsInt: true,
+												Int64: 3,
+											},
+											Right: &NumberNode{
+												position: position{
+													pos:  102,
+													line: 4,
+													char: 15,
+												},
+												IsInt: true,
+												Int64: 4,
+											},
+										},
+										Right: &NumberNode{
+											position: position{
+												pos:  106,
+												line: 4,
+												char: 19,
+											},
+											IsInt: true,
+											Int64: 5,
+										},
+									},
+									Comment: &CommentNode{
+										position: position{
+											pos:  17,
+											line: 2,
+											char: 2,
+										},
+										Comments: []string{"Test Left-Associative operators", "should parse as ((1+2)-(3*4)/5)"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			script: `global(lambda: 
 // If this
 // is less than that
 (1 + 2 - 3 * 4 / 5) 
@@ -829,29 +950,29 @@ AND
 										MultiLine: true,
 										Left: &BinaryNode{
 											position: position{
-												pos:  51,
+												pos:  55,
 												line: 4,
-												char: 4,
+												char: 8,
 											},
-											Operator: TokenPlus,
+											Operator: TokenMinus,
 											Parens:   true,
-											Left: &NumberNode{
+											Left: &BinaryNode{
 												position: position{
-													pos:  49,
+													pos:  51,
 													line: 4,
-													char: 2,
+													char: 4,
 												},
-												IsInt: true,
-												Int64: 1,
-											},
-											Right: &BinaryNode{
-												position: position{
-													pos:  55,
-													line: 4,
-													char: 8,
-												},
-												Operator: TokenMinus,
+												Operator: TokenPlus,
 												Left: &NumberNode{
+													position: position{
+														pos:  49,
+														line: 4,
+														char: 2,
+													},
+													IsInt: true,
+													Int64: 1,
+												},
+												Right: &NumberNode{
 													position: position{
 														pos:  53,
 														line: 4,
@@ -860,7 +981,15 @@ AND
 													IsInt: true,
 													Int64: 2,
 												},
-												Right: &BinaryNode{
+											},
+											Right: &BinaryNode{
+												position: position{
+													pos:  63,
+													line: 4,
+													char: 16,
+												},
+												Operator: TokenDiv,
+												Left: &BinaryNode{
 													position: position{
 														pos:  59,
 														line: 4,
@@ -876,32 +1005,24 @@ AND
 														IsInt: true,
 														Int64: 3,
 													},
-													Right: &BinaryNode{
+													Right: &NumberNode{
 														position: position{
-															pos:  63,
+															pos:  61,
 															line: 4,
-															char: 16,
+															char: 14,
 														},
-														Operator: TokenDiv,
-														Left: &NumberNode{
-															position: position{
-																pos:  61,
-																line: 4,
-																char: 14,
-															},
-															IsInt: true,
-															Int64: 4,
-														},
-														Right: &NumberNode{
-															position: position{
-																pos:  65,
-																line: 4,
-																char: 18,
-															},
-															IsInt: true,
-															Int64: 5,
-														},
+														IsInt: true,
+														Int64: 4,
 													},
+												},
+												Right: &NumberNode{
+													position: position{
+														pos:  65,
+														line: 4,
+														char: 18,
+													},
+													IsInt: true,
+													Int64: 5,
 												},
 											},
 											Comment: &CommentNode{


### PR DESCRIPTION
Change TICKscript parser to be left-associative on equal precedence operators. 

For example previously this statement `(1+2-3*4/5)` was evaluated as `(1+(2-(3*(4/5))))` which is not the typical/expected behavior. Now using left-associative parsing the statement is evaluated as `((1+2)-((3*4)/5))`.


Fixes #429
