### PR TITLE
Join can emit ready sets without waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ For example, let's say we want to store all data that triggered an alert in Infl
 - [#425](https://github.com/influxdata/kapacitor/pull/425): BREAKING: Preserving tags on influxql simple selectors - first, last, max, min, percentile
 - [#423](https://github.com/influxdata/kapacitor/issues/423): Recording stream queries with group by now correctly saves data in time order not group by order.
 - [#331](https://github.com/influxdata/kapacitor/issues/331): Fix panic when missing `.as()` for JoinNode.
+- [#523](https://github.com/influxdata/kapacitor/pull/523): JoinNode will now emit join sets as soon as they are ready. If multiple joinable sets arrive in the same tolerance window than each will be emitted (previously the first points were dropped).
 
 ## v0.12.0 [2016-04-04]
 

--- a/integrations/data/TestStream_JoinTolerance.srpl
+++ b/integrations/data/TestStream_JoinTolerance.srpl
@@ -18,7 +18,7 @@ rpname
 errors,service=front,dc=A value=2 0000000001
 dbname
 rpname
-views,service=front,dc=A value=200 0000000002
+views,service=front,dc=A value=200 0000000001
 dbname
 rpname
 errors,service=cartA,dc=B value=9 0000000002
@@ -27,13 +27,13 @@ rpname
 views,service=cartA,dc=B value=900 0000000002
 dbname
 rpname
-errors,service=login,dc=A value=5 0000000003
+errors,service=login,dc=A value=5 0000000002
 dbname
 rpname
-views,service=login,dc=A value=500 0000000003
+views,service=login,dc=A value=500 0000000002
 dbname
 rpname
-errors,service=front,dc=B value=9 0000000003
+errors,service=front,dc=B value=9 0000000002
 dbname
 rpname
 views,service=front,dc=B value=900 0000000003
@@ -51,10 +51,10 @@ rpname
 views,service=login,dc=B value=900 0000000004
 dbname
 rpname
-errors,service=front,dc=A value=2 0000000005
+errors,service=front,dc=A value=7 0000000005
 dbname
 rpname
-views,service=front,dc=A value=200 0000000005
+views,service=front,dc=A value=700 0000000005
 dbname
 rpname
 errors,service=login,dc=B value=2 0000000005
@@ -69,10 +69,10 @@ rpname
 views,service=front,dc=A value=500 0000000006
 dbname
 rpname
-errors,service=cartA,dc=B value=9 0000000006
+errors,service=cartA,dc=B value=11 0000000006
 dbname
 rpname
-views,service=cartA,dc=B value=900 0000000006
+views,service=cartA,dc=B value=1100 0000000006
 dbname
 rpname
 errors,service=login,dc=C value=7 0000000006
@@ -87,10 +87,10 @@ rpname
 views,service=front,dc=A value=400 0000000007
 dbname
 rpname
-errors,service=cartA,dc=B value=8 0000000007
+errors,service=cartA,dc=B value=12 0000000007
 dbname
 rpname
-views,service=cartA,dc=B value=800 0000000007
+views,service=cartA,dc=B value=1200 0000000007
 dbname
 rpname
 errors,service=front,dc=A value=6 0000000008

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -1084,13 +1084,9 @@ errorCounts
 		.as('errors', 'views')
 		.tolerance(2s)
 		.streamName('error_view')
-	|eval(lambda: "errors.value" / "views.value")
-		.as('error_percent')
 	|window()
 		.period(10s)
 		.every(10s)
-	|mean('error_percent')
-		.as('error_percent')
 	|httpOut('TestStream_JoinTolerance')
 `
 
@@ -1099,29 +1095,118 @@ errorCounts
 			{
 				Name:    "error_view",
 				Tags:    map[string]string{"service": "cartA"},
-				Columns: []string{"time", "error_percent"},
-				Values: [][]interface{}{[]interface{}{
-					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
-					0.01,
-				}},
+				Columns: []string{"time", "errors.value", "views.value"},
+				Values: [][]interface{}{
+					{
+						time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC),
+						7.0,
+						700.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 2, 0, time.UTC),
+						9.0,
+						900.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 4, 0, time.UTC),
+						3.0,
+						300.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 6, 0, time.UTC),
+						11.0,
+						1100.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 6, 0, time.UTC),
+						12.0,
+						1200.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 8, 0, time.UTC),
+						6.0,
+						600.0,
+					},
+				},
 			},
 			{
 				Name:    "error_view",
 				Tags:    map[string]string{"service": "login"},
-				Columns: []string{"time", "error_percent"},
-				Values: [][]interface{}{[]interface{}{
-					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
-					0.01,
-				}},
+				Columns: []string{"time", "errors.value", "views.value"},
+				Values: [][]interface{}{
+					{
+						time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC),
+						9.0,
+						900.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 2, 0, time.UTC),
+						5.0,
+						500.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 4, 0, time.UTC),
+						9.0,
+						900.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 4, 0, time.UTC),
+						2.0,
+						200.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 6, 0, time.UTC),
+						7.0,
+						700.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 8, 0, time.UTC),
+						10.0,
+						1000.0,
+					},
+				},
 			},
 			{
 				Name:    "error_view",
 				Tags:    map[string]string{"service": "front"},
-				Columns: []string{"time", "error_percent"},
-				Values: [][]interface{}{[]interface{}{
-					time.Date(1971, 1, 1, 0, 0, 12, 0, time.UTC),
-					0.01,
-				}},
+				Columns: []string{"time", "errors.value", "views.value"},
+				Values: [][]interface{}{
+					{
+						time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC),
+						2.0,
+						200.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 2, 0, time.UTC),
+						9.0,
+						900.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 4, 0, time.UTC),
+						7.0,
+						700.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 6, 0, time.UTC),
+						5.0,
+						500.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 6, 0, time.UTC),
+						4.0,
+						400.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 8, 0, time.UTC),
+						6.0,
+						600.0,
+					},
+					{
+						time.Date(1971, 1, 1, 0, 0, 8, 0, time.UTC),
+						4.0,
+						400.0,
+					},
+				},
 			},
 		},
 	}
@@ -1226,7 +1311,7 @@ cpu
 				Columns: []string{"time", "count"},
 				Values: [][]interface{}{[]interface{}{
 					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
-					9.0,
+					10.0,
 				}},
 			},
 		},


### PR DESCRIPTION
This improves the JoinNode by removing some of the latency introduced. The JoinNode will now emit joined sets as soon as they are full.

This may fix #374 as the join node could have buffered a join set per group, causing delayed alerts.