### PR TITLE
add duration to alert data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ For example, let's say we want to store all data that triggered an alert in Infl
 - [#384](https://github.com/influxdata/kapacitor/issues/384): Add `elapsed` function to compute the time difference between subsequent points.
 - [#230](https://github.com/influxdata/kapacitor/issues/230): Alert.StateChangesOnly now accepts optional duration arg. An alert will be triggered for every interval even if the state has not changed.
 - [#426](https://github.com/influxdata/kapacitor/issues/426): Add `skip-format` query parameter to the `GET /task` endpoint so that returned TICKscript content is left unmodified from the user input.
+- [#388](https://github.com/influxdata/kapacitor/issues/388): The duration of an alert is now tracked and exposed as part of the alert data as well as can be set as a field via `.durationField('duration')`.
 
 
 ### Bugfixes

--- a/integrations/data/TestStream_AlertDuration.srpl
+++ b/integrations/data/TestStream_AlertDuration.srpl
@@ -1,0 +1,36 @@
+dbname
+rpname
+cpu,type=idle,host=serverA value=9 0000000001
+dbname
+rpname
+cpu,type=idle,host=serverA value=9 0000000002
+dbname
+rpname
+cpu,type=idle,host=serverA value=8 0000000003
+dbname
+rpname
+cpu,type=idle,host=serverA value=8 0000000004
+dbname
+rpname
+cpu,type=idle,host=serverA value=6 0000000005
+dbname
+rpname
+cpu,type=idle,host=serverA value=8 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverA value=8 0000000007
+dbname
+rpname
+cpu,type=idle,host=serverA value=8 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverA value=3 0000000009
+dbname
+rpname
+cpu,type=idle,host=serverA value=5 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverA value=7 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverA value=7 0000000012

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -54,6 +54,7 @@ const defaultLogFileMode = 0600
 //    * Message -- the alert message, user defined.
 //    * Details -- the alert details, user defined HTML content.
 //    * Time -- the time the alert occurred.
+//    * Duration -- the duration of the alert in nanoseconds.
 //    * Level -- one of OK, INFO, WARNING or CRITICAL.
 //    * Data -- influxql.Result containing the data that triggered the alert.
 //
@@ -214,6 +215,10 @@ type AlertNode struct {
 	LevelTag string
 	// Optional field key to add to the data, containing the alert level as a string.
 	LevelField string
+
+	// Optional field key to add the alert duration to the data.
+	// The duration is always in units of nanoseconds.
+	DurationField string
 
 	// Optional tag key to use when tagging the data with the alert ID.
 	IdTag string


### PR DESCRIPTION
Fixes #388 Adds a duration to the alert data of all triggered alerts. 

You can also store this duration by using the `.durationField` property of an AlertNode in a similar way to the  `levelField` property.

```go
|alert()
    .durationField('duration')
|influxDBOut()
    ....
```

The data in InfluxDB will now contain a field with the key `duration` containing and int64 for the duration of the event in nanoseconds.
 