### PR TITLE
Add optional .serviceKey('XXX') argument to pagerduty alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Release Notes
 
 ### Features
+- [#82](https://github.com/influxdata/kapacitor/issues/82): Multiple services for PagerDuty alert
 
 
 ### Bugfixes

--- a/alert.go
+++ b/alert.go
@@ -878,6 +878,7 @@ func (a *AlertNode) handlePagerDuty(pd *pipeline.PagerDutyHandler, ad *AlertData
 		return
 	}
 	err := a.et.tm.PagerDutyService.Alert(
+		pd.ServiceKey,
 		ad.ID,
 		ad.Message,
 		ad.Level,

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -646,6 +646,10 @@ func (a *AlertNode) PagerDuty() *PagerDutyHandler {
 // tick:embedded:AlertNode.PagerDuty
 type PagerDutyHandler struct {
 	*AlertNode
+
+	// The service key to use for the alert.
+	// Defaults to the value in the configuration if empty.
+	ServiceKey string
 }
 
 // Send the alert to HipChat.

--- a/services/pagerduty/service.go
+++ b/services/pagerduty/service.go
@@ -43,7 +43,7 @@ func (s *Service) Global() bool {
 	return s.global
 }
 
-func (s *Service) Alert(incidentKey, desc string, level kapacitor.AlertLevel, details interface{}) error {
+func (s *Service) Alert(serviceKey, incidentKey, desc string, level kapacitor.AlertLevel, details interface{}) error {
 	var eventType string
 	switch level {
 	case kapacitor.WarnAlert, kapacitor.CritAlert:
@@ -55,7 +55,11 @@ func (s *Service) Alert(incidentKey, desc string, level kapacitor.AlertLevel, de
 	}
 
 	pData := make(map[string]string)
-	pData["service_key"] = s.serviceKey
+	if serviceKey == "" {
+		pData["service_key"] = s.serviceKey
+	} else {
+		pData["service_key"] = serviceKey
+	}
 	pData["event_type"] = eventType
 	pData["description"] = desc
 	pData["incident_key"] = incidentKey

--- a/task_master.go
+++ b/task_master.go
@@ -65,7 +65,7 @@ type TaskMaster struct {
 	}
 	PagerDutyService interface {
 		Global() bool
-		Alert(incidentKey, desc string, level AlertLevel, details interface{}) error
+		Alert(serviceKey, incidentKey, desc string, level AlertLevel, details interface{}) error
 	}
 	SlackService interface {
 		Global() bool


### PR DESCRIPTION
Resolves issue #82, should work like VictorOps integration, if you do not specify a service key, the default service key from the configuration file is used. If you do include a service key, it is used instead of the default.