### PR TITLE
Proposed HTTP API Changes

### DIFF
--- a/client/API.md
+++ b/client/API.md
@@ -388,15 +388,17 @@ A recording ID is returned to later identify the recording.
 
 ##### Stream
 
-| Parameter | Purpose                                                             |
-| --------- | -------                                                             |
-| task      | ID of a task, used to only record data for the DBRPs of the task. |
-| stop      | Record stream data until stop date.                                 |
+| Parameter | Purpose                                                                    |
+| --------- | -------                                                                    |
+| id        | Unique identifier for the recording. If empty a random one will be chosen. |
+| task      | ID of a task, used to only record data for the DBRPs of the task.          |
+| stop      | Record stream data until stop date.                                        |
 
 ##### Batch
 
 | Parameter | Purpose                                                                                                          |
 | --------- | -------                                                                                                          |
+| id        | Unique identifier for the recording. If empty a random one will be chosen.                                       |
 | task      | ID of a task, records the results of the queries defined in the task.                                            |
 | start     | Earliest date for which data will be recorded. RFC3339Nano formatted.                                            |
 | stop      | Latest date for which data will be recorded. If not specified uses the current time. RFC3339Nano formatted data. |
@@ -404,11 +406,12 @@ A recording ID is returned to later identify the recording.
 
 ##### Query
 
-| Parameter | Purpose                                                                   |
-| --------- | -------                                                                   |
-| type      | Type of recording, `stream` or `batch`.                                   |
-| query     | Query to execute.                                                         |
-| cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster. |
+| Parameter | Purpose                                                                    |
+| --------- | -------                                                                    |
+| id        | Unique identifier for the recording. If empty a random one will be chosen. |
+| type      | Type of recording, `stream` or `batch`.                                    |
+| query     | Query to execute.                                                          |
+| cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster.  |
 
 >NOTE: A recording itself is typed as either a stream or batch recording and can only be replayed to a task of a corresponding type.
 Therefore when you record the result of a raw query you must specify the type recording you wish to create.
@@ -451,6 +454,17 @@ Create a recording using the `query` method specifying a `batch` type.
 ```
 POST /kapacitor/v1/recording/query
 {
+    "query" : "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1h GROUP BY time(10m)",
+    "type" : "batch"
+}
+```
+
+Create a recording with a custom ID.
+
+```
+POST /kapacitor/v1/recording/query
+{
+    "id" : "MY_RECORDING_ID",
     "query" : "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1h GROUP BY time(10m)",
     "type" : "batch"
 }
@@ -633,6 +647,18 @@ POST /kapacitor/v1/replays/
     "recording" : "RECORDING_ID",
     "clock" : "real",
     "recording-time" : true,
+}
+```
+
+
+Replay a recording using a custom ID.
+
+```
+POST /kapacitor/v1/replays/
+{
+    "id" : "MY_REPLAY_ID",
+    "task" : "TASK_ID",
+    "recording" : "RECORDING_ID"
 }
 ```
 

--- a/client/API.md
+++ b/client/API.md
@@ -5,14 +5,15 @@ With the API you can control which tasks are executing, query status of tasks an
 
 Each section below defines the available API endpoints and there inputs and outputs.
 
+All requests are versioned and namespaced using the root path `/kapacitor/v1/`.
+
 ### Response Codes
 
 All requests can return these response codes:
 
 | HTTP Response Code | Meaning                                                                                                                                                             |
 | ------------------ | -------                                                                                                                                                             |
-| 200                | The request was a success the content is dependent on the request.                                                                                                  |
-| 204                | The request was a success and no content was returned.                                                                                                              |
+| 2xx                | The request was a success the content is dependent on the request.                                                                                                  |
 | 4xx                | Invalid request, refer to error for what it wrong with the request. Repeating the request will continue to return the same error.                                   |
 | 5xx                | The server was unable to process the request, refer to the error for a reason. Repeating the request may result in a success if the server issue has been resolved. |
 
@@ -31,44 +32,87 @@ All requests can return JSON in the following format to provide more information
 To make using this API a consistent and easy experience we follow one simple rule for when extra information
 about a request is found in the query parameters of the URL or when they are part of the submitted JSON body.
 
-Query parameters are used only for GET requests and all POST requests expect parameters to be specified in the JSON body.
+Query parameters are used only for GET requests and all other requests expect parameters to be specified in the JSON body.
+
+>NOTE: The /kapacitor/v1/write endpoint is the one exception to this rule since Kapacitor is compatible with the InfluxDB /write endpoint.
+
+## Writing Data
+
+Kapacitor can accept writes over HTTP using the line protocol.
+This endpoint is identical in nature to the InfluxDB write endpoint.
+
+| Query Parameter | Purpose                               |
+| --------------- | -------                               |
+| db              | Database name for the writes.         |
+| rp              | Retention policy name for the writes. |
+
+>NOTE: Kapacitor scopes all points by their database and retention policy. This means you MUST specify the `rp` for writes or Kapacitor will not know which retention policy to use.
+
+#### Example
+
+Write data to Kapacitor.
+
+```
+POST /kapacitor/v1/write?db=DB_NAME&rp=RP_NAME
+cpu,host=example.com value=87.6
+```
+
+For compatibility with the equivalent InfluxDB write endpoint the `/write` endpoint is maintained as an alias to the `/kapacitor/v1/write` endpoint.
+
+```
+POST /write?db=DB_NAME&rp=RP_NAME
+cpu,host=example.com value=87.6
+```
 
 ## Tasks
 
 A task represents work for Kapacitor to perform.
-A task is defined by its name, type, TICKscript, and list of database retention policy pairs it is allowed to access.
+A task is defined by its id, type, TICKscript, and list of database retention policy pairs it is allowed to access.
 
 ### Define Task
 
-To define a task POST to the `/task/TASK_NAME` endpoint.
-If no task exists it with that name it will be created.
-Otherwise the existing task will be updated with the provided information.
+To define a task POST to the `/kapacitor/v1/tasks/` endpoint.
+If a task already exists then use the `PATCH` method to modify any property of the task.
 
 Define a task using a JSON object with the following options:
 
-| Parameter | Purpose                                                                |
-| --------- | -------                                                                |
-| type      | The task type: `stream` or `batch`.                                    |
-| dbrps     | List of database retention policy pairs the task is allowed to access. |
-| script    | The content of the script.                                             |
+| Property | Purpose                                                                |
+| -------- | -------                                                                |
+| id       | Unique identifier for the task. If empty a random ID will be chosen. |
+| type     | The task type: `stream` or `batch`.                                    |
+| dbrps    | List of database retention policy pairs the task is allowed to access. |
+| script   | The content of the script.                                             |
+| enabled  | Whether the task is enabled or disabled.                               |
 
-If any option is missing it will be left unmodified if the task already exists.
+When using PATCH, if any option is missing it will be left unmodified.
 
 #### Example
 
+Create a new task with ID TASK_ID.
+
 ```
-POST /task/TASK_NAME
+POST /kapacitor/v1/tasks/
 {
+    "id" : "TASK_ID",
     "type" : "stream",
     "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
     "script": "stream\n    |from()\n        .measurement('cpu')\n"
 }
 ```
 
+Response with task id and link.
+
+```
+{
+    "id" : "TASK_ID",
+    "link" : {"rel": "self", "href": "/kapacitor/v1/tasks/TASK_ID"}
+}
+```
+
 Modify only the dbrps of the task.
 
 ```
-POST /task/TASK_NAME
+PATCH /kapacitor/v1/tasks/TASK_ID
 {
     "dbrps": [{"db": "NEW_DATABASE_NAME", "rp" : "NEW_RP_NAME"}]
 }
@@ -76,38 +120,89 @@ POST /task/TASK_NAME
 
 >NOTE: Setting any DBRP will overwrite all stored DBRPs.
 
+
+Enable an existing task.
+
+```
+PATCH /kapacitor/v1/tasks/TASK_ID
+{
+    "enabled" : true,
+}
+```
+
+Disable an existing task.
+
+```
+PATCH /kapacitor/v1/tasks/TASK_ID
+{
+    "enabled" : false,
+}
+```
+
+Define a new task that is enabled on creation.
+
+```
+POST /kapacitor/v1/tasks/TASK_ID
+{
+    "type" : "stream",
+    "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+    "script": "stream\n    |from()\n        .measurement('cpu')\n"
+    "enabled" true,
+}
+```
+
+Response with task id and link.
+
+```
+{
+    "id" : "TASK_ID",
+    "link" : {"rel": "self", "href": "/kapacitor/v1/tasks/TASK_ID"}
+}
+```
+
 #### Response
 
-| Code | Meaning |
-| ---- | ------- |
-| 204  | Success |
-
+| Code | Meaning                                     |
+| ---- | -------                                     |
+| 200  | Success, contains id and link for new task. |
+| 204  | Success                                     |
+| 404  | Task does not exist                         |
 
 ### Get Task
 
-To get information about a task make a GET request to the `/task/TASK_NAME` endpoint.
+To get information about a task make a GET request to the `/kapacitor/v1/tasks/TASK_ID` endpoint.
 
-| Query Parameter | Default | Purpose                                                                                                                                                            |
-| --------------- | ------- | -------                                                                                                                                                            |
-| dot-labels      | false   | Return the DOT formatted string using only label attributes. This is useful if you intend to render a diagram from the DOT content. Otherwise it is less readable. |
-| skip-format     | false   | Do not format the TICKscript before returning.                                                                                                                     |
+| Query Parameter | Default    | Purpose                                                                                                                          |
+| --------------- | -------    | -------                                                                                                                          |
+| dot-view        | attributes | One of `labels` or `attributes`. Labels is less readable but will correctly render with all the information contained in labels. |
+| script-format   | formatted  | One of `formatted` or `raw`. Raw will return the script identical to how it was defined. Formatted will first format the script. |
 
+
+A task has these read only properties in addition to the properties listed [above](#define-task).
+
+| Property  | Description                                                                                                                     |
+| --------  | -----------                                                                                                                     |
+| dot       | [GraphViz DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) syntax formatted representation of the task DAG. |
+| executing | Whether the task is currently executing.                                                                                        |
+| error     | Any error encountered when executing the task.                                                                                  |
+| stats     | Map of statistics about a task.                                                                                                 |
 
 #### Example
 
 Get information about a task using defaults.
 
 ```
-GET /task/TASK_NAME
+GET /kapacitor/v1/tasks/TASK_ID
 ```
 
 ```
 {
-    "name" : "TASK_NAME",
+    "link" : {"rel": "self", "href": "/kapacitor/v1/tasks/TASK_ID"},
+    "id" : "TASK_ID",
     "type" : "stream",
     "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
     "script": "stream\n    |from()\n        .measurement('cpu')\n",
-    "dot" : "digraph TASK_NAME { ... }",
+    "dot" : "digraph TASK_ID { ... }",
     "enabled" : true,
     "executing" : true,
     "error" : "",
@@ -118,16 +213,17 @@ GET /task/TASK_NAME
 Get information about a task using only labels in the DOT content and skip the format step.
 
 ```
-GET /task/TASK_NAME?skip-format=true&dot-labels=true
+GET /kapacitor/v1/tasks/TASK_ID?dot-view=labels&script-format=raw
 ```
 
 ```
 {
-    "name" : "TASK_NAME",
+    "link" : {"rel": "self", "href": "/kapacitor/v1/tasks/TASK_ID"},
+    "id" : "TASK_ID",
     "type" : "stream",
     "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
     "script": "stream|from().measurement('cpu')",
-    "dot" : "digraph TASK_NAME { ... }",
+    "dot" : "digraph TASK_ID { ... }",
     "enabled" : true,
     "executing" : true,
     "error" : "",
@@ -143,48 +239,12 @@ GET /task/TASK_NAME?skip-format=true&dot-labels=true
 | 404  | Task does not exist |
 
 
-### Enable Task
-
-To enable a task and start it executing make a POST request to the `/task/TASK_NAME/enable` endpoint.
-
-
-#### Example
-
-```
-POST /task/TASK_NAME/enable
-```
-
-#### Response
-
-| Code | Meaning             |
-| ---- | -------             |
-| 204  | Success             |
-| 404  | Task does not exist |
-
-### Disable Task
-
-To disable a task and stop it executing make a POST request to the `/task/TASK_NAME/disable` endpoint.
-
-#### Example
-
-```
-POST /task/TASK_NAME/disable
-```
-
-#### Response
-
-| Code | Meaning             |
-| ---- | -------             |
-| 204  | Success             |
-| 404  | Task does not exist |
-
-
 ### Delete Task
 
-To delete a task make a DELETE request to the `/task/TASK_NAME` endpoint.
+To delete a task make a DELETE request to the `/kapacitor/v1/tasks/TASK_ID` endpoint.
 
 ```
-DELETE /task/TASK_NAME
+DELETE /kapacitor/v1/tasks/TASK_ID
 ```
 
 #### Response
@@ -198,37 +258,50 @@ DELETE /task/TASK_NAME
 
 ### List Tasks
 
-To get information about several tasks make a GET request to the `/task` endpoint.
+To get information about several tasks make a GET request to the `/kapacitor/v1/tasks` endpoint.
 
-| Query Parameter | Purpose                                                                                                                                           |
-| --------------- | -------                                                                                                                                           |
-| pattern         | Filter results based on the pattern. Uses standard shell glob matching, see [this](https://golang.org/pkg/path/filepath/#Match) for more details. |
+| Query Parameter | Default    | Purpose                                                                                                                                           |
+| --------------- | -------    | -------                                                                                                                                           |
+| pattern         |            | Filter results based on the pattern. Uses standard shell glob matching, see [this](https://golang.org/pkg/path/filepath/#Match) for more details. |
+| fields          |            | List of fields to return. If empty returns all fields. Fields `id` and `link` are always returned.                                              |
+| dot-view        | attributes | One of `labels` or `attributes`. Labels is less readable but will correctly render with all the information contained in labels.                  |
+| script-format   | formatted  | One of `formatted` or `raw`. Raw will return the script identical to how it was defined. Formatted will first format the script.                  |
+| offset          | 0          | Offset count for paginating through tasks.                                                                                                        |
+| limit           | 100        | Maximum number of tasks to return.                                                                                                                |
 
 #### Example
 
 Get all tasks.
 
 ```
-GET /task
+GET /kapacitor/v1/tasks
 ```
 
 ```
 {
     "tasks" : [
         {
-            "name" : "TASK_NAME",
+            "link" : "/kapacitor/v1/tasks/TASK_ID",
+            "id" : "TASK_ID",
             "type" : "stream",
             "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "script": "stream|from().measurement('cpu')",
+            "dot" : "digraph TASK_ID { ... }",
             "enabled" : true,
             "executing" : true,
+            "error" : "",
             "stats": {}
         },
         {
-            "name" : "ANOTHER_TASK_NAME",
-            "type" : "batch",
+            "link" : "/kapacitor/v1/tasks/ANOTHER_TASK_ID",
+            "id" : "ANOTHER_TASK_ID",
+            "type" : "stream",
             "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "script": "stream|from().measurement('cpu')",
+            "dot" : "digraph ANOTHER_TASK_ID{ ... }",
             "enabled" : true,
             "executing" : true,
+            "error" : "",
             "stats": {}
         }
     ]
@@ -238,19 +311,50 @@ GET /task
 Optionally specify a glob `pattern` to list only matching tasks.
 
 ```
-GET /task?pattern=TASK*
+GET /kapacitor/v1/task?pattern=TASK*
 ```
 
 ```
 {
     "tasks" : [
         {
-            "name" : "TASK_NAME",
+            "link" : "/kapacitor/v1/tasks/TASK_ID",
+            "id" : "TASK_ID",
             "type" : "stream",
             "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "script": "stream|from().measurement('cpu')",
+            "dot" : "digraph TASK_ID { ... }",
             "enabled" : true,
             "executing" : true,
+            "error" : "",
             "stats": {}
+        }
+    ]
+}
+```
+
+Get all tasks, but only the enabled, executing and error fields.
+
+```
+GET /kapacitor/v1/tasks?fields=enabled&fields=executing&fields=error
+```
+
+```
+{
+    "tasks" : [
+        {
+            "link" : "/kapacitor/v1/tasks/TASK_ID",
+            "id" : "TASK_ID",
+            "enabled" : true,
+            "executing" : true,
+            "error" : "",
+        },
+        {
+            "link" : "/kapacitor/v1/tasks/ANOTHER_TASK_ID",
+            "id" : "ANOTHER_TASK_ID",
+            "enabled" : true,
+            "executing" : true,
+            "error" : "",
         }
     ]
 }
@@ -261,7 +365,8 @@ GET /task?pattern=TASK*
 | Code | Meaning                |
 | ---- | -------                |
 | 200  | Success                |
-| 404  | No tasks match pattern |
+
+>NOTE: If the pattern does not match any tasks an empty list will be returned, with a 200 success.
 
 ## Replays and Recordings
 
@@ -269,17 +374,14 @@ Kapacitor can save recordings of data and replay them against a specified task.
 
 ### Start Recording
 
-To create a recording make a POST request to the `/recording` endpoint.
 There are three methods for recording data with Kapacitor:
+To create a recording make a POST request to the `/kapacitor/v1/recordings/METHOD` endpoint.
 
 | Method | Description                                        |
 | ------ | -----------                                        |
 | stream | Record the incoming stream of data.                |
 | batch  | Record the results of the queries in a batch task. |
 | query  | Record the result of an explicit query.            |
-
-All record POST requests must specify the parameter `method` with one of the above options.
-Each different `method` has it's own parameters.
 
 The request returns once the recording is started and does not wait for it to finish.
 A recording ID is returned to later identify the recording.
@@ -288,25 +390,22 @@ A recording ID is returned to later identify the recording.
 
 | Parameter | Purpose                                                             |
 | --------- | -------                                                             |
-| name      | Name of a task, used to only record data for the DBRPs of the task. |
-| duration  | Duration string indicating how long to record the stream.           |
+| task      | ID of a task, used to only record data for the DBRPs of the task. |
+| stop      | Record stream data until stop date.                                 |
 
 ##### Batch
 
 | Parameter | Purpose                                                                                                          |
 | --------- | -------                                                                                                          |
-| name      | Name of a task, records the results of the queries defined in the task.                                          |
+| task      | ID of a task, records the results of the queries defined in the task.                                            |
 | start     | Earliest date for which data will be recorded. RFC3339Nano formatted.                                            |
 | stop      | Latest date for which data will be recorded. If not specified uses the current time. RFC3339Nano formatted data. |
-| past      | Duration string indicating how far into the past to start recording data relative to the stop date.              |
-| cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster.                                    |
-
-Only one of `start` or `past` may be specified.
+| cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster.                                        |
 
 ##### Query
 
-| Parameter | Purpose                                                                       |
-| --------- | -------                                                                       |
+| Parameter | Purpose                                                                   |
+| --------- | -------                                                                   |
 | type      | Type of recording, `stream` or `batch`.                                   |
 | query     | Query to execute.                                                         |
 | cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster. |
@@ -320,43 +419,28 @@ Therefore when you record the result of a raw query you must specify the type re
 Create a recording using the `stream` method
 
 ```
-POST /recording
+POST /kapacitor/v1/recordings/stream
 {
-    "method" : "stream",
-    "name" : "TASK_NAME",
-    "duration" : "10m"
+    "task" : "TASK_ID",
+    "stop" : "2006-01-02T15:04:05Z07:00"
 }
 ```
-
 
 Create a recording using the `batch` method specifying a start time.
 
 ```
-POST /recording
+POST /kapacitor/v1/recordings/batch
 {
-    "method" : "batch",
-    "name" : "TASK_NAME",
+    "task" : "TASK_ID",
     "start" : "2006-01-02T15:04:05Z07:00"
-}
-```
-
-Create a recording using the `batch` method specifying a past duration.
-
-```
-POST /recording
-{
-    "method" : "batch",
-    "name" : "TASK_NAME",
-    "past" : "7d"
 }
 ```
 
 Create a recording using the `query` method specifying a `stream` type.
 
 ```
-POST /recording
+POST /kapacitor/v1/recordings/query
 {
-    "method" : "query",
     "query" : "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1h GROUP BY time(10m)",
     "type" : "stream"
 }
@@ -365,61 +449,97 @@ POST /recording
 Create a recording using the `query` method specifying a `batch` type.
 
 ```
-POST /recording
+POST /kapacitor/v1/recording/query
 {
-    "method" : "query",
     "query" : "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1h GROUP BY time(10m)",
     "type" : "batch"
 }
 ```
 
-
 #### Response
 
-All recordings are assigned an ID which is returned in this format.
+All recordings are assigned an ID which is returned in this format with a link.
 
 ```
 {
+    "link" : {"rel": "self", "href": "/kapacitor/v1/recordings/e24db07d-1646-4bb3-a445-828f5049bea0"},
     "id" : "e24db07d-1646-4bb3-a445-828f5049bea0"
 }
 ```
 
 | Code | Meaning                             |
 | ---- | -------                             |
-| 200  | Success, the recording has started. |
+| 201  | Success, the recording has started. |
 
 ### Wait for Recording
 
-In order to determine when a recording has finished you must request it by making a GET request to `/recording/RECORDING_ID`.
-A GET request for a recording will block until the recording is complete.
+In order to determine when a recording has finished you must make a GET request to the returned link typically something like `/kapacitor/v1/recordings/RECORDING_ID`.
 
-As a result it is typical to make a POST request to start a recording and then immediately GET it in order to report when it has finished.
+A recording has these read only properties.
+
+| Property | Description                                                                               |
+| -------- | -----------                                                                               |
+| id       | A unique identifier for the recording.                                                    |
+| type     | One of `stream` or `batch`. A recording cannot be replayed to a task of a different type. |
+| size     | Size of the recording on disk in bytes.                                                   |
+| date     | Date the recording finished.                                                              |
+| error    | Any error encountered when creating the recording.                                        |
+| status   | One of `running` or `finished`.                                                           |
+| progress | Number between 0 and 1 indicating the approximate progress of the recording.              |
+
 
 #### Example
 
 ```
-GET /recording/e24db07d-1646-4bb3-a445-828f5049bea0
+GET /kapacitor/v1/recordings/e24db07d-1646-4bb3-a445-828f5049bea0
 ```
 
 ```
 {
-    "id" : "e24db07d-1646-4bb3-a445-828f5049bea0"
+    "link" : {"rel": "self", "href": "/kapacitor/v1/recordings/e24db07d-1646-4bb3-a445-828f5049bea0"},
+    "id" : "e24db07d-1646-4bb3-a445-828f5049bea0",
+    "type" : "stream",
+    "size" : 1980353,
+    "date" : "2006-01-02T15:04:05Z07:00",
+    "error" : "",
+    "status" : "running",
+    "progress" : 0.75
+}
+```
+
+Once the recording is complete.
+
+```
+GET /kapacitor/v1/recordings/e24db07d-1646-4bb3-a445-828f5049bea0
+```
+
+```
+{
+    "link" : {"rel": "self", "href": "/kapacitor/v1/recordings/e24db07d-1646-4bb3-a445-828f5049bea0"},
+    "id" : "e24db07d-1646-4bb3-a445-828f5049bea0",
+    "type" : "stream",
+    "size" : 1980353,
+    "date" : "2006-01-02T15:04:05Z07:00",
+    "error" : "",
+    "status" : "finished",
+    "progress" : 1
 }
 ```
 
 #### Response
 
-| Code | Meaning                                   |
-| ---- | -------                                   |
-| 200  | Success if the recording was found.       |
-| 404  | No recording exists for the specified ID. |
+| Code | Meaning                                            |
+| ---- | -------                                            |
+| 200  | Success, the recording is finished.                |
+| 202  | Success, the recording exists but is not finished. |
+| 404  | No such recording exists.                          |
 
 ### Delete Recording
 
-To delete a recording make a DELETE request to the `/recording/RECORDING_ID` endpoint.
+To delete a recording make a DELETE request to the `/kapacitor/v1/recordings/RECORDING_ID` endpoint.
 
 ```
-DELETE /recording/RECORDING_ID
+DELETE /kapacitor/v1/recordings/RECORDING_ID
 ```
 
 #### Response
@@ -432,30 +552,42 @@ DELETE /recording/RECORDING_ID
 
 ### List Recordings
 
-To list all recordings make a GET request to the `/recording` endpoint.
+To list all recordings make a GET request to the `/kapacitor/v1/recordings` endpoint.
+Recordings are sorted by date.
+
+| Query Parameter | Default | Purpose                                    |
+| --------------- | ------- | -------                                    |
+| offset          | 0       | Offset count for paginating through tasks. |
+| limit           | 100     | Maximum number of tasks to return.         |
 
 #### Example
 
 ```
-GET /recording
+GET /kapacitor/v1/recordings
 ```
 
 ```
 {
     "recordings" : [
         {
+            "link" : {"rel": "self", "href": "/kapacitor/v1/recordings/e24db07d-1646-4bb3-a445-828f5049bea0"},
             "id" : "e24db07d-1646-4bb3-a445-828f5049bea0",
             "type" : "stream",
             "size" : 1980353,
-            "created" : "2006-01-02T15:04:05Z07:00",
-            "error" : ""
+            "date" : "2006-01-02T15:04:05Z07:00",
+            "error" : "",
+            "status" : "finished",
+            "progress" : 1
         },
         {
+            "link" : {"rel": "self", "href": "/kapacitor/v1/recordings/8a4c06c6-30fb-42f4-ac4a-808aa31278f6"},
             "id" : "8a4c06c6-30fb-42f4-ac4a-808aa31278f6",
             "type" : "batch",
             "size" : 216819562,
-            "created" : "2006-01-02T15:04:05Z07:00",
-            "error" : ""
+            "date" : "2006-01-02T15:04:05Z07:00",
+            "error" : "",
+            "status" : "finished",
+            "progress" : 1
         }
     ]
 }
@@ -468,34 +600,37 @@ GET /recording
 | 200  | Success |
 
 
-### Replay recording
+### Replay Recording
 
-To replay a recording make a POST request to `/recording/RECORDING_ID/replay`.
-When replaying a recording specify these options:
+To replay a recording make a POST request to `/kapacitor/v1/replays/`
 
-| Parameter      | Default | Purpose                                                                                                                                                                                                                                       |
-| ----------     | ------- | -------                                                                                                                                                                                                                                       |
-| name           |         | The recording will be replayed against this task.                                                                                                                                                                                             |
-| recording-time | false   | If true, use the times in the recording, otherwise adjust times relative to the current time.                                                                                                                                                 |
-| clock          | fast    | One of `fast`, `real`. If `real` wait for real time to pass corresponding with the time in the recordings. If `fast` replay data without delay. For example, if fast is `real` then a stream recording of duration 5m will take 5m to replay. |
+| Parameter      | Default | Purpose                                                                                                                                                                                                                                          |
+| ----------     | ------- | -------                                                                                                                                                                                                                                          |
+| id             |         | Unique identifier for the replay. If empty a random ID is chosen.                                                                                                                                                                                |
+| task           |         | ID of task.                                                                                                                                                                                                                                      |
+| recording      |         | ID of recording.                                                                                                                                                                                                                                 |
+| recording-time | false   | If true, use the times in the recording, otherwise adjust times relative to the current time.                                                                                                                                                    |
+| clock          | fast    | One of `fast` or `real`. If `real` wait for real time to pass corresponding with the time in the recordings. If `fast` replay data without delay. For example, if clock is `real` then a stream recording of duration 5m will take 5m to replay. |
 
 #### Example
 
 Replay a recording using default parameters.
 
 ```
-POST /recording/RECORDING_ID/replay
+POST /kapacitor/v1/replays/
 {
-    "name" : "TASK_NAME",
+    "task" : "TASK_ID",
+    "recording" : "RECORDING_ID"
 }
 ```
 
 Replay a recording in real-time mode and preserve recording times.
 
 ```
-POST /recording/RECORDING_ID/replay
+POST /kapacitor/v1/replays/
 {
-    "name" : "TASK_NAME",
+    "task" : "TASK_ID",
+    "recording" : "RECORDING_ID",
     "clock" : "real",
     "recording-time" : true,
 }
@@ -503,12 +638,113 @@ POST /recording/RECORDING_ID/replay
 
 #### Response
 
-The request blocks until the replay is complete.
+The request returns once the replay is started and provides a replay ID and link.
 
-| Code | Meaning                                                   |
-| ---- | -------                                                   |
-| 204  | Success                                                   |
-| 404  | No recording or task exists for the specified ID or name. |
+```
+{
+    "link" : {"rel": "self", "href": "/kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c"},
+    "id" : "ad95677b-096b-40c8-82a8-912706f41d4c",
+}
+```
+
+| Code | Meaning                                         |
+| ---- | -------                                         |
+| 201  | Success, replay has started.                    |
+| 404  | The specified task or recording does not exist. |
+
+### Waiting for a Replay
+
+Like recordings you make a GET request to the `/kapacitor/v1/replays/REPLAY_ID` endpoint to get the status of the replay.
+
+A replay has these read only properties in addition to the properties listed [above](#replay-recording).
+
+| Property | Description                                                               |
+| -------- | -----------                                                               |
+| status   | One of `running` or `finished`.                                           |
+| progress | Number between 0 and 1 indicating the approximate progress of the replay. |
+
+
+#### Example
+
+Get the status of a replay.
+
+```
+GET /kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c
+```
+
+```
+{
+    "link" : {"rel": "self", "href": "/kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c"},
+    "id" : "ad95677b-096b-40c8-82a8-912706f41d4c",
+    "task" : "TASK_ID",
+    "recording" : "RECORDING_ID",
+    "clock" : "fast",
+    "recording-time" : false,
+    "status" : "running",
+    "progress" : 0.57
+}
+```
+
+Once the replay is complete.
+
+```
+GET /kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c
+```
+
+```
+{
+    "link" : {"rel": "self", "href": "/kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c"},
+    "id" : "ad95677b-096b-40c8-82a8-912706f41d4c",
+    "task" : "TASK_ID",
+    "recording" : "RECORDING_ID",
+    "clock" : "fast",
+    "recording-time" : false,
+    "status" : "finished",
+    "progress" : 1
+}
+```
+
+### List Replays
+
+You can list replays for a given recording by making a GET request to `/kapacitor/v1/replays`.
+
+| Query Parameter | Default | Purpose                                    |
+| --------------- | ------- | -------                                    |
+| offset          | 0       | Offset count for paginating through tasks. |
+| limit           | 100     | Maximum number of tasks to return.         |
+
+#### Example
+
+```
+GET /kapacitor/v1/replays
+```
+
+```
+{
+    "replays" [
+        {
+            "link" : {"rel": "self", "href": "/kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c"},
+            "id" : "ad95677b-096b-40c8-82a8-912706f41d4c",
+            "task" : "TASK_ID",
+            "recording" : "RECORDING_ID",
+            "clock" : "fast",
+            "recording-time" : false,
+            "status" : "finished",
+            "progress" : 1
+        },
+        {
+            "link" : {"rel": "self", "href": "/kapacitor/v1/replays/be33f0a1-0272-4019-8662-c730706dac7d"},
+            "id" : "be33f0a1-0272-4019-8662-c730706dac7d",
+            "task" : "TASK_ID",
+            "recording" : "RECORDING_ID",
+            "clock" : "fast",
+            "recording-time" : false,
+            "status" : "finished",
+            "progress" : 1
+        }
+    ]
+}
+```
 
 
 ## Miscellaneous
@@ -524,7 +760,7 @@ Ping is a useful request if you simply need the verify the version of server you
 #### Example
 
 ```
-GET /ping
+GET /kapacitor/v1/ping
 ```
 
 #### Response
@@ -534,3 +770,13 @@ GET /ping
 | 204  | Success |
 
 
+### Debug Vars
+
+Kapacitor also exposes several statistics and information about its runtime.
+These can be accessed at the `/kapacitor/v1/debug/vars` endpoint.
+
+#### Example
+
+```
+GET /kapacitor/v1/debug/vars
+```

--- a/client/API.md
+++ b/client/API.md
@@ -1,0 +1,536 @@
+# Kapacitor API Reference Documentation
+
+Kapacitor provides an HTTP API on port 9092 by default.
+With the API you can control which tasks are executing, query status of tasks and manage recordings etc.
+
+Each section below defines the available API endpoints and there inputs and outputs.
+
+### Response Codes
+
+All requests can return these response codes:
+
+| HTTP Response Code | Meaning                                                                                                                                                             |
+| ------------------ | -------                                                                                                                                                             |
+| 200                | The request was a success the content is dependent on the request.                                                                                                  |
+| 204                | The request was a success and no content was returned.                                                                                                              |
+| 4xx                | Invalid request, refer to error for what it wrong with the request. Repeating the request will continue to return the same error.                                   |
+| 5xx                | The server was unable to process the request, refer to the error for a reason. Repeating the request may result in a success if the server issue has been resolved. |
+
+### Errors
+
+All requests can return JSON in the following format to provide more information about a failed request.
+
+```
+{
+    "error" : "error message"
+}
+```
+
+### Query Parameters vs JSON body
+
+To make using this API a consistent and easy experience we follow one simple rule for when extra information
+about a request is found in the query parameters of the URL or when they are part of the submitted JSON body.
+
+Query parameters are used only for GET requests and all POST requests expect parameters to be specified in the JSON body.
+
+## Tasks
+
+A task represents work for Kapacitor to perform.
+A task is defined by its name, type, TICKscript, and list of database retention policy pairs it is allowed to access.
+
+### Define Task
+
+To define a task POST to the `/task/TASK_NAME` endpoint.
+If no task exists it with that name it will be created.
+Otherwise the existing task will be updated with the provided information.
+
+Define a task using a JSON object with the following options:
+
+| Parameter | Purpose                                                                |
+| --------- | -------                                                                |
+| type      | The task type: `stream` or `batch`.                                    |
+| dbrps     | List of database retention policy pairs the task is allowed to access. |
+| script    | The content of the script.                                             |
+
+If any option is missing it will be left unmodified if the task already exists.
+
+#### Example
+
+```
+POST /task/TASK_NAME
+{
+    "type" : "stream",
+    "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+    "script": "stream\n    |from()\n        .measurement('cpu')\n"
+}
+```
+
+Modify only the dbrps of the task.
+
+```
+POST /task/TASK_NAME
+{
+    "dbrps": [{"db": "NEW_DATABASE_NAME", "rp" : "NEW_RP_NAME"}]
+}
+```
+
+>NOTE: Setting any DBRP will overwrite all stored DBRPs.
+
+#### Response
+
+| Code | Meaning |
+| ---- | ------- |
+| 204  | Success |
+
+
+### Get Task
+
+To get information about a task make a GET request to the `/task/TASK_NAME` endpoint.
+
+| Query Parameter | Default | Purpose                                                                                                                                                            |
+| --------------- | ------- | -------                                                                                                                                                            |
+| dot-labels      | false   | Return the DOT formatted string using only label attributes. This is useful if you intend to render a diagram from the DOT content. Otherwise it is less readable. |
+| skip-format     | false   | Do not format the TICKscript before returning.                                                                                                                     |
+
+
+#### Example
+
+Get information about a task using defaults.
+
+```
+GET /task/TASK_NAME
+```
+
+```
+{
+    "name" : "TASK_NAME",
+    "type" : "stream",
+    "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+    "script": "stream\n    |from()\n        .measurement('cpu')\n",
+    "dot" : "digraph TASK_NAME { ... }",
+    "enabled" : true,
+    "executing" : true,
+    "error" : "",
+    "stats": {}
+}
+```
+
+Get information about a task using only labels in the DOT content and skip the format step.
+
+```
+GET /task/TASK_NAME?skip-format=true&dot-labels=true
+```
+
+```
+{
+    "name" : "TASK_NAME",
+    "type" : "stream",
+    "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+    "script": "stream|from().measurement('cpu')",
+    "dot" : "digraph TASK_NAME { ... }",
+    "enabled" : true,
+    "executing" : true,
+    "error" : "",
+    "stats": {}
+}
+```
+
+#### Response
+
+| Code | Meaning             |
+| ---- | -------             |
+| 200  | Success             |
+| 404  | Task does not exist |
+
+
+### Enable Task
+
+To enable a task and start it executing make a POST request to the `/task/TASK_NAME/enable` endpoint.
+
+
+#### Example
+
+```
+POST /task/TASK_NAME/enable
+```
+
+#### Response
+
+| Code | Meaning             |
+| ---- | -------             |
+| 204  | Success             |
+| 404  | Task does not exist |
+
+### Disable Task
+
+To disable a task and stop it executing make a POST request to the `/task/TASK_NAME/disable` endpoint.
+
+#### Example
+
+```
+POST /task/TASK_NAME/disable
+```
+
+#### Response
+
+| Code | Meaning             |
+| ---- | -------             |
+| 204  | Success             |
+| 404  | Task does not exist |
+
+
+### Delete Task
+
+To delete a task make a DELETE request to the `/task/TASK_NAME` endpoint.
+
+```
+DELETE /task/TASK_NAME
+```
+
+#### Response
+
+| Code | Meaning             |
+| ---- | -------             |
+| 204  | Success             |
+
+>NOTE: Deleting a non-existent task is not an error and will return a 204 success.
+
+
+### List Tasks
+
+To get information about several tasks make a GET request to the `/task` endpoint.
+
+| Query Parameter | Purpose                                                                                                                                           |
+| --------------- | -------                                                                                                                                           |
+| pattern         | Filter results based on the pattern. Uses standard shell glob matching, see [this](https://golang.org/pkg/path/filepath/#Match) for more details. |
+
+#### Example
+
+Get all tasks.
+
+```
+GET /task
+```
+
+```
+{
+    "tasks" : [
+        {
+            "name" : "TASK_NAME",
+            "type" : "stream",
+            "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "enabled" : true,
+            "executing" : true,
+            "stats": {}
+        },
+        {
+            "name" : "ANOTHER_TASK_NAME",
+            "type" : "batch",
+            "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "enabled" : true,
+            "executing" : true,
+            "stats": {}
+        }
+    ]
+}
+```
+
+Optionally specify a glob `pattern` to list only matching tasks.
+
+```
+GET /task?pattern=TASK*
+```
+
+```
+{
+    "tasks" : [
+        {
+            "name" : "TASK_NAME",
+            "type" : "stream",
+            "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "enabled" : true,
+            "executing" : true,
+            "stats": {}
+        }
+    ]
+}
+```
+
+#### Response
+
+| Code | Meaning                |
+| ---- | -------                |
+| 200  | Success                |
+| 404  | No tasks match pattern |
+
+## Replays and Recordings
+
+Kapacitor can save recordings of data and replay them against a specified task.
+
+### Start Recording
+
+To create a recording make a POST request to the `/recording` endpoint.
+There are three methods for recording data with Kapacitor:
+
+| Method | Description                                        |
+| ------ | -----------                                        |
+| stream | Record the incoming stream of data.                |
+| batch  | Record the results of the queries in a batch task. |
+| query  | Record the result of an explicit query.            |
+
+All record POST requests must specify the parameter `method` with one of the above options.
+Each different `method` has it's own parameters.
+
+The request returns once the recording is started and does not wait for it to finish.
+A recording ID is returned to later identify the recording.
+
+##### Stream
+
+| Parameter | Purpose                                                             |
+| --------- | -------                                                             |
+| name      | Name of a task, used to only record data for the DBRPs of the task. |
+| duration  | Duration string indicating how long to record the stream.           |
+
+##### Batch
+
+| Parameter | Purpose                                                                                                          |
+| --------- | -------                                                                                                          |
+| name      | Name of a task, records the results of the queries defined in the task.                                          |
+| start     | Earliest date for which data will be recorded. RFC3339Nano formatted.                                            |
+| stop      | Latest date for which data will be recorded. If not specified uses the current time. RFC3339Nano formatted data. |
+| past      | Duration string indicating how far into the past to start recording data relative to the stop date.              |
+| cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster.                                    |
+
+Only one of `start` or `past` may be specified.
+
+##### Query
+
+| Parameter | Purpose                                                                       |
+| --------- | -------                                                                       |
+| type      | Type of recording, `stream` or `batch`.                                   |
+| query     | Query to execute.                                                         |
+| cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster. |
+
+>NOTE: A recording itself is typed as either a stream or batch recording and can only be replayed to a task of a corresponding type.
+Therefore when you record the result of a raw query you must specify the type recording you wish to create.
+
+
+#### Example
+
+Create a recording using the `stream` method
+
+```
+POST /recording
+{
+    "method" : "stream",
+    "name" : "TASK_NAME",
+    "duration" : "10m"
+}
+```
+
+
+Create a recording using the `batch` method specifying a start time.
+
+```
+POST /recording
+{
+    "method" : "batch",
+    "name" : "TASK_NAME",
+    "start" : "2006-01-02T15:04:05Z07:00"
+}
+```
+
+Create a recording using the `batch` method specifying a past duration.
+
+```
+POST /recording
+{
+    "method" : "batch",
+    "name" : "TASK_NAME",
+    "past" : "7d"
+}
+```
+
+Create a recording using the `query` method specifying a `stream` type.
+
+```
+POST /recording
+{
+    "method" : "query",
+    "query" : "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1h GROUP BY time(10m)",
+    "type" : "stream"
+}
+```
+
+Create a recording using the `query` method specifying a `batch` type.
+
+```
+POST /recording
+{
+    "method" : "query",
+    "query" : "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1h GROUP BY time(10m)",
+    "type" : "batch"
+}
+```
+
+
+#### Response
+
+All recordings are assigned an ID which is returned in this format.
+
+```
+{
+    "id" : "e24db07d-1646-4bb3-a445-828f5049bea0"
+}
+```
+
+| Code | Meaning                             |
+| ---- | -------                             |
+| 200  | Success, the recording has started. |
+
+### Wait for Recording
+
+In order to determine when a recording has finished you must request it by making a GET request to `/recording/RECORDING_ID`.
+A GET request for a recording will block until the recording is complete.
+
+As a result it is typical to make a POST request to start a recording and then immediately GET it in order to report when it has finished.
+
+#### Example
+
+```
+GET /recording/e24db07d-1646-4bb3-a445-828f5049bea0
+```
+
+```
+{
+    "id" : "e24db07d-1646-4bb3-a445-828f5049bea0"
+}
+```
+
+#### Response
+
+| Code | Meaning                                   |
+| ---- | -------                                   |
+| 200  | Success if the recording was found.       |
+| 404  | No recording exists for the specified ID. |
+
+### Delete Recording
+
+To delete a recording make a DELETE request to the `/recording/RECORDING_ID` endpoint.
+
+```
+DELETE /recording/RECORDING_ID
+```
+
+#### Response
+
+| Code | Meaning             |
+| ---- | -------             |
+| 204  | Success             |
+
+>NOTE: Deleting a non-existent recording is not an error and will return a 204 success.
+
+### List Recordings
+
+To list all recordings make a GET request to the `/recording` endpoint.
+
+#### Example
+
+```
+GET /recording
+```
+
+```
+{
+    "recordings" : [
+        {
+            "id" : "e24db07d-1646-4bb3-a445-828f5049bea0",
+            "type" : "stream",
+            "size" : 1980353,
+            "created" : "2006-01-02T15:04:05Z07:00",
+            "error" : ""
+        },
+        {
+            "id" : "8a4c06c6-30fb-42f4-ac4a-808aa31278f6",
+            "type" : "batch",
+            "size" : 216819562,
+            "created" : "2006-01-02T15:04:05Z07:00",
+            "error" : ""
+        }
+    ]
+}
+```
+
+#### Response
+
+| Code | Meaning |
+| ---- | ------- |
+| 200  | Success |
+
+
+### Replay recording
+
+To replay a recording make a POST request to `/recording/RECORDING_ID/replay`.
+When replaying a recording specify these options:
+
+| Parameter      | Default | Purpose                                                                                                                                                                                                                                       |
+| ----------     | ------- | -------                                                                                                                                                                                                                                       |
+| name           |         | The recording will be replayed against this task.                                                                                                                                                                                             |
+| recording-time | false   | If true, use the times in the recording, otherwise adjust times relative to the current time.                                                                                                                                                 |
+| clock          | fast    | One of `fast`, `real`. If `real` wait for real time to pass corresponding with the time in the recordings. If `fast` replay data without delay. For example, if fast is `real` then a stream recording of duration 5m will take 5m to replay. |
+
+#### Example
+
+Replay a recording using default parameters.
+
+```
+POST /recording/RECORDING_ID/replay
+{
+    "name" : "TASK_NAME",
+}
+```
+
+Replay a recording in real-time mode and preserve recording times.
+
+```
+POST /recording/RECORDING_ID/replay
+{
+    "name" : "TASK_NAME",
+    "clock" : "real",
+    "recording-time" : true,
+}
+```
+
+#### Response
+
+The request blocks until the replay is complete.
+
+| Code | Meaning                                                   |
+| ---- | -------                                                   |
+| 204  | Success                                                   |
+| 404  | No recording or task exists for the specified ID or name. |
+
+
+## Miscellaneous
+
+### Ping
+
+You can 'ping' the Kapacitor server to validate you have a successful connection.
+A ping request does nothing but respond with a 204.
+
+>NOTE: The Kapacitor server version is returned in the `X-Kapacitor-Version` HTTP header on all requests.
+Ping is a useful request if you simply need the verify the version of server you are talking to.
+
+#### Example
+
+```
+GET /ping
+```
+
+#### Response
+
+| Code | Meaning |
+| ---- | ------- |
+| 204  | Success |
+
+

--- a/client/API.md
+++ b/client/API.md
@@ -78,11 +78,11 @@ Define a task using a JSON object with the following options:
 
 | Property | Purpose                                                                |
 | -------- | -------                                                                |
-| id       | Unique identifier for the task. If empty a random ID will be chosen. |
+| id       | Unique identifier for the task. If empty a random ID will be chosen.   |
 | type     | The task type: `stream` or `batch`.                                    |
 | dbrps    | List of database retention policy pairs the task is allowed to access. |
 | script   | The content of the script.                                             |
-| enabled  | Whether the task is enabled or disabled.                               |
+| status   | One of `enabled` or `disabled`.                                        |
 
 When using PATCH, if any option is missing it will be left unmodified.
 
@@ -126,7 +126,7 @@ Enable an existing task.
 ```
 PATCH /kapacitor/v1/tasks/TASK_ID
 {
-    "enabled" : true,
+    "status" : "enabled",
 }
 ```
 
@@ -135,7 +135,7 @@ Disable an existing task.
 ```
 PATCH /kapacitor/v1/tasks/TASK_ID
 {
-    "enabled" : false,
+    "status" : "disabled",
 }
 ```
 
@@ -145,9 +145,9 @@ Define a new task that is enabled on creation.
 POST /kapacitor/v1/tasks/TASK_ID
 {
     "type" : "stream",
-    "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
-    "script": "stream\n    |from()\n        .measurement('cpu')\n"
-    "enabled" true,
+    "dbrps" : [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+    "script" : "stream\n    |from()\n        .measurement('cpu')\n",
+    "status" : "enabled"
 }
 ```
 
@@ -200,13 +200,13 @@ GET /kapacitor/v1/tasks/TASK_ID
     "link" : {"rel": "self", "href": "/kapacitor/v1/tasks/TASK_ID"},
     "id" : "TASK_ID",
     "type" : "stream",
-    "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
-    "script": "stream\n    |from()\n        .measurement('cpu')\n",
+    "dbrps" : [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+    "script" : "stream\n    |from()\n        .measurement('cpu')\n",
     "dot" : "digraph TASK_ID { ... }",
-    "enabled" : true,
+    "status" : "enabled",
     "executing" : true,
     "error" : "",
-    "stats": {}
+    "stats" : {}
 }
 ```
 
@@ -221,13 +221,13 @@ GET /kapacitor/v1/tasks/TASK_ID?dot-view=labels&script-format=raw
     "link" : {"rel": "self", "href": "/kapacitor/v1/tasks/TASK_ID"},
     "id" : "TASK_ID",
     "type" : "stream",
-    "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
-    "script": "stream|from().measurement('cpu')",
+    "dbrps" : [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+    "script" : "stream|from().measurement('cpu')",
     "dot" : "digraph TASK_ID { ... }",
-    "enabled" : true,
+    "status" : "enabled",
     "executing" : true,
     "error" : "",
-    "stats": {}
+    "stats" : {}
 }
 ```
 
@@ -284,25 +284,25 @@ GET /kapacitor/v1/tasks
             "link" : "/kapacitor/v1/tasks/TASK_ID",
             "id" : "TASK_ID",
             "type" : "stream",
-            "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
-            "script": "stream|from().measurement('cpu')",
+            "dbrps" : [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "script" : "stream|from().measurement('cpu')",
             "dot" : "digraph TASK_ID { ... }",
-            "enabled" : true,
+            "status" : "enabled",
             "executing" : true,
             "error" : "",
-            "stats": {}
+            "stats" : {}
         },
         {
             "link" : "/kapacitor/v1/tasks/ANOTHER_TASK_ID",
             "id" : "ANOTHER_TASK_ID",
             "type" : "stream",
-            "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
-            "script": "stream|from().measurement('cpu')",
+            "dbrps" : [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "script" : "stream|from().measurement('cpu')",
             "dot" : "digraph ANOTHER_TASK_ID{ ... }",
-            "enabled" : true,
+            "status" : "disabled",
             "executing" : true,
             "error" : "",
-            "stats": {}
+            "stats" : {}
         }
     ]
 }
@@ -321,22 +321,22 @@ GET /kapacitor/v1/task?pattern=TASK*
             "link" : "/kapacitor/v1/tasks/TASK_ID",
             "id" : "TASK_ID",
             "type" : "stream",
-            "dbrps": [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
-            "script": "stream|from().measurement('cpu')",
+            "dbrps" : [{"db": "DATABASE_NAME", "rp" : "RP_NAME"}],
+            "script" : "stream|from().measurement('cpu')",
             "dot" : "digraph TASK_ID { ... }",
-            "enabled" : true,
+            "status" : "enabled:,
             "executing" : true,
             "error" : "",
-            "stats": {}
+            "stats" : {}
         }
     ]
 }
 ```
 
-Get all tasks, but only the enabled, executing and error fields.
+Get all tasks, but only the status, executing and error fields.
 
 ```
-GET /kapacitor/v1/tasks?fields=enabled&fields=executing&fields=error
+GET /kapacitor/v1/tasks?fields=status&fields=executing&fields=error
 ```
 
 ```
@@ -345,14 +345,14 @@ GET /kapacitor/v1/tasks?fields=enabled&fields=executing&fields=error
         {
             "link" : "/kapacitor/v1/tasks/TASK_ID",
             "id" : "TASK_ID",
-            "enabled" : true,
+            "status" : "enabled",
             "executing" : true,
             "error" : "",
         },
         {
             "link" : "/kapacitor/v1/tasks/ANOTHER_TASK_ID",
             "id" : "ANOTHER_TASK_ID",
-            "enabled" : true,
+            "status" : "disabled",
             "executing" : true,
             "error" : "",
         }

--- a/client/API.md
+++ b/client/API.md
@@ -165,7 +165,6 @@ Response with task id and link.
 | Code | Meaning                                     |
 | ---- | -------                                     |
 | 200  | Success, contains id and link for new task. |
-| 204  | Success                                     |
 | 404  | Task does not exist                         |
 
 ### Get Task
@@ -368,7 +367,7 @@ GET /kapacitor/v1/tasks?fields=status&fields=executing&fields=error
 
 >NOTE: If the pattern does not match any tasks an empty list will be returned, with a 200 success.
 
-## Replays and Recordings
+## Recordings
 
 Kapacitor can save recordings of data and replay them against a specified task.
 
@@ -498,7 +497,7 @@ A recording has these read only properties.
 | size     | Size of the recording on disk in bytes.                                                   |
 | date     | Date the recording finished.                                                              |
 | error    | Any error encountered when creating the recording.                                        |
-| status   | One of `running` or `finished`.                                                           |
+| status   | One of `recording` or `finished`.                                                           |
 | progress | Number between 0 and 1 indicating the approximate progress of the recording.              |
 
 
@@ -614,7 +613,9 @@ GET /kapacitor/v1/recordings
 | 200  | Success |
 
 
-### Replay Recording
+## Replays
+
+### Replaying a recording
 
 To replay a recording make a POST request to `/kapacitor/v1/replays/`
 
@@ -686,8 +687,9 @@ A replay has these read only properties in addition to the properties listed [ab
 
 | Property | Description                                                               |
 | -------- | -----------                                                               |
-| status   | One of `running` or `finished`.                                           |
+| status   | One of `replaying` or `finished`.                                           |
 | progress | Number between 0 and 1 indicating the approximate progress of the replay. |
+| error    | Any error that occured while perfoming the replay                         |
 
 
 #### Example
@@ -707,7 +709,8 @@ GET /kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c
     "clock" : "fast",
     "recording-time" : false,
     "status" : "running",
-    "progress" : 0.57
+    "progress" : 0.57,
+    "error" : ""
 }
 ```
 
@@ -726,7 +729,8 @@ GET /kapacitor/v1/replays/ad95677b-096b-40c8-82a8-912706f41d4c
     "clock" : "fast",
     "recording-time" : false,
     "status" : "finished",
-    "progress" : 1
+    "progress" : 1,
+    "error" : ""
 }
 ```
 
@@ -756,7 +760,8 @@ GET /kapacitor/v1/replays
             "clock" : "fast",
             "recording-time" : false,
             "status" : "finished",
-            "progress" : 1
+            "progress" : 1,
+            "error" : ""
         },
         {
             "link" : {"rel": "self", "href": "/kapacitor/v1/replays/be33f0a1-0272-4019-8662-c730706dac7d"},
@@ -766,7 +771,8 @@ GET /kapacitor/v1/replays
             "clock" : "fast",
             "recording-time" : false,
             "status" : "finished",
-            "progress" : 1
+            "progress" : 1,
+            "error" : ""
         }
     ]
 }

--- a/client/v1/swagger.yml
+++ b/client/v1/swagger.yml
@@ -1,0 +1,592 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Kapacitor
+  description: >
+    Kapacitor, open source data processing engine.
+    Part of the TICK stack http://influxdata.com
+basePath: /kapacitor/v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /tasks:
+    get:
+      summary: Get information on all tasks
+      tags: [tasks]
+      operationId: listTasks
+      parameters:
+        - name: pattern
+          in: query
+          description: Glob style pattern to match task IDs
+          required: false
+          type: string
+        - name: fields
+          in: query
+          description: List of fields to return
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+        - name: dot-view
+          in: query
+          description: One of `labels` or `attributes`. Labels is less readable but will correctly render with all the information contained in labels.
+          required: true
+          type: string
+          pattern: (attributes|labels)
+        - name: script-format
+          in: query
+          description: One of `formatted` or `raw`. Raw will return the script identical to how it was defined. Formatted will first format the script.
+          required: true
+          type: string
+          pattern: (formatted|raw)
+        - name: offset
+          in: query
+          description: Offset count for paginating through tasks.
+          type: integer
+          format: int32
+          required: false
+          default: 0
+        - name: limit
+          in: query
+          description: Maximum number of tasks to return.
+          type: integer
+          format: int32
+          required: false
+          default: 20
+      responses:
+        '200':
+          description: List of tasks
+          schema:
+            $ref: '#/definitions/Tasks'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a new task
+      tags: [tasks]
+      operationId: createTask
+      parameters:
+        - name: task
+          in: body
+          schema:
+            $ref: '#/definitions/Task'
+      responses:
+        '200':
+          description: Task ID
+          schema:
+            $ref: '#/definitions/Task'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /tasks/{id}:
+    patch:
+      summary: Update an existing task
+      tags: [tasks]
+      operationId: updateTask
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+        - name: task
+          in: body
+          schema:
+            $ref: '#/definitions/Task'
+      responses:
+        '200':
+          description: Task ID
+          schema:
+            $ref: '#/definitions/Task'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete an existing task
+      tags: [tasks]
+      operationId: deleteTask
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+      responses:
+        '204':
+          description: Task deleted
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+    get:
+      summary: Get an existing task
+      tags: [tasks]
+      operationId: task
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+        - name: dot-view
+          in: query
+          description: One of `labels` or `attributes`. Labels is less readable but will correctly render with all the information contained in labels.
+          required: true
+          type: string
+          pattern: (attributes|labels)
+        - name: script-format
+          in: query
+          description: One of `formatted` or `raw`. Raw will return the script identical to how it was defined. Formatted will first format the script.
+          required: true
+          type: string
+          pattern: (formatted|raw)
+      responses:
+        '200':
+          description: Task information
+          schema:
+            $ref: '#/definitions/Task'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /recordings:
+    get:
+      summary: Get information on all recordings
+      tags: [recordings]
+      operationId: listRecordings
+      parameters:
+        - name: pattern
+          in: query
+          description: Glob style pattern to match recording IDs
+          required: false
+          type: string
+        - name: fields
+          in: query
+          description: List of fields to return
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+        - name: offset
+          in: query
+          description: Offset count for paginating through recordings.
+          type: integer
+          format: int32
+          required: false
+          default: 0
+        - name: limit
+          in: query
+          description: Maximum number of recordings to return.
+          type: integer
+          format: int32
+          required: false
+          default: 20
+      responses:
+        '200':
+          description: List of recordings
+          schema:
+            $ref: '#/definitions/Recordings'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /recordings/stream:
+    post:
+      summary: Create a new stream recording
+      tags: [recordings]
+      operationId: recordStream
+      parameters:
+        - name: id
+          in: body
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Recording ID
+              task:
+                type: string
+                description: ID of task
+              stop:
+                type: string
+                format: dateTime
+            required:
+              - task
+              - stop
+      responses:
+        '200':
+          description: Recording ID
+          schema:
+            $ref: '#/definitions/Recording'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /recordings/batch:
+    post:
+      summary: Create a new batch recording
+      tags: [recordings]
+      operationId: recordBatch
+      parameters:
+        - name: id
+          in: body
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Recording ID
+              task:
+                type: string
+                description: ID of task
+              start:
+                type: string
+                format: dateTime
+              stop:
+                type: string
+                format: dateTime
+              cluster:
+                type: string
+            required:
+              - task
+              - start
+      responses:
+        '200':
+          description: Recording ID
+          schema:
+            $ref: '#/definitions/Recording'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /recordings/query:
+    post:
+      summary: Create a new recording from an arbitrary InfluxQL query
+      tags: [recordings]
+      operationId: recordQuery
+      parameters:
+        - name: id
+          in: body
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Recording ID
+              type:
+                type: string
+                description: Type of recording to save
+                pattern: (stream|batch)
+              query:
+                type: string
+              cluster:
+                type: string
+            required:
+              - type
+              - query
+      responses:
+        '200':
+          description: Recording ID
+          schema:
+            $ref: '#/definitions/Recording'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /recordings/{id}:
+    delete:
+      summary: Delete an existing recording
+      tags: [recordings]
+      operationId: deleteRecording
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+      responses:
+        '204':
+          description: Recording deleted
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+    get:
+      summary: Get an existing recording
+      tags: [recordings]
+      operationId: recording
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+      responses:
+        '200':
+          description: Recording information
+          schema:
+            $ref: '#/definitions/Recording'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /replays:
+    get:
+      summary: Get information on all replays
+      tags: [replays]
+      operationId: listReplays
+      parameters:
+        - name: pattern
+          in: query
+          description: Glob style pattern to match replay IDs
+          required: false
+          type: string
+        - name: fields
+          in: query
+          description: List of fields to return
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+        - name: offset
+          in: query
+          description: Offset count for paginating through replays.
+          type: integer
+          format: int32
+          required: false
+          default: 0
+        - name: limit
+          in: query
+          description: Maximum number of replays to return.
+          type: integer
+          format: int32
+          required: false
+          default: 20
+      responses:
+        '200':
+          description: List of replays
+          schema:
+            $ref: '#/definitions/Replays'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a new replay
+      tags: [replays]
+      operationId: createReplay
+      parameters:
+        - name: id
+          in: body
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Replay ID
+              task:
+                type: string
+                description: ID of task
+              recording:
+                type: string
+                description: ID of recording
+              recording-time:
+                type: boolean
+                default: false
+              clock:
+                type: string
+                pattern: (fast|real)
+                default: fast
+            required:
+              - task
+              - recording
+      responses:
+        '200':
+          description: Replay ID
+          schema:
+            $ref: '#/definitions/Replay'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /replays/{id}:
+    delete:
+      summary: Delete an existing replay
+      tags: [replays]
+      operationId: deleteReplay
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+      responses:
+        '204':
+          description: Replay deleted
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+    get:
+      summary: Get an existing replay
+      tags: [replays]
+      operationId: replay
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+      responses:
+        '200':
+          description: Task information
+          schema:
+            $ref: '#/definitions/Replay'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
+
+definitions:
+  DBRP:
+    type: object
+    description: Database retention policy pair
+    properties:
+      db:
+        description: Database name
+        type: string
+      rp:
+        description: Retention policy
+        type: string
+    required: [db, rp]
+  Task:
+    type: object
+    description: A task
+    properties:
+      id:
+        description: Task ID
+        type: string
+      type:
+        description: Task type, one of 'stream' or 'batch'
+        type: string
+      dbrps:
+        description: List of database retention policy pairs
+        type: array
+        items:
+          $ref: '#/definitions/DBRP'
+      script:
+        description: TICKscript content
+        type: string
+      status:
+        description: Enabled/Disabled status of the task
+        type: string
+        pattern: (enabled|disabled)
+      dot:
+        description: Graphviz DOT syntax representation of the task DAG
+        type: string
+        readOnly: true
+      executing:
+        description: Whether the task is currently executing
+        type: boolean
+        readOnly: true
+      error:
+        description: Any error the task may have encountered while executing
+        readOnly: true
+      stats:
+        type: object
+        description: Statisitcs about the task execution
+        readOnly: true
+        properties:
+          task-stats:
+            type: object
+            description: Map of stat name to value
+            additionalProperties:
+              type: number
+          node-stats:
+            type: object
+            description: Map of node name to node stat map
+            additionalProperties:
+              type: object
+              description: Map of stat name to value
+              additionalProperties:
+                type: number
+  Tasks:
+    type: object
+    description: List of tasks
+    properties:
+      tasks:
+        type: array
+        items:
+          $ref: "#/definitions/Task"
+  Recording:
+    type: object
+    properties:
+      id:
+        type: string
+      type:
+        type: string
+      date:
+        type: string
+        format: dateTime
+      error:
+        type: string
+      status:
+        type: string
+        pattern: (recording|finished)
+      progress:
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+  Recordings:
+    type: object
+    description: List of recordings
+    properties:
+      tasks:
+        type: array
+        items:
+          $ref: "#/definitions/Recordings"
+  Replay:
+    type: object
+    properties:
+      id:
+        type: string
+      task:
+        type: string
+      recording:
+        type: string
+      recording-time:
+        type: boolean
+      clock:
+        type: string
+      error:
+        type: string
+      status:
+        type: string
+        pattern: (replaying|finished)
+      progress:
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+  Replays:
+    type: object
+    description: List of replays
+    properties:
+      tasks:
+        type: array
+        items:
+          $ref: "#/definitions/Replay"
+  Error:
+    type: object
+    description: Generic error object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+        description: Detailed description of an error
+    required: [code, message]

--- a/client/v1/swagger.yml
+++ b/client/v1/swagger.yml
@@ -467,6 +467,8 @@ definitions:
     type: object
     description: A task
     properties:
+      link:
+        $ref: '#/definitions/Link'
       id:
         description: Task ID
         type: string
@@ -525,6 +527,8 @@ definitions:
   Recording:
     type: object
     properties:
+      link:
+        $ref: '#/definitions/Link'
       id:
         type: string
       type:
@@ -552,6 +556,8 @@ definitions:
   Replay:
     type: object
     properties:
+      link:
+        $ref: '#/definitions/Link'
       id:
         type: string
       task:
@@ -582,11 +588,20 @@ definitions:
   Error:
     type: object
     description: Generic error object
+    readOnly: true
     properties:
-      code:
-        type: integer
-        format: int32
-      message:
+      error:
         type: string
         description: Detailed description of an error
-    required: [code, message]
+  Link:
+    type: object
+    readOnly: true
+    description: URI of resource.
+    properties:
+      rel:
+        type: string
+      href:
+        type: string
+        format: url
+    required: [rel, href]
+


### PR DESCRIPTION
Up until this point the Kapacitor HTTP API has been "implemented" rather than "designed". This PR presents an API "design" in the form of documentation, in preparation for locking down the API to a more supportable long lived API.

Currently the existing API has some inconsistencies and odd usage patterns. This doc attempts to unify and simplify using the API. It makes the API more RESTful and consistent with itself.

For the most part only small changes where made to the existing API. For example when query parameters vs JSON structures vs path elements are used is clear and consistent. Parameter names and top level keys in JSON structures all use lower case names. 

This represents  a breaking change to the API. It is intended that once we settle on this API design that it will not need any further changes before it becomes a stable locked down 1.0 version.

This PR only documents the proposed behavior of the API but does not implement any of the changes. Once accepted another PR will finalize the implementation.


Some notable usage changes from the existing workflow.

* Task pattern matching is only supported on the `list task` requests. To enable/disable multiple tasks matching a pattern one must first list matching tasks and then make the appropriate request for each returned task. This simplifies using the API since each task has a unique path and only modified via that path. If this is not going to work for some's use case please comment and we can work on a consistent solution, but I defaulted for simplicity in this case.
* No more plural path names like `/tasks` or `/recordings` since the lack of a child path indicates you want all to interact with all entities.

