### PR TITLE
Allow disabling TICKscript formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ For example, let's say we want to store all data that triggered an alert in Infl
 - [#281](https://github.com/influxdata/kapacitor/issues/281): AlertNode now has an `.all()` property that specifies that all points in a batch must match the criteria in order to trigger an alert.
 - [#384](https://github.com/influxdata/kapacitor/issues/384): Add `elapsed` function to compute the time difference between subsequent points.
 - [#230](https://github.com/influxdata/kapacitor/issues/230): Alert.StateChangesOnly now accepts optional duration arg. An alert will be triggered for every interval even if the state has not changed.
+- [#426](https://github.com/influxdata/kapacitor/issues/426): Add `skip-format` query parameter to the `GET /task` endpoint so that returned TICKscript content is left unmodified from the user input.
 
 
 ### Bugfixes

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -234,13 +234,17 @@ func (c *Client) ListTasks(names []string) ([]TaskSummary, error) {
 // If dotLabels is true then the DOT string returned
 // will use label attributes for the stats on the nodes and edges
 // making it more useful to graph.
-func (c *Client) Task(name string, dotLabels bool) (Task, error) {
+// Using skipFormat will skip the formatting step when returning the TICKscript contents.
+func (c *Client) Task(name string, dotLabels, skipFormat bool) (Task, error) {
 	task := Task{}
 
 	v := url.Values{}
 	v.Add("name", name)
 	if dotLabels {
 		v.Add("labels", "true")
+	}
+	if skipFormat {
+		v.Add("skip-format", "true")
 	}
 
 	u := *c.url

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -691,7 +691,7 @@ func doShow(args []string) error {
 		os.Exit(2)
 	}
 
-	ti, err := cli.Task(args[0], false)
+	ti, err := cli.Task(args[0], false, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -63,7 +63,7 @@ func TestServer_DefineTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ti, err := cli.Task(name, false)
+	ti, err := cli.Task(name, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestServer_EnableTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ti, err := cli.Task(name, false)
+	ti, err := cli.Task(name, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestServer_DisableTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ti, err := cli.Task(name, false)
+	ti, err := cli.Task(name, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestServer_DeleteTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ti, err := cli.Task(name, false)
+	ti, err := cli.Task(name, false, false)
 	if err == nil {
 		t.Fatal("unexpected task:", ti)
 	}


### PR DESCRIPTION
Now an optional `skip-format` query parameter is available on the `GET /task` endpoint.