### PR TITLE
Alert data outputs to children nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ Example UDF config for a socket based UDF.
        timeout = "10s"
 ```
 
+Alert data can now be consumed directly from within TICKscripts.
+For example, let's say we want to store all data that triggered an alert in InfluxDB with a tag `level` containing the level string value (i.e CRITICAL).
+
+```javascript
+...
+    |alert()
+        .warn(...)
+        .crit(...)
+        .levelTag('level')
+        // and/or use a field
+        //.levelField('level')
+        // Also tag the data with the alert ID
+        .idTag('id')
+        // and/or use a field
+        //.idField('id')
+    |influxDBOut()
+        .database('alerts')
+        ...
+```
+
+
 ### Features
 
 - [#360](https://github.com/influxdata/kapacitor/pull/360): Forking tasks by measurement in order to improve performance
@@ -25,6 +46,7 @@ Example UDF config for a socket based UDF.
 - [#399](https://github.com/influxdata/kapacitor/issues/399): Allow disabling of subscriptions.
 - [#417](https://github.com/influxdata/kapacitor/issues/417): UDFs can be connected over a Unix socket. This enables UDFs from across Docker containers.
 - [#451](https://github.com/influxdata/kapacitor/issues/451): StreamNode supports `|groupBy` and `|where` methods.
+- [#93](https://github.com/influxdata/kapacitor/issues/93): AlertNode now outputs data to child nodes. The output data can have either a tag or field indicating the alert level.
 
 ### Bugfixes
 

--- a/integrations/batcher_test.go
+++ b/integrations/batcher_test.go
@@ -284,6 +284,123 @@ batch
 
 	testBatcherWithOutput(t, "TestBatch_SimpleMR", script, 30*time.Second, er)
 }
+func TestBatch_AlertLevelField(t *testing.T) {
+
+	var script = `
+batch
+	|query('''
+		SELECT mean("value")
+		FROM "telegraf"."default".cpu_usage_idle
+		WHERE "host" = 'serverA' AND "cpu" != 'cpu-total'
+''')
+		.period(10s)
+		.every(10s)
+		.groupBy(time(2s), 'cpu')
+	|alert()
+		.crit(lambda:"mean" > 95)
+		.levelField('level')
+		.idField('id')
+	|httpOut('TestBatch_SimpleMR')
+`
+
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "cpu_usage_idle",
+				Tags:    map[string]string{"cpu": "cpu1"},
+				Columns: []string{"time", "id", "level", "mean"},
+				Values: [][]interface{}{
+					{
+						time.Date(1971, 1, 1, 0, 0, 20, 0, time.UTC),
+						"cpu_usage_idle:cpu=cpu1,",
+						"CRITICAL",
+						96.49999999996908,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 22, 0, time.UTC),
+						"cpu_usage_idle:cpu=cpu1,",
+						"CRITICAL",
+						93.46464646468584,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 24, 0, time.UTC),
+						"cpu_usage_idle:cpu=cpu1,",
+						"CRITICAL",
+						95.00950095007724,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 26, 0, time.UTC),
+						"cpu_usage_idle:cpu=cpu1,",
+						"CRITICAL",
+						92.99999999998636,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 28, 0, time.UTC),
+						"cpu_usage_idle:cpu=cpu1,",
+						"CRITICAL",
+						90.99999999998545,
+					},
+				},
+			},
+		},
+	}
+
+	testBatcherWithOutput(t, "TestBatch_SimpleMR", script, 30*time.Second, er)
+}
+
+func TestBatch_AlertLevelTag(t *testing.T) {
+
+	var script = `
+batch
+	|query('''
+		SELECT mean("value")
+		FROM "telegraf"."default".cpu_usage_idle
+		WHERE "host" = 'serverA' AND "cpu" != 'cpu-total'
+''')
+		.period(10s)
+		.every(10s)
+		.groupBy(time(2s), 'cpu')
+	|alert()
+		.crit(lambda:"mean" > 95)
+		.levelTag('level')
+		.idTag('id')
+	|httpOut('TestBatch_SimpleMR')
+`
+
+	er := kapacitor.Result{
+		Series: imodels.Rows{
+			{
+				Name:    "cpu_usage_idle",
+				Tags:    map[string]string{"cpu": "cpu1", "level": "CRITICAL", "id": "cpu_usage_idle:cpu=cpu1,"},
+				Columns: []string{"time", "mean"},
+				Values: [][]interface{}{
+					{
+						time.Date(1971, 1, 1, 0, 0, 20, 0, time.UTC),
+						96.49999999996908,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 22, 0, time.UTC),
+						93.46464646468584,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 24, 0, time.UTC),
+						95.00950095007724,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 26, 0, time.UTC),
+						92.99999999998636,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 28, 0, time.UTC),
+						90.99999999998545,
+					},
+				},
+			},
+		},
+	}
+
+	testBatcherWithOutput(t, "TestBatch_SimpleMR", script, 30*time.Second, er)
+}
 
 func TestBatch_Join(t *testing.T) {
 

--- a/node.go
+++ b/node.go
@@ -156,6 +156,9 @@ func (n *node) addChild(c Node) (*Edge, error) {
 	if n.Provides() != c.Wants() {
 		return nil, fmt.Errorf("cannot add child mismatched edges: %s:%s -> %s:%s", n.Name(), n.Provides(), c.Name(), c.Wants())
 	}
+	if n.Provides() == pipeline.NoEdge {
+		return nil, fmt.Errorf("cannot add child no edge expected: %s:%s -> %s:%s", n.Name(), n.Provides(), c.Name(), c.Wants())
+	}
 	n.children = append(n.children, c)
 
 	edge := newEdge(n.et.Task.Name, n.Name(), c.Name(), n.Provides(), defaultEdgeBufferSize, n.et.tm.LogService)

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -25,6 +25,8 @@ type ID int
 
 func (e EdgeType) String() string {
 	switch e {
+	case NoEdge:
+		return "noedge"
 	case StreamEdge:
 		return "stream"
 	case BatchEdge:

--- a/pipeline/stream.go
+++ b/pipeline/stream.go
@@ -1,7 +1,7 @@
 package pipeline
 
 import (
-	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/influxdata/kapacitor/tick"
@@ -74,9 +74,6 @@ func (s *SourceStreamNode) From() *StreamNode {
 type StreamNode struct {
 	chainnode
 
-	// self describer
-	describer *tick.ReflectionDescriber
-
 	// An expression to filter the data stream.
 	// tick:ignore
 	Expression tick.Node `tick:"Where"`
@@ -113,9 +110,16 @@ func newStreamNode() *StreamNode {
 	s := &StreamNode{
 		chainnode: newBasicChainNode("stream", StreamEdge, StreamEdge),
 	}
-	s.describer, _ = tick.NewReflectionDescriber(s)
 	return s
 
+}
+
+//tick:ignore
+func (n *StreamNode) ChainMethods() map[string]reflect.Value {
+	return map[string]reflect.Value{
+		"GroupBy": reflect.ValueOf(n.chainnode.GroupBy),
+		"Where":   reflect.ValueOf(n.chainnode.Where),
+	}
 }
 
 // Creates a new stream node that can be further
@@ -232,53 +236,4 @@ func (s *StreamNode) Where(expression tick.Node) *StreamNode {
 func (s *StreamNode) GroupBy(tag ...interface{}) *StreamNode {
 	s.Dimensions = tag
 	return s
-}
-
-// Tick Describer methods
-
-//tick:ignore
-func (s *StreamNode) Desc() string {
-	return s.describer.Desc()
-}
-
-//tick:ignore
-func (s *StreamNode) HasChainMethod(name string) bool {
-	if name == "groupBy" || name == "where" {
-		return true
-	}
-	return s.describer.HasChainMethod(name)
-}
-
-//tick:ignore
-func (s *StreamNode) CallChainMethod(name string, args ...interface{}) (interface{}, error) {
-	switch name {
-	case "groupBy":
-		return s.chainnode.GroupBy(args...), nil
-	case "where":
-		if len(args) != 1 {
-			return nil, fmt.Errorf("invalid number of args to |where() got %d exp 1", len(args))
-		}
-		expr, ok := args[0].(tick.Node)
-		if !ok {
-			return nil, fmt.Errorf("invalid arg to |where() got %T exp tick.Node", args[0])
-		}
-		return s.chainnode.Where(expr), nil
-	default:
-		return s.describer.CallChainMethod(name, args...)
-	}
-}
-
-//tick:ignore
-func (s *StreamNode) HasProperty(name string) bool {
-	return s.describer.HasProperty(name)
-}
-
-//tick:ignore
-func (s *StreamNode) Property(name string) interface{} {
-	return s.describer.Property(name)
-}
-
-//tick:ignore
-func (s *StreamNode) SetProperty(name string, args ...interface{}) (interface{}, error) {
-	return s.describer.SetProperty(name, args...)
 }

--- a/pipeline/udf.go
+++ b/pipeline/udf.go
@@ -82,7 +82,7 @@ func NewUDF(
 		UDFName:   name,
 		options:   options,
 	}
-	udf.describer, _ = tick.NewReflectionDescriber(udf)
+	udf.describer, _ = tick.NewReflectionDescriber(udf, nil)
 	parent.linkChild(udf)
 	return udf
 }

--- a/tick/eval_test.go
+++ b/tick/eval_test.go
@@ -266,3 +266,619 @@ var s2 = a.structB()
 		t.Fatal("expected error from Evaluate")
 	}
 }
+
+//------------------------------------
+// Types for TestReflectionDescriber
+//
+
+// Basic type
+type A struct {
+	AProperty               string
+	AFlag                   bool `tick:"PropertyMethodA"`
+	AHiddenPMFlag           bool `tick:"HiddenPropertyMethod"`
+	propertyMethodCallCount int
+	chainMethodCallCount    int
+	hcmCallCount            int
+}
+
+func (a *A) PropertyMethodA() *A {
+	a.AFlag = true
+	a.propertyMethodCallCount++
+	return a
+}
+
+func (a *A) ChainMethodA() *A {
+	a.chainMethodCallCount++
+	return new(A)
+}
+
+func (a *A) HiddenPropertyMethod() *A {
+	a.AHiddenPMFlag = true
+	return a
+}
+
+func (a *A) HiddenChainMethod() *A {
+	a.hcmCallCount++
+	return new(A)
+}
+
+func (a *A) privateMethod() {}
+
+// Type that embeds A
+type B struct {
+	A
+	BProperty        string
+	BFlag            bool   `tick:"PropertyMethodB"`
+	BOverriddingProp string `tick:"HiddenChainMethod"`
+
+	// Property hiding ChainMethodA
+	ChainMethodA string
+
+	propertyMethodCallCount int
+	chainMethodCallCount    int
+	apCallCount             int
+	hpmCallCount            int
+}
+
+func (b *B) PropertyMethodB() *B {
+	b.BFlag = true
+	b.propertyMethodCallCount++
+	return b
+}
+
+func (b *B) ChainMethodB() *B {
+	b.chainMethodCallCount++
+	return new(B)
+}
+
+// Chain method hiding AProperty
+func (b *B) AProperty() *B {
+	b.apCallCount++
+	return new(B)
+}
+
+// Chain method hiding A.HiddenPropertyMethod property method
+func (b *B) HiddenPropertyMethod() *B {
+	b.hpmCallCount++
+	return new(B)
+}
+
+// Property method hidding chain method
+func (b *B) HiddenChainMethod(value string) *B {
+	b.BOverriddingProp = value
+	return b
+}
+
+// Type that embeds *A
+type C struct {
+	*A
+	CProperty        string
+	CFlag            bool   `tick:"PropertyMethodC"`
+	COverriddingProp string `tick:"HiddenChainMethod"`
+
+	// Property hiding ChainMethodA
+	ChainMethodA string
+
+	propertyMethodCallCount int
+	chainMethodCallCount    int
+	apCallCount             int
+	hpmCallCount            int
+}
+
+func (c *C) PropertyMethodC() *C {
+	c.CFlag = true
+	c.propertyMethodCallCount++
+	return c
+}
+
+func (c *C) ChainMethodC() (*C, error) {
+	c.chainMethodCallCount++
+	return new(C), nil
+}
+
+// Chain method hiding AProperty
+func (c *C) AProperty() *C {
+	c.apCallCount++
+	return new(C)
+}
+
+// Chain method hiding A.HiddenPropertyMethod property method
+func (c *C) HiddenPropertyMethod() *C {
+	c.hpmCallCount++
+	return new(C)
+}
+
+// Property method hidding chain method
+func (c *C) HiddenChainMethod(value string) *C {
+	c.COverriddingProp = value
+	return c
+}
+
+func TestReflectionDescriber(t *testing.T) {
+	//----------------
+	// Test A type
+	//
+	a := new(A)
+	rdA, err := tick.NewReflectionDescriber(a, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test A.privateMethod
+	if exp, got := false, rdA.HasProperty("privateMethod"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+
+	// Test A.AProperty
+	if exp, got := true, rdA.HasProperty("aProperty"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdA.HasChainMethod("aProperty"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdA.SetProperty("aProperty", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", a.AProperty; exp != got {
+		t.Fatalf("unexpected a.AProperty got: %v exp: %v", got, exp)
+	}
+
+	// Test A.PropertyMethodA
+	if exp, got := true, rdA.HasProperty("propertyMethodA"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdA.HasChainMethod("propertyMethodA"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdA.HasProperty("aFlag"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdA.SetProperty("propertyMethodA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, a.AFlag; exp != got {
+		t.Fatalf("unexpected a.AFlag got: %v exp: %v", got, exp)
+	}
+	if exp, got := 1, a.propertyMethodCallCount; exp != got {
+		t.Fatalf("unexpected a.propertyMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test A.HiddenPropertyMethod
+	if exp, got := true, rdA.HasProperty("hiddenPropertyMethod"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdA.HasChainMethod("hiddenPropertyMethod"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdA.HasProperty("aHiddenPMFlag"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdA.SetProperty("hiddenPropertyMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, a.AHiddenPMFlag; exp != got {
+		t.Fatalf("unexpected a.AHiddenPMFlag got: %v exp: %v", got, exp)
+	}
+
+	// Test A.ChainMethodA
+	if exp, got := true, rdA.HasChainMethod("chainMethodA"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdA.HasProperty("chainMethodA"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdA.CallChainMethod("chainMethodA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, a.chainMethodCallCount; exp != got {
+		t.Fatalf("unexpected a.chainMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test A.HiddenChainMethod
+	if exp, got := true, rdA.HasChainMethod("hiddenChainMethod"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdA.HasProperty("hiddenChainMethod"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdA.CallChainMethod("hiddenChainMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, a.hcmCallCount; exp != got {
+		t.Fatalf("unexpected a.hcmCallCount got: %v exp: %v", got, exp)
+	}
+
+	//----------------
+	// Test B type
+	//
+	b := new(B)
+	rdB, err := tick.NewReflectionDescriber(b, map[string]reflect.Value{
+		"HiddenPropertyMethod": reflect.ValueOf(b.HiddenPropertyMethod),
+		"HiddenChainMethod":    reflect.ValueOf(b.A.HiddenChainMethod),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test B.AProperty as property
+	if exp, got := true, rdB.HasProperty("aProperty"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.SetProperty("aProperty", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", b.A.AProperty; exp != got {
+		t.Fatalf("unexpected b.A.AProperty got: %v exp: %v", got, exp)
+	}
+
+	// Test B.AProperty as chain
+	if exp, got := true, rdB.HasChainMethod("aProperty"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.CallChainMethod("aProperty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, b.apCallCount; exp != got {
+		t.Fatalf("unexpected b.apCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test B.PropertyMethodA
+	if exp, got := true, rdB.HasProperty("propertyMethodA"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdB.HasChainMethod("propertyMethodA"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdB.HasProperty("aFlag"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.SetProperty("propertyMethodA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, b.AFlag; exp != got {
+		t.Fatalf("unexpected b.AFlag got: %v exp: %v", got, exp)
+	}
+	if exp, got := 1, b.A.propertyMethodCallCount; exp != got {
+		t.Fatalf("unexpected b.A.propertyMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test B.HiddenPropertyMethod as chain
+	if exp, got := true, rdB.HasChainMethod("hiddenPropertyMethod"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.CallChainMethod("hiddenPropertyMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, b.hpmCallCount; exp != got {
+		t.Fatalf("unexpected b.hpmCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test B.HiddenPropertyMethod as property
+	if exp, got := true, rdB.HasProperty("hiddenPropertyMethod"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.SetProperty("hiddenPropertyMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, b.AHiddenPMFlag; exp != got {
+		t.Fatalf("unexpected b.AHiddenPMFlag got: %v exp: %v", got, exp)
+	}
+
+	// Test B.HiddenChainMethod as chain
+	if exp, got := true, rdB.HasChainMethod("hiddenChainMethod"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.CallChainMethod("hiddenChainMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, b.A.hcmCallCount; exp != got {
+		t.Fatalf("unexpected b.A.hcmCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test B.HiddenPropertyMethod as property
+	if exp, got := true, rdB.HasProperty("hiddenChainMethod"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.SetProperty("hiddenChainMethod", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", b.BOverriddingProp; exp != got {
+		t.Fatalf("unexpected b.BOverriddingProp got: %v exp: %v", got, exp)
+	}
+
+	// Test B.ChainMethodA as chain
+	if exp, got := true, rdB.HasChainMethod("chainMethodA"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.CallChainMethod("chainMethodA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, b.A.chainMethodCallCount; exp != got {
+		t.Fatalf("unexpected b.A.chainMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test B.ChainMethodA as property
+	if exp, got := true, rdB.HasProperty("chainMethodA"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.SetProperty("chainMethodA", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", b.ChainMethodA; exp != got {
+		t.Fatalf("unexpected b.ChainMethodA got: %v exp: %v", got, exp)
+	}
+
+	// Test B.BProperty
+	if exp, got := true, rdB.HasProperty("bProperty"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdB.HasChainMethod("bProperty"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.SetProperty("bProperty", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", b.BProperty; exp != got {
+		t.Fatalf("unexpected b.BProperty got: %v exp: %v", got, exp)
+	}
+
+	// Test B.PropertyMethodB
+	if exp, got := true, rdB.HasProperty("propertyMethodB"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdB.HasChainMethod("propertyMethodB"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.SetProperty("propertyMethodB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, b.BFlag; exp != got {
+		t.Fatalf("unexpected b.BFlag got: %v exp: %v", got, exp)
+	}
+	if exp, got := 1, b.propertyMethodCallCount; exp != got {
+		t.Fatalf("unexpected b.propertyMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test B.ChainMethodB
+	if exp, got := true, rdB.HasChainMethod("chainMethodB"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdB.HasProperty("chainMethodB"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdB.CallChainMethod("chainMethodB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, b.chainMethodCallCount; exp != got {
+		t.Fatalf("unexpected b.chainMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	//----------------
+	// Test C type
+	//
+	c := &C{
+		A: new(A),
+	}
+	rdC, err := tick.NewReflectionDescriber(c, map[string]reflect.Value{
+		"HiddenPropertyMethod": reflect.ValueOf(c.HiddenPropertyMethod),
+		"HiddenChainMethod":    reflect.ValueOf(c.A.HiddenChainMethod),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test C.AProperty as property
+	if exp, got := true, rdC.HasProperty("aProperty"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.SetProperty("aProperty", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", c.A.AProperty; exp != got {
+		t.Fatalf("unexpected c.A.AProperty got: %v exp: %v", got, exp)
+	}
+
+	// Test C.AProperty as chain
+	if exp, got := true, rdC.HasChainMethod("aProperty"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.CallChainMethod("aProperty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, c.apCallCount; exp != got {
+		t.Fatalf("unexpected c.apCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test C.PropertyMethodA
+	if exp, got := true, rdC.HasProperty("propertyMethodA"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdC.HasChainMethod("propertyMethodA"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdC.HasProperty("aFlag"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.SetProperty("propertyMethodA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, c.AFlag; exp != got {
+		t.Fatalf("unexpected c.AFlag got: %v exp: %v", got, exp)
+	}
+	if exp, got := 1, c.A.propertyMethodCallCount; exp != got {
+		t.Fatalf("unexpected c.A.propertyMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test C.HiddenPropertyMethod as chain
+	if exp, got := true, rdC.HasChainMethod("hiddenPropertyMethod"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.CallChainMethod("hiddenPropertyMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, c.hpmCallCount; exp != got {
+		t.Fatalf("unexpected c.hpmCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test C.HiddenPropertyMethod as property
+	if exp, got := true, rdC.HasProperty("hiddenPropertyMethod"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.SetProperty("hiddenPropertyMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, c.AHiddenPMFlag; exp != got {
+		t.Fatalf("unexpected c.AHiddenPMFlag got: %v exp: %v", got, exp)
+	}
+
+	// Test C.HiddenChainMethod as chain
+	if exp, got := true, rdC.HasChainMethod("hiddenChainMethod"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.CallChainMethod("hiddenChainMethod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, c.A.hcmCallCount; exp != got {
+		t.Fatalf("unexpected c.A.hcmCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test C.HiddenPropertyMethod as property
+	if exp, got := true, rdC.HasProperty("hiddenChainMethod"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.SetProperty("hiddenChainMethod", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", c.COverriddingProp; exp != got {
+		t.Fatalf("unexpected c.COverriddingProp got: %v exp: %v", got, exp)
+	}
+
+	// Test C.ChainMethodA as chain
+	if exp, got := true, rdC.HasChainMethod("chainMethodA"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.CallChainMethod("chainMethodA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, c.A.chainMethodCallCount; exp != got {
+		t.Fatalf("unexpected c.A.chainMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test C.ChainMethodA as property
+	if exp, got := true, rdC.HasProperty("chainMethodA"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.SetProperty("chainMethodA", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", c.ChainMethodA; exp != got {
+		t.Fatalf("unexpected c.ChainMethodA got: %v exp: %v", got, exp)
+	}
+
+	// Test C.CProperty
+	if exp, got := true, rdC.HasProperty("cProperty"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdC.HasChainMethod("cProperty"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.SetProperty("cProperty", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := "test", c.CProperty; exp != got {
+		t.Fatalf("unexpected c.CProperty got: %v exp: %v", got, exp)
+	}
+
+	// Test C.PropertyMethodC
+	if exp, got := true, rdC.HasProperty("propertyMethodC"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdC.HasChainMethod("propertyMethodC"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.SetProperty("propertyMethodC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := true, c.CFlag; exp != got {
+		t.Fatalf("unexpected c.CFlag got: %v exp: %v", got, exp)
+	}
+	if exp, got := 1, c.propertyMethodCallCount; exp != got {
+		t.Fatalf("unexpected c.propertyMethodCallCount got: %v exp: %v", got, exp)
+	}
+
+	// Test C.ChainMethodC
+	if exp, got := true, rdC.HasChainMethod("chainMethodC"); exp != got {
+		t.Fatalf("unexpected HasChainMethod got: %v exp: %v", got, exp)
+	}
+	if exp, got := false, rdC.HasProperty("chainMethodC"); exp != got {
+		t.Fatalf("unexpected HasProperty got: %v exp: %v", got, exp)
+	}
+	_, err = rdC.CallChainMethod("chainMethodC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp, got := 1, c.chainMethodCallCount; exp != got {
+		t.Fatalf("unexpected c.chainMethodCallCount got: %v exp: %v", got, exp)
+	}
+}
+
+func TestReflectionDescriberErrors(t *testing.T) {
+	_, err := tick.NewReflectionDescriber(nil, nil)
+	if err == nil {
+		t.Error("expected err got nil")
+	}
+
+	o := struct{}{}
+	_, err = tick.NewReflectionDescriber(o, nil)
+	if err == nil {
+		t.Error("expected err got nil")
+	}
+
+	var c *C
+	_, err = tick.NewReflectionDescriber(c, nil)
+	if err == nil {
+		t.Error("expected err got nil")
+	}
+
+	c = new(C)
+	_, err = tick.NewReflectionDescriber(c, nil)
+	if err == nil {
+		t.Error("expected err got nil")
+	}
+
+	i := new(int)
+	*i = 42
+	_, err = tick.NewReflectionDescriber(i, nil)
+	if err == nil {
+		t.Error("expected err got nil")
+	}
+
+}


### PR DESCRIPTION
Fixes #93 

Alert data can now be consumed directly from within TICKscripts.
For example, let's say we want to store all data that triggered an alert in InfluxDB with a tag `level` containing the level string value (i.e CRITICAL).

```javascript
...
    |alert()
        .warn(...)
        .crit(...)
        .levelTag('level')
         // Or use a field
        .levelField('level')
    |influxDBOut()
        .database('alerts')
        ...
```



