### PR TITLE
Add live replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,22 @@
 
 ### Release Notes
 
+With this release you can now replay data directly against a task from InfluxDB without having to first create a recording.
+Replay the queries defined in the batch task `cpu_alert` for the past 10 hours.
+```sh
+kapacitor replay-live batch -task cpu_alert -past 10h
+```
+
+Or for a stream task with use a query directly:
+
+```sh
+kapacitor replay-live query -task cpu_alert -query 'SELECT usage_idle FROM telegraf."default".cpu WHERE time > now() - 10h'
+```
+
+
 ### Features
 
+- [#283](https://github.com/influxdata/kapacitor/issues/283): Add live replays.
 - [#82](https://github.com/influxdata/kapacitor/issues/82): Multiple services for PagerDuty alert
 - [#558](https://github.com/influxdata/kapacitor/pull/558): Preserve fields as well as tags on selector InfluxQL functions.
 

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -34,6 +34,8 @@ const recordStreamPath = basePath + "/recordings/stream"
 const recordBatchPath = basePath + "/recordings/batch"
 const recordQueryPath = basePath + "/recordings/query"
 const replaysPath = basePath + "/replays"
+const replayBatchPath = basePath + "/replays/batch"
+const replayQueryPath = basePath + "/replays/query"
 
 // HTTP configuration for connecting to Kapacitor
 type Config struct {
@@ -866,6 +868,77 @@ func (c *Client) CreateReplay(opt CreateReplayOptions) (Replay, error) {
 	if err != nil {
 		return r, err
 	}
+
+	req, err := http.NewRequest("POST", u.String(), &buf)
+	if err != nil {
+		return r, err
+	}
+
+	_, err = c.do(req, &r, http.StatusCreated)
+	if err != nil {
+		return r, err
+	}
+	return r, nil
+}
+
+type ReplayBatchOptions struct {
+	ID            string    `json:"id,omitempty"`
+	Task          string    `json:"task"`
+	Start         time.Time `json:"start"`
+	Stop          time.Time `json:"stop"`
+	Cluster       string    `json:"cluster,omitempty"`
+	RecordingTime bool      `json:"recording-time"`
+	Clock         Clock     `json:"clock"`
+}
+
+// Replay a query against a task.
+func (c *Client) ReplayBatch(opt ReplayBatchOptions) (Replay, error) {
+	r := Replay{}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	err := enc.Encode(opt)
+	if err != nil {
+		return r, err
+	}
+
+	u := *c.url
+	u.Path = replayBatchPath
+
+	req, err := http.NewRequest("POST", u.String(), &buf)
+	if err != nil {
+		return r, err
+	}
+
+	_, err = c.do(req, &r, http.StatusCreated)
+	if err != nil {
+		return r, err
+	}
+	return r, nil
+}
+
+type ReplayQueryOptions struct {
+	ID            string `json:"id,omitempty"`
+	Task          string `json:"task"`
+	Query         string `json:"query"`
+	Cluster       string `json:"cluster,omitempty"`
+	RecordingTime bool   `json:"recording-time"`
+	Clock         Clock  `json:"clock"`
+}
+
+// Replay a query against a task.
+func (c *Client) ReplayQuery(opt ReplayQueryOptions) (Replay, error) {
+	r := Replay{}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	err := enc.Encode(opt)
+	if err != nil {
+		return r, err
+	}
+
+	u := *c.url
+	u.Path = replayQueryPath
 
 	req, err := http.NewRequest("POST", u.String(), &buf)
 	if err != nil {

--- a/client/v1/swagger.yml
+++ b/client/v1/swagger.yml
@@ -455,6 +455,91 @@ paths:
           description: A processing or an unexpected error.
           schema:
             $ref: '#/definitions/Error'
+  /replays/batch:
+    post:
+      summary: Replay a batch directly without creating a recording.
+      tags: [replays]
+      operationId: replayBatch
+      parameters:
+        - name: id
+          in: body
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Replay ID
+              task:
+                type: string
+                description: ID of task
+              start:
+                type: string
+                format: dateTime
+              stop:
+                type: string
+                format: dateTime
+              cluster:
+                type: string
+              recording-time:
+                type: boolean
+                default: false
+              clock:
+                type: string
+                pattern: (fast|real)
+                default: fast
+            required:
+              - task
+              - start
+      responses:
+        '201':
+          description: Replay Started
+          schema:
+            $ref: '#/definitions/Replay'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+  /replays/query:
+    post:
+      summary: Replay data from a query directly without creating a recording.
+      tags: [recordings]
+      operationId: replayQuery
+      parameters:
+        - name: id
+          in: body
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Replay ID
+              task:
+                type: string
+                description: ID of task
+              query:
+                type: string
+              cluster:
+                type: string
+              recording-time:
+                type: boolean
+                default: false
+              clock:
+                type: string
+                pattern: (fast|real)
+                default: fast
+            required:
+              - task
+              - query
+      responses:
+        '201':
+          description: Replay Started
+          schema:
+            $ref: '#/definitions/Replay'
+        default:
+          description: A processing or an unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
 
 
 definitions:

--- a/integrations/batcher_test.go
+++ b/integrations/batcher_test.go
@@ -881,10 +881,6 @@ func testBatcher(t *testing.T, name, script string) (clock.Setter, *kapacitor.Ex
 		t.Fatal("could not find any data files for", name)
 	}
 
-	// Use 1971 so that we don't get true negatives on Epoch 0 collisions
-	c := clock.New(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
-	r := kapacitor.NewReplay(c)
-
 	//Start the task
 	et, err := tm.StartTask(task)
 	if err != nil {
@@ -893,10 +889,12 @@ func testBatcher(t *testing.T, name, script string) (clock.Setter, *kapacitor.Ex
 
 	// Replay test data to executor
 	batches := tm.BatchCollectors(name)
-	replayErr := r.ReplayBatch(allData, batches, false)
+	// Use 1971 so that we don't get true negatives on Epoch 0 collisions
+	c := clock.New(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
+	replayErr := kapacitor.ReplayBatchFromIO(c, allData, batches, false)
 
 	t.Log(string(et.Task.Dot()))
-	return r.Setter, et, replayErr, tm
+	return c, et, replayErr, tm
 }
 
 func testBatcherWithOutput(

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -3812,10 +3812,6 @@ func testStreamer(
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Use 1971 so that we don't get true negatives on Epoch 0 collisions
-	c := clock.New(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
-	r := kapacitor.NewReplay(c)
-
 	//Start the task
 	et, err := tm.StartTask(task)
 	if err != nil {
@@ -3827,10 +3823,13 @@ func testStreamer(
 	if err != nil {
 		t.Fatal(err)
 	}
-	replayErr := r.ReplayStream(data, stream, false, "s")
+	// Use 1971 so that we don't get true negatives on Epoch 0 collisions
+	c := clock.New(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	replayErr := kapacitor.ReplayStreamFromIO(c, data, stream, false, "s")
 
 	t.Log(string(et.Task.Dot()))
-	return r.Setter, et, replayErr, tm
+	return c, et, replayErr, tm
 }
 
 func fastForwardTask(

--- a/replay.go
+++ b/replay.go
@@ -12,85 +12,87 @@ import (
 	"github.com/influxdata/kapacitor/models"
 )
 
-// Replay engine that can replay static data sets against a specific executor and its tasks.
-type Replay struct {
-	clck   clock.Clock
-	Setter clock.Setter
+// Replay stream data from a channel source.
+func ReplayStreamFromChan(clck clock.Clock, points <-chan models.Point, collector StreamCollector, recTime bool) <-chan error {
+	errC := make(chan error, 1)
+	go func() {
+		errC <- replayStreamFromChan(clck, points, collector, recTime)
+	}()
+	return errC
 }
 
-// Create a new replay engine.
-func NewReplay(c clock.Clock) *Replay {
-	return &Replay{
-		clck:   c,
-		Setter: c,
-	}
+// Replay stream data from an IO source.
+func ReplayStreamFromIO(clck clock.Clock, data io.ReadCloser, collector StreamCollector, recTime bool, precision string) <-chan error {
+	allErrs := make(chan error, 2)
+	errC := make(chan error, 1)
+	points := make(chan models.Point)
+	go func() {
+		allErrs <- replayStreamFromChan(clck, points, collector, recTime)
+	}()
+	go func() {
+		allErrs <- readPointsFromIO(data, points, precision)
+	}()
+	go func() {
+		for i := 0; i < cap(allErrs); i++ {
+			err := <-allErrs
+			if err != nil {
+				errC <- err
+				return
+			}
+		}
+		errC <- nil
+	}()
+	return errC
 }
 
-// Replay a data set against an executor.
-func (r *Replay) ReplayStream(data io.ReadCloser, stream StreamCollector, recTime bool, precision string) <-chan error {
-	src := newReplayStreamSource(data, r.clck)
-	go src.replayStream(stream, recTime, precision)
-	return src.Err()
-}
-
-type replayStreamSource struct {
-	data io.Closer
-	in   *bufio.Scanner
-	clck clock.Clock
-	err  chan error
-}
-
-func newReplayStreamSource(data io.ReadCloser, clck clock.Clock) *replayStreamSource {
-	return &replayStreamSource{
-		data: data,
-		in:   bufio.NewScanner(data),
-		clck: clck,
-		err:  make(chan error, 1),
-	}
-}
-
-func (r *replayStreamSource) Err() <-chan error {
-	return r.err
-}
-
-func (r *replayStreamSource) replayStream(stream StreamCollector, recTime bool, precision string) {
-	defer stream.Close()
-	defer r.data.Close()
+func replayStreamFromChan(clck clock.Clock, points <-chan models.Point, collector StreamCollector, recTime bool) error {
+	defer collector.Close()
 	start := time.Time{}
 	var diff time.Duration
-	zero := r.clck.Zero()
-	for r.in.Scan() {
-		db := r.in.Text()
-		if !r.in.Scan() {
-			r.err <- fmt.Errorf("invalid replay file format, expected another line")
-			return
+	zero := clck.Zero()
+	for p := range points {
+		if start.IsZero() {
+			start = p.Time
+			diff = zero.Sub(start)
 		}
-		rp := r.in.Text()
-		if !r.in.Scan() {
-			r.err <- fmt.Errorf("invalid replay file format, expected another line")
-			return
+		waitTime := p.Time.Add(diff).UTC()
+		if !recTime {
+			p.Time = waitTime
 		}
-		points, err := dbmodels.ParsePointsWithPrecision(
-			r.in.Bytes(),
-			zero,
+		clck.Until(waitTime)
+		err := collector.CollectPoint(p)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readPointsFromIO(data io.ReadCloser, points chan<- models.Point, precision string) error {
+	defer data.Close()
+	defer close(points)
+
+	now := time.Time{}
+
+	in := bufio.NewScanner(data)
+	for in.Scan() {
+		db := in.Text()
+		if !in.Scan() {
+			return fmt.Errorf("invalid replay file format, expected another line")
+		}
+		rp := in.Text()
+		if !in.Scan() {
+			return fmt.Errorf("invalid replay file format, expected another line")
+		}
+		mps, err := dbmodels.ParsePointsWithPrecision(
+			in.Bytes(),
+			now,
 			precision,
 		)
 		if err != nil {
-			r.err <- err
-			return
+			return err
 		}
-		if start.IsZero() {
-			start = points[0].Time()
-			diff = zero.Sub(start)
-		}
-		var t time.Time
-		waitTime := points[0].Time().Add(diff).UTC()
-		if !recTime {
-			t = waitTime
-		} else {
-			t = points[0].Time().UTC()
-		}
-		mp := points[0]
+		mp := mps[0]
 		p := models.Point{
 			Database:        db,
 			RetentionPolicy: rp,
@@ -98,104 +100,87 @@ func (r *replayStreamSource) replayStream(stream StreamCollector, recTime bool, 
 			Group:           models.NilGroup,
 			Tags:            models.Tags(mp.Tags()),
 			Fields:          models.Fields(mp.Fields()),
-			Time:            t,
+			Time:            mp.Time().UTC(),
 		}
-		r.clck.Until(waitTime)
-		err = stream.CollectPoint(p)
-		if err != nil {
-			r.err <- err
-			return
-		}
+		points <- p
 	}
-	r.err <- r.in.Err()
+	return nil
 }
 
-// Replay a data set against an executor.
-// If source time is true then the replay will use the times stored in the
-// recording instead of the clock time.
-func (r *Replay) ReplayBatch(data []io.ReadCloser, batches []BatchCollector, recTime bool) <-chan error {
-	src := newReplayBatchSource(data, r.clck)
-	src.replayBatch(batches, recTime)
-	return src.Err()
-}
-
-type replayBatchSource struct {
-	data    []io.ReadCloser
-	clck    clock.Clock
-	allErrs chan error
-	err     chan error
-}
-
-func newReplayBatchSource(data []io.ReadCloser, clck clock.Clock) *replayBatchSource {
-	return &replayBatchSource{
-		data:    data,
-		clck:    clck,
-		allErrs: make(chan error, len(data)),
-		err:     make(chan error, 1),
+// Replay batch data from a channel source.
+func ReplayBatchFromChan(clck clock.Clock, batches []<-chan models.Batch, collectors []BatchCollector, recTime bool) <-chan error {
+	errC := make(chan error, 1)
+	if e, g := len(batches), len(collectors); e != g {
+		errC <- fmt.Errorf("unexpected number of batch collectors. exp %d got %d", e, g)
+		return errC
 	}
-}
-func (r *replayBatchSource) Err() <-chan error {
-	return r.err
-}
 
-func (r *replayBatchSource) replayBatch(batches []BatchCollector, recTime bool) {
-	if e, g := len(r.data), len(batches); e != g {
-		r.err <- fmt.Errorf("unexpected number of batch collectors. exp %d got %d", e, g)
-		return
-	}
-	for i := range r.data {
-		go r.replayBatchFromData(r.data[i], batches[i], recTime)
+	allErrs := make(chan error, len(batches))
+	for i := range batches {
+		go func(collector BatchCollector, batches <-chan models.Batch, clck clock.Clock, recTime bool) {
+			allErrs <- replayBatchFromChan(clck, batches, collector, recTime)
+		}(collectors[i], batches[i], clck, recTime)
 	}
 	go func() {
 		// Wait for each one to finish and report first error if any
-		for range r.data {
-			err := <-r.allErrs
+		for i := 0; i < cap(allErrs); i++ {
+			err := <-allErrs
 			if err != nil {
-
-				r.err <- err
+				errC <- err
 				return
 			}
 		}
-		r.err <- nil
+		errC <- nil
 	}()
+	return errC
+
+}
+
+// Replay batch data from an IO source.
+func ReplayBatchFromIO(clck clock.Clock, data []io.ReadCloser, collectors []BatchCollector, recTime bool) <-chan error {
+	errC := make(chan error, 1)
+	if e, g := len(data), len(collectors); e != g {
+		errC <- fmt.Errorf("unexpected number of batch collectors. exp %d got %d", e, g)
+		return errC
+	}
+
+	allErrs := make(chan error, len(data)*2)
+	for i := range data {
+		batches := make(chan models.Batch)
+		go func(collector BatchCollector, batches <-chan models.Batch, clck clock.Clock, recTime bool) {
+			allErrs <- replayBatchFromChan(clck, batches, collector, recTime)
+		}(collectors[i], batches, clck, recTime)
+		go func(data io.ReadCloser, batches chan<- models.Batch) {
+			allErrs <- readBatchFromIO(data, batches)
+		}(data[i], batches)
+	}
+	go func() {
+		// Wait for each one to finish and report first error if any
+		for i := 0; i < cap(allErrs); i++ {
+			err := <-allErrs
+			if err != nil {
+				errC <- err
+				return
+			}
+		}
+		errC <- nil
+	}()
+	return errC
 }
 
 // Replay the batch data from a single source
-func (r *replayBatchSource) replayBatchFromData(data io.ReadCloser, batch BatchCollector, recTime bool) {
-	defer batch.Close()
-	defer data.Close()
-
-	in := bufio.NewScanner(data)
+func replayBatchFromChan(clck clock.Clock, batches <-chan models.Batch, collector BatchCollector, recTime bool) error {
+	defer collector.Close()
 
 	// Find relative times
 	start := time.Time{}
 	var diff time.Duration
-	zero := r.clck.Zero()
+	zero := clck.Zero()
 
-	for in.Scan() {
-		var b models.Batch
-		err := json.Unmarshal(in.Bytes(), &b)
-		if err != nil {
-			r.allErrs <- err
-			return
-		}
-		if len(b.Points) == 0 {
-			// do nothing
-			continue
-		}
-		b.Group = models.TagsToGroupID(models.SortedKeys(b.Tags), b.Tags)
-
+	for b := range batches {
 		if start.IsZero() {
 			start = b.Points[0].Time
 			diff = zero.Sub(start)
-		}
-		// Add tags to all points
-		if len(b.Tags) > 0 {
-			for i := range b.Points {
-				if len(b.Points[i].Tags) == 0 {
-					b.Points[i].Tags = b.Tags
-				}
-			}
 		}
 		var lastTime time.Time
 		if !recTime {
@@ -206,11 +191,41 @@ func (r *replayBatchSource) replayBatchFromData(data io.ReadCloser, batch BatchC
 		} else {
 			lastTime = b.Points[len(b.Points)-1].Time.Add(diff).UTC()
 		}
-		r.clck.Until(lastTime)
+		clck.Until(lastTime)
 		b.TMax = b.Points[len(b.Points)-1].Time
-		batch.CollectBatch(b)
+		collector.CollectBatch(b)
 	}
-	r.allErrs <- in.Err()
+	return nil
+}
+
+// Replay the batch data from a single source
+func readBatchFromIO(data io.ReadCloser, batches chan<- models.Batch) error {
+	defer close(batches)
+	defer data.Close()
+
+	in := bufio.NewScanner(data)
+	for in.Scan() {
+		var b models.Batch
+		err := json.Unmarshal(in.Bytes(), &b)
+		if err != nil {
+			return err
+		}
+		if len(b.Points) == 0 {
+			// do nothing
+			continue
+		}
+		b.Group = models.TagsToGroupID(models.SortedKeys(b.Tags), b.Tags)
+		// Add tags to all points
+		if len(b.Tags) > 0 {
+			for i := range b.Points {
+				if len(b.Points[i].Tags) == 0 {
+					b.Points[i].Tags = b.Tags
+				}
+			}
+		}
+		batches <- b
+	}
+	return nil
 }
 
 func WritePointForRecording(w io.Writer, p models.Point, precision string) error {

--- a/services/task_store/service.go
+++ b/services/task_store/service.go
@@ -957,7 +957,7 @@ func (ts *Service) startTask(task Task) error {
 		err := et.StartBatching()
 		if err != nil {
 			ts.saveLastError(t.ID, err.Error())
-			ts.stopTask(t.ID)
+			ts.TaskMaster.StopTask(t.ID)
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #283 

Now via the API and the CLI you can replay data against a task without having to first create a recording.

Basically the record and replay commands were into a new command with the capabilities of both. 

See the CLI help or API docs for more details.

TODO:

- [x] Changelog
- [x] Update swagger.yml
