### PR TITLE
[Alerta] Do not set status, fix rawData and default severity is indeterminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Example UDF config for a socket based UDF.
 - [#441](https://github.com/influxdata/kapacitor/issues/441): Fix panic in UDF code.
 - [#429](https://github.com/influxdata/kapacitor/issues/429): BREAKING: Change TICKscript parser to be left-associative on equal precedence operators. For example previously this statement `(1+2-3*4/5)` was evaluated as `(1+(2-(3*(4/5))))`
     which is not the typical/expected behavior. Now using left-associative parsing the statement is evaluated as `((1+2)-((3*4)/5))`.
+- [#456](https://github.com/influxdata/kapacitor/pull/456): Fixes Alerta integration to let server set status, fix `rawData` attribute and set default severity to `indeterminate`.
 
 ## v0.12.0 [2016-04-04]
 

--- a/alert.go
+++ b/alert.go
@@ -761,24 +761,18 @@ func (a *AlertNode) handleAlerta(alerta alertaHandler, ad *AlertData) {
 	}
 
 	var severity string
-	var status string
 
 	switch ad.Level {
 	case OKAlert:
 		severity = "ok"
-		status = "closed"
 	case InfoAlert:
 		severity = "informational"
-		status = "open"
 	case WarnAlert:
 		severity = "warning"
-		status = "open"
 	case CritAlert:
 		severity = "critical"
-		status = "open"
 	default:
-		severity = "unknown"
-		status = "unknown"
+		severity = "indeterminate"
 	}
 	var buf bytes.Buffer
 	err := alerta.resourceTmpl.Execute(&buf, ad.info)
@@ -823,7 +817,6 @@ func (a *AlertNode) handleAlerta(alerta alertaHandler, ad *AlertData) {
 		ad.ID,
 		environment,
 		severity,
-		status,
 		group,
 		value,
 		ad.Message,

--- a/services/alerta/service.go
+++ b/services/alerta/service.go
@@ -37,7 +37,7 @@ func (s *Service) Close() error {
 	return nil
 }
 
-func (s *Service) Alert(token, resource, event, environment, severity, status, group, value, message, origin string, service []string, data interface{}) error {
+func (s *Service) Alert(token, resource, event, environment, severity, group, value, message, origin string, service []string, data interface{}) error {
 	if resource == "" || event == "" {
 		return errors.New("Resource and Event are required to send an alert")
 	}
@@ -65,12 +65,11 @@ func (s *Service) Alert(token, resource, event, environment, severity, status, g
 	postData["event"] = event
 	postData["environment"] = environment
 	postData["severity"] = severity
-	postData["status"] = status
 	postData["group"] = group
 	postData["value"] = value
 	postData["text"] = message
 	postData["origin"] = origin
-	postData["data"] = data
+	postData["rawData"] = data
 	if len(service) > 0 {
 		postData["service"] = service
 	}

--- a/task_master.go
+++ b/task_master.go
@@ -83,7 +83,6 @@ type TaskMaster struct {
 			event,
 			environment,
 			severity,
-			status,
 			group,
 			value,
 			message,


### PR DESCRIPTION
Some minor fixes to the Alerta integration...

* let the Alerta server determine the alert status otherwise alerts that have been acknowledged in the console will be incorrectly modified
* change incorrect `data` attribute to `rawData`
* default severity should be `indeterminate` otherwise automatic status changes don't work as expected

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)