### PR TITLE
Fixes several issues with the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@
 
 ### Bugfixes
 
+## v0.13.1 [unreleased]
+
+### Release Notes
+
+>**Breaking changes may require special upgrade steps from versions <= 0.12, please read the 0.13.0 release notes**
+
+Along with the API changes of 0.13.0, validation logic was added to task IDs, but this was not well documented.
+All IDs (tasks, recordings, replays) must match this regex `^[-\._\p{L}0-9]+$`, which is essentially numbers, unicode letters, '-', '.' and '_'.
+
+If you have existings tasks which do not match this pattern they should continue to function normally.
+
+### Features
+
+
+### Bugfixes
+
+- [#545](https://github.com/influxdata/kapacitor/issues/545): Fixes inconsistancy with API docs for creating a task.
+- [#544](https://github.com/influxdata/kapacitor/issues/544): Fixes issues with existings tasks and invalid names.
+- [#543](https://github.com/influxdata/kapacitor/issues/543): Fixes default values not being set correctly in API calls.
+
 
 ## v0.13.0 [2016-05-11]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@
 >**Breaking changes may require special upgrade steps from versions <= 0.12, please read the 0.13.0 release notes**
 
 Along with the API changes of 0.13.0, validation logic was added to task IDs, but this was not well documented.
+This minor release remedies that.
+
 All IDs (tasks, recordings, replays) must match this regex `^[-\._\p{L}0-9]+$`, which is essentially numbers, unicode letters, '-', '.' and '_'.
 
-If you have existings tasks which do not match this pattern they should continue to function normally.
+If you have existing tasks which do not match this pattern they should continue to function normally.
 
 ### Features
 

--- a/client/API.md
+++ b/client/API.md
@@ -51,6 +51,14 @@ Query parameters are used only for GET requests and all other requests expect pa
 When creating resources in Kapacitor the API server will return a `link` object with an `href` of the resource.
 Clients should not need to perform path manipulation in most cases and can use the links provided from previous calls.
 
+### IDs
+
+The API allows the client to specify IDs for the various resources.
+This way you can control the meaning of the IDs.
+If you do not specify an ID a random UUID will be generated for the resource.
+
+All IDs must match this regex `^[-\._\p{L}0-9]+$`, which is essentially numbers, unicode letters, '-', '.' and '_'.
+
 ## Writing Data
 
 Kapacitor can accept writes over HTTP using the line protocol.
@@ -107,7 +115,7 @@ When using PATCH, if any option is missing it will be left unmodified.
 Create a new task with ID TASK_ID.
 
 ```
-POST /kapacitor/v1/tasks/
+POST /kapacitor/v1/tasks
 {
     "id" : "TASK_ID",
     "type" : "stream",

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -470,7 +470,7 @@ func HttpError(w http.ResponseWriter, err string, pretty bool, code int) {
 	w.WriteHeader(code)
 
 	type errResponse struct {
-		Error string
+		Error string `json:"error"`
 	}
 
 	response := errResponse{Error: err}

--- a/services/task_store/service.go
+++ b/services/task_store/service.go
@@ -384,7 +384,6 @@ func (ts *Service) handleTask(w http.ResponseWriter, r *http.Request) {
 		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
 		return
 	}
-	ts.logger.Println("D! handleTask", r.URL.Path, id)
 
 	raw, err := ts.tasks.Get(id)
 	if err != nil {


### PR DESCRIPTION
Fixes #543 #544 #545 

As for #544 all IDs (tasks, recordings, replays) must match this regex `^[-\._\p{L}0-9]+$`, which is essentially numbers, unicode letters, '-', '.' and '_'.

If you have existing tasks which do not match this pattern they should continue to function normally with this fix.