### PR TITLE
Minor build script improvements, upload artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,4 +20,4 @@ deployment:
     release:
         tag: /v[0-9]+(\.[0-9]+){2}(-rc[0-9]+)?/
         commands:
-            - ./build.sh --debug --clean --generate --package --upload --platform=all --arch=all --release
+            - ./build.sh --debug --clean --generate --package --upload --bucket=dl.influxdata.com/kapacitor/releases --platform=all --arch=all --release

--- a/test.sh
+++ b/test.sh
@@ -74,6 +74,8 @@ function run_test_docker {
          -e "INFLUXDB_DATA_ENGINE=$INFLUXDB_DATA_ENGINE" \
          -e "GORACE=$GORACE" \
          -e "GO_CHECKOUT=$GO_CHECKOUT" \
+	 -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+	 -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
          "$imagename" \
          "--parallel=$PARALLELISM" \
          "--timeout=$TIMEOUT" \
@@ -129,7 +131,7 @@ fi
 case $ENVIRONMENT_INDEX in
     0)
         # 64 bit tests
-        run_test_docker Dockerfile_build_ubuntu64 test_64bit --debug --test --generate --no-uncommitted
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit --debug --test --generate --no-uncommitted --upload --package
         rc=$?
         ;;
     1)
@@ -140,7 +142,7 @@ case $ENVIRONMENT_INDEX in
         ;;
     2)
         # 32 bit tests
-        run_test_docker Dockerfile_build_ubuntu32 test_32bit --debug --test --generate --no-uncommitted
+        run_test_docker Dockerfile_build_ubuntu32 test_32bit --debug --test --generate --no-uncommitted --arch=i386
         rc=$?
         ;;
     3)


### PR DESCRIPTION
With this PR:

- Minor overall updates to build script
- Changes non-release versioning scheme to `<version>~<branch>.<commit>`
- Circle build artifacts are now uploaded to S3
- Changes default upload bucket to `dl.influxdata.com/kapacitor/artifacts` for circle build artifacts and `dl.influxdata.com/kapacitor/releases` for releases
- Package iteration is now removed from output package names (for example, `0.12.2-1` displays as `0.12.2`), however the iteration is still included in the package metadata.