### PR TITLE
Default config file location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ For example, let's say we want to store all data that triggered an alert in Infl
 - [#230](https://github.com/influxdata/kapacitor/issues/230): Alert.StateChangesOnly now accepts optional duration arg. An alert will be triggered for every interval even if the state has not changed.
 - [#426](https://github.com/influxdata/kapacitor/issues/426): Add `skip-format` query parameter to the `GET /task` endpoint so that returned TICKscript content is left unmodified from the user input.
 - [#388](https://github.com/influxdata/kapacitor/issues/388): The duration of an alert is now tracked and exposed as part of the alert data as well as can be set as a field via `.durationField('duration')`.
-
+- [#486](https://github.com/influxdata/kapacitor/pull/486): Default config file location.
 
 ### Bugfixes
 

--- a/cmd/kapacitord/run/command.go
+++ b/cmd/kapacitord/run/command.go
@@ -251,3 +251,28 @@ type Options struct {
 	LogFile    string
 	LogLevel   string
 }
+
+// GetConfigPath returns the config path from the options.
+// It will return a path by searching in this order:
+//   1. The CLI option in ConfigPath
+//   2. The environment variable KAPACITOR_CONFIG_PATH
+//   3. The first influxdb.conf file on the path:
+//        - ~/.kapacitor
+//        - /etc/kapacitor
+func (opt *Options) GetConfigPath() string {
+	if opt.ConfigPath != "" {
+		return opt.ConfigPath
+	} else if envVar := os.Getenv("KAPACITOR_CONFIG_PATH"); envVar != "" {
+		return envVar
+	}
+
+	for _, path := range []string{
+		os.ExpandEnv("${HOME}/.kapacitor/kapacitor.conf"),
+		"/etc/kapacitor/kapacitor.conf",
+	} {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}

--- a/cmd/kapacitord/run/config_command.go
+++ b/cmd/kapacitord/run/config_command.go
@@ -37,7 +37,8 @@ func (cmd *PrintConfigCommand) Run(args ...string) error {
 	}
 
 	// Parse config from path.
-	config, err := cmd.parseConfig(*configPath)
+	opt := Options{ConfigPath: *configPath}
+	config, err := cmd.parseConfig(opt.GetConfigPath())
 	if err != nil {
 		return fmt.Errorf("parse config: %s", err)
 	}


### PR DESCRIPTION
If the `-config` option isn't used, Kapacitor will now attempt to read a
configuration file from the environment variable `KAPACITOR_CONFIG_PATH`
or a list of default locations.

The list of default locations:
* `~/.kapacitor/kapacitor.conf`
* `/etc/kapacitor/kapacitor.conf`