### PR TITLE
Can now require that all points in alert batch match criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ For example, let's say we want to store all data that triggered an alert in Infl
 - [#417](https://github.com/influxdata/kapacitor/issues/417): UDFs can be connected over a Unix socket. This enables UDFs from across Docker containers.
 - [#451](https://github.com/influxdata/kapacitor/issues/451): StreamNode supports `|groupBy` and `|where` methods.
 - [#93](https://github.com/influxdata/kapacitor/issues/93): AlertNode now outputs data to child nodes. The output data can have either a tag or field indicating the alert level.
+- [#281](https://github.com/influxdata/kapacitor/issues/281): AlertNode now has an `.all()` property that specifies that all points in a batch must match the criteria in order to trigger an alert.
+
 
 ### Bugfixes
 

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -219,6 +219,10 @@ type AlertNode struct {
 	// Optional field key to add to the data, containing the alert ID as a string.
 	IdField string
 
+	// Indicates an alert should trigger only if all points in a batch match the criteria
+	// tick:ignore
+	AllFlag bool `tick:"All"`
+
 	// Send alerts only on state changes.
 	// tick:ignore
 	IsStateChangesOnly bool `tick:"StateChangesOnly"`
@@ -288,6 +292,14 @@ func (n *AlertNode) ChainMethods() map[string]reflect.Value {
 	return map[string]reflect.Value{
 		"Log": reflect.ValueOf(n.chainnode.Log),
 	}
+}
+
+// Indicates an alert should trigger only if all points in a batch match the criteria
+// Does not apply to stream alerts.
+// tick:property
+func (n *AlertNode) All() *AlertNode {
+	n.AllFlag = true
+	return n
 }
 
 // Only sends events where the state changed.


### PR DESCRIPTION
Fixes #281 

Note the `any` method was not added as that is the default behavior.

This is now possible:

```javascript

|alert()
    .all()
    .warn(lamnda: "value" > 5)
    .crit(lamnda: "value" > 10)
```

Given a batch of data with:

```
value 7
value 12
value 4
```

No alert would be triggered

Given a batch of data with:

```
value 7
value 12
value 6
```

A `WARNING` will be triggered

Given a batch of data with:

```
value 13
value 12
value 15
```

A `CRITICAL` will be triggered