### PR TITLE
Fix panic when missing value in scope

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -87,9 +87,10 @@ func (e *EvalNode) eval(now time.Time, fields models.Fields, tags map[string]str
 	vars := e.scopePool.Get()
 	defer e.scopePool.Put(vars)
 	err := fillScope(vars, e.scopePool.ReferenceVariables(), now, fields, tags)
-
 	if err != nil {
-		e.logger.Println("E!", err)
+		if !e.e.QuiteFlag {
+			e.logger.Println("E!", err)
+		}
 		return nil
 	}
 	for i, expr := range e.expressions {

--- a/expr.go
+++ b/expr.go
@@ -36,17 +36,21 @@ func fillScope(vars *tick.Scope, referenceVariables []string, now time.Time, fie
 		// Support the error with tags/fields collison
 		var fieldValue interface{}
 		var isFieldExists bool
+		var tagValue interface{}
+		var isTagExists bool
 
 		if fieldValue, isFieldExists = fields[refVariableName]; isFieldExists {
 			vars.Set(refVariableName, fieldValue)
 		}
 
-		if tagValue, ok := tags[refVariableName]; ok {
+		if tagValue, isTagExists = tags[refVariableName]; isTagExists {
 			if isFieldExists {
 				return fmt.Errorf("cannot have field and tags with same name %q", refVariableName)
 			}
-
 			vars.Set(refVariableName, tagValue)
+		}
+		if !isFieldExists && !isTagExists {
+			return fmt.Errorf("no field or tag exists for %s", refVariableName)
 		}
 	}
 

--- a/tick/stateful/eval_reference_node.go
+++ b/tick/stateful/eval_reference_node.go
@@ -1,6 +1,7 @@
 package stateful
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 
@@ -16,6 +17,9 @@ func (n *EvalReferenceNode) getReferenceValue(scope *tick.Scope, executionState 
 	value, err := scope.Get(n.Node.Reference)
 	if err != nil {
 		return nil, err
+	}
+	if value == nil {
+		return nil, fmt.Errorf("referenced value %q is nil.", n.Node.Reference)
 	}
 
 	return value, nil

--- a/tick/stateful/expr_test.go
+++ b/tick/stateful/expr_test.go
@@ -628,6 +628,51 @@ func TestExpression_EvalBool_ReferenceNodeDosentExist(t *testing.T) {
 	}
 }
 
+func TestExpression_EvalBool_ReferenceNodeNil(t *testing.T) {
+	scope := tick.NewScope()
+	scope.Set("value", nil)
+
+	expectedError := `referenced value "value" is nil.`
+
+	// Check left side
+	_, err := evalCompiledBoolWithScope(t, scope, &tick.BinaryNode{
+		Operator: tick.TokenEqual,
+		Left: &tick.ReferenceNode{
+			Reference: "value",
+		},
+		Right: &tick.StringNode{
+			Literal: "yo",
+		},
+	})
+
+	if err != nil && (err.Error() != expectedError) {
+		t.Errorf("Unexpected error result: \ngot: %v\nexpected: %v", err.Error(), expectedError)
+	}
+
+	if err == nil {
+		t.Error("Unexpected error result: but didn't got any error")
+	}
+
+	// Check right side
+	_, err = evalCompiledBoolWithScope(t, scope, &tick.BinaryNode{
+		Operator: tick.TokenEqual,
+		Left: &tick.StringNode{
+			Literal: "yo",
+		},
+		Right: &tick.ReferenceNode{
+			Reference: "value",
+		},
+	})
+
+	if err != nil && (err.Error() != expectedError) {
+		t.Errorf("Unexpected error result: \ngot: %v\nexpected: %v", err.Error(), expectedError)
+	}
+
+	if err == nil {
+		t.Error("Unexpected error result: but didn't got any error")
+	}
+}
+
 func TestExpression_EvalBool_ReturnsReferenceNode(t *testing.T) {
 	scope := tick.NewScope()
 

--- a/tick/stateful/types.go
+++ b/tick/stateful/types.go
@@ -42,6 +42,9 @@ func (v ValueType) String() string {
 }
 
 func valueTypeOf(t reflect.Type) ValueType {
+	if t == nil {
+		return InvalidType
+	}
 	switch t.Kind() {
 	case reflect.Float64:
 		return TFloat64


### PR DESCRIPTION
Since using `ScopePool` all scope values are always set. As a result the EvalReferenceNode would return `nil` values instead of an error. Now we check for `nil` values and return appropriate error.