### PR TITLE
Scope reusing & smaller scopes

### DIFF
--- a/tick/stateful/scope_pool.go
+++ b/tick/stateful/scope_pool.go
@@ -1,0 +1,57 @@
+package stateful
+
+import (
+	"sync"
+
+	"github.com/influxdata/kapacitor/tick"
+)
+
+// ScopePool - pooling mechanism for tick.Scope
+// The idea behind scope pool is to pool scopes and to put them only
+// the needed variables for execution.
+type ScopePool interface {
+	Get() *tick.Scope
+	Put(scope *tick.Scope)
+
+	ReferenceVariables() []string
+}
+
+type scopePool struct {
+	referenceVariables []string
+	pool               sync.Pool
+}
+
+// NewScopePool - creates new ScopePool for the given Node
+func NewScopePool(referenceVariables []string) ScopePool {
+	scopePool := &scopePool{
+		referenceVariables: referenceVariables,
+	}
+
+	scopePool.pool = sync.Pool{
+		New: func() interface{} {
+			scope := tick.NewScope()
+			for _, refVariable := range scopePool.referenceVariables {
+				scope.Set(refVariable, nil)
+			}
+
+			return scope
+		},
+	}
+
+	return scopePool
+}
+
+func (s *scopePool) ReferenceVariables() []string {
+	return s.referenceVariables
+}
+
+// Get - returns a scope from a pool with the needed reference variables
+// (with nil values/old values) in the scope
+func (s *scopePool) Get() *tick.Scope {
+	return s.pool.Get().(*tick.Scope)
+}
+
+// Put - put used scope back to the pool
+func (s *scopePool) Put(scope *tick.Scope) {
+	s.pool.Put(scope)
+}

--- a/tick/stateful/scope_pool_test.go
+++ b/tick/stateful/scope_pool_test.go
@@ -1,0 +1,56 @@
+package stateful_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/kapacitor/tick"
+	"github.com/influxdata/kapacitor/tick/stateful"
+)
+
+func TestScopePool_Sanity(t *testing.T) {
+	n := stateful.NewScopePool([]string{"value"})
+
+	// first
+	scope := n.Get()
+
+	_, existsErr := scope.Get("value")
+
+	if existsErr != nil {
+		t.Errorf("First: Expected \"value\" to exist in the scope, but go an error: %v", existsErr)
+	}
+
+	// second, after put
+	n.Put(scope)
+
+	scope = n.Get()
+	_, existsErr = scope.Get("value")
+
+	if existsErr != nil {
+		t.Errorf("Second: Expected \"value\" to exist in the scope, but go an error: %v", existsErr)
+	}
+}
+
+func TestExpression_RefernceVariables(t *testing.T) {
+
+	type expectation struct {
+		node         tick.Node
+		refVariables []string
+	}
+
+	expectations := []expectation{
+		{node: &tick.NumberNode{IsFloat: true}, refVariables: make([]string, 0)},
+		{node: &tick.BoolNode{}, refVariables: make([]string, 0)},
+
+		{node: &tick.ReferenceNode{Reference: "yosi"}, refVariables: []string{"yosi"}},
+		{node: &tick.BinaryNode{Left: &tick.ReferenceNode{Reference: "value"}, Right: &tick.NumberNode{IsInt: true}}, refVariables: []string{"value"}},
+	}
+
+	for i, expect := range expectations {
+		refVariables := stateful.FindReferenceVariables(expect.node)
+		if !reflect.DeepEqual(refVariables, expect.refVariables) {
+			t.Errorf("[Iteration: %v, Node: %T] Got unexpected result:\ngot: %v\nexpected: %v", i+1, expect.node, refVariables, expect.refVariables)
+		}
+
+	}
+}


### PR DESCRIPTION
**This pull request, is experiment, If you like the idea, we can improve the readability and the quality of the code**

For each expression we are creating "scope pool", which is object pool of scopes - with some extra magic.
By doing quick analysis on the node AST I know which tags and fields he requires. so we put only the required ones.
For example: "value" > 10, I fill only "value" from field or tag.
```
name                     old time/op    new time/op    delta
_T10_P500_AlertTask-4       133ms ± 4%     123ms ± 4%   -7.58%  (p=0.008 n=5+5)
_T10_P50000_AlertTask-4     13.4s ± 8%     12.3s ± 7%     ~     (p=0.056 n=5+5)
_T1000_P500_AlertTask-4     13.5s ± 4%     12.1s ± 3%  -10.46%  (p=0.008 n=5+5)

name                     old alloc/op   new alloc/op   delta
_T10_P500_AlertTask-4      32.2MB ± 0%    26.0MB ± 0%  -19.32%  (p=0.008 n=5+5)
_T10_P50000_AlertTask-4    3.26GB ± 0%    2.62GB ± 0%  -19.71%  (p=0.008 n=5+5)
_T1000_P500_AlertTask-4    3.21GB ± 0%    2.61GB ± 0%  -18.56%  (p=0.008 n=5+5)

name                     old allocs/op  new allocs/op  delta
_T10_P500_AlertTask-4        408k ± 0%      335k ± 0%  -17.85%  (p=0.008 n=5+5)
_T10_P50000_AlertTask-4     41.5M ± 0%     34.1M ± 0%  -17.98%  (p=0.008 n=5+5)
_T1000_P500_AlertTask-4     40.2M ± 0%     33.1M ± 0%  -17.61%  (p=0.008 n=5+5)
```

I thought about this idea while researching the performance of alerts, but before that I wanted to implement "compiled stateful expression" ( #491 ).
If we combine this pull request with #491 , we will have great performance and low memory usage while evaluating predicates.

