### PR TITLE
Preserve fields in selectors as well as tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features
 
 - [#82](https://github.com/influxdata/kapacitor/issues/82): Multiple services for PagerDuty alert
+- [#558](https://github.com/influxdata/kapacitor/pull/558): Preserve fields as well as tags on selector InfluxQL functions.
 
 
 ### Bugfixes

--- a/influxql.gen.go
+++ b/influxql.gen.go
@@ -55,7 +55,7 @@ func (a *floatPointAggregator) AggregateBatch(b *models.Batch) error {
 		}
 
 		if a.isSimpleSelector {
-			ap.Aux = []interface{}{p.Tags}
+			ap.Aux = []interface{}{p.Tags, p.Fields}
 		}
 
 		a.aggregator.AggregateFloat(ap)
@@ -84,7 +84,7 @@ func (a *floatPointAggregator) AggregatePoint(p *models.Point) error {
 	}
 
 	if a.isSimpleSelector {
-		ap.Aux = []interface{}{p.Tags}
+		ap.Aux = []interface{}{p.Tags, p.Fields}
 	}
 
 	a.aggregator.AggregateFloat(ap)
@@ -121,7 +121,7 @@ func (a *floatPointBulkAggregator) AggregateBatch(b *models.Batch) error {
 		}
 
 		if a.isSimpleSelector {
-			slice[i].Aux = []interface{}{p.Tags}
+			slice[i].Aux = []interface{}{p.Tags, p.Fields}
 		}
 	}
 	a.aggregator.AggregateFloatBulk(slice)
@@ -149,7 +149,7 @@ func (a *floatPointBulkAggregator) AggregatePoint(p *models.Point) error {
 	}
 
 	if a.isSimpleSelector {
-		ap.Aux = []interface{}{p.Tags}
+		ap.Aux = []interface{}{p.Tags, p.Fields}
 	}
 
 	a.aggregator.AggregateFloat(ap)
@@ -179,9 +179,19 @@ func (e *floatPointEmitter) EmitPoint() (models.Point, error) {
 		t = e.time
 	}
 
-	tags := e.tags
+	var fields models.Fields
+	var tags models.Tags
 	if e.isSimpleSelector {
 		tags = ap.Aux[0].(models.Tags)
+		fields = ap.Aux[1].(models.Fields)
+		if e.as != e.field {
+			fields = fields.Copy()
+			fields[e.as] = fields[e.field]
+			delete(fields, e.field)
+		}
+	} else {
+		tags = e.tags
+		fields = map[string]interface{}{e.as: ap.Value}
 	}
 
 	return models.Point{
@@ -190,7 +200,7 @@ func (e *floatPointEmitter) EmitPoint() (models.Point, error) {
 		Group:      e.group,
 		Dimensions: e.dimensions,
 		Tags:       tags,
-		Fields:     map[string]interface{}{e.as: ap.Value},
+		Fields:     fields,
 	}, nil
 }
 
@@ -263,7 +273,7 @@ func (a *integerPointAggregator) AggregateBatch(b *models.Batch) error {
 		}
 
 		if a.isSimpleSelector {
-			ap.Aux = []interface{}{p.Tags}
+			ap.Aux = []interface{}{p.Tags, p.Fields}
 		}
 
 		a.aggregator.AggregateInteger(ap)
@@ -292,7 +302,7 @@ func (a *integerPointAggregator) AggregatePoint(p *models.Point) error {
 	}
 
 	if a.isSimpleSelector {
-		ap.Aux = []interface{}{p.Tags}
+		ap.Aux = []interface{}{p.Tags, p.Fields}
 	}
 
 	a.aggregator.AggregateInteger(ap)
@@ -329,7 +339,7 @@ func (a *integerPointBulkAggregator) AggregateBatch(b *models.Batch) error {
 		}
 
 		if a.isSimpleSelector {
-			slice[i].Aux = []interface{}{p.Tags}
+			slice[i].Aux = []interface{}{p.Tags, p.Fields}
 		}
 	}
 	a.aggregator.AggregateIntegerBulk(slice)
@@ -357,7 +367,7 @@ func (a *integerPointBulkAggregator) AggregatePoint(p *models.Point) error {
 	}
 
 	if a.isSimpleSelector {
-		ap.Aux = []interface{}{p.Tags}
+		ap.Aux = []interface{}{p.Tags, p.Fields}
 	}
 
 	a.aggregator.AggregateInteger(ap)
@@ -387,9 +397,19 @@ func (e *integerPointEmitter) EmitPoint() (models.Point, error) {
 		t = e.time
 	}
 
-	tags := e.tags
+	var fields models.Fields
+	var tags models.Tags
 	if e.isSimpleSelector {
 		tags = ap.Aux[0].(models.Tags)
+		fields = ap.Aux[1].(models.Fields)
+		if e.as != e.field {
+			fields = fields.Copy()
+			fields[e.as] = fields[e.field]
+			delete(fields, e.field)
+		}
+	} else {
+		tags = e.tags
+		fields = map[string]interface{}{e.as: ap.Value}
 	}
 
 	return models.Point{
@@ -398,7 +418,7 @@ func (e *integerPointEmitter) EmitPoint() (models.Point, error) {
 		Group:      e.group,
 		Dimensions: e.dimensions,
 		Tags:       tags,
-		Fields:     map[string]interface{}{e.as: ap.Value},
+		Fields:     fields,
 	}, nil
 }
 

--- a/influxql.gen.go.tmpl
+++ b/influxql.gen.go.tmpl
@@ -53,7 +53,7 @@ func (a *{{.name}}PointAggregator) AggregateBatch(b *models.Batch) error {
 		}
 
 		if a.isSimpleSelector {
-			ap.Aux = []interface{}{ p.Tags }
+			ap.Aux = []interface{}{ p.Tags, p.Fields }
 		}
 		
 		a.aggregator.Aggregate{{.Name}}(ap)
@@ -82,7 +82,7 @@ func (a *{{.name}}PointAggregator) AggregatePoint(p *models.Point) error {
 	}
 
 	if a.isSimpleSelector {
-		ap.Aux = []interface{}{ p.Tags }
+		ap.Aux = []interface{}{ p.Tags, p.Fields }
 	}
 	
 	a.aggregator.Aggregate{{.Name}}(ap)
@@ -121,7 +121,7 @@ func (a *{{.name}}PointBulkAggregator) AggregateBatch(b *models.Batch) error {
 		}
 
 		if a.isSimpleSelector {
-			slice[i].Aux = []interface{}{ p.Tags }
+			slice[i].Aux = []interface{}{ p.Tags, p.Fields }
 		}
 	}
 	a.aggregator.Aggregate{{.Name}}Bulk(slice)
@@ -149,7 +149,7 @@ func (a *{{.name}}PointBulkAggregator) AggregatePoint(p *models.Point) error {
 	}
 
 	if a.isSimpleSelector {
-		ap.Aux = []interface{}{ p.Tags }
+		ap.Aux = []interface{}{ p.Tags, p.Fields }
 	}
 
 	a.aggregator.Aggregate{{.Name}}(ap)
@@ -179,9 +179,19 @@ func (e *{{.name}}PointEmitter) EmitPoint() (models.Point, error) {
 		t = e.time
 	}
 
-	tags := e.tags
+	var fields models.Fields
+	var tags models.Tags
 	if e.isSimpleSelector {
 		tags = ap.Aux[0].(models.Tags)
+		fields = ap.Aux[1].(models.Fields)
+		if e.as != e.field {
+			fields = fields.Copy()
+			fields[e.as] = fields[e.field]
+			delete(fields, e.field)
+		}
+	} else {
+		tags = e.tags
+		fields = map[string]interface{}{e.as: ap.Value}
 	}
 
 	return models.Point{
@@ -190,7 +200,7 @@ func (e *{{.name}}PointEmitter) EmitPoint() (models.Point, error) {
 		Group:      e.group,
 		Dimensions: e.dimensions,
 		Tags:       tags,
-		Fields:     map[string]interface{}{e.as: ap.Value},
+		Fields:     fields,
 	}, nil
 }
 

--- a/integrations/data/TestStream_Selectors.srpl
+++ b/integrations/data/TestStream_Selectors.srpl
@@ -1,0 +1,81 @@
+dbname
+rpname
+cpu,type=idle,host=serverA value=97.1,another=7 0000000001
+dbname
+rpname
+cpu,type=idle,host=serverB value=97.1,another=7 0000000001
+dbname
+rpname
+disk,type=sda,host=serverB value=39,another=9   0000000001
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.6,another=2 0000000002
+dbname
+rpname
+cpu,type=idle,host=serverB value=92.6,another=2 0000000002
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.6,another=5 0000000003
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.6,another=5 0000000003
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.1,another=3 0000000004
+dbname
+rpname
+cpu,type=idle,host=serverB value=93.1,another=3 0000000004
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.6,another=2 0000000005
+dbname
+rpname
+cpu,type=idle,host=serverB value=92.6,another=2 0000000005
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.8,another=5 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.8,another=5 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverC value=95.8,another=5 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.7,another=2 0000000007
+dbname
+rpname
+cpu,type=idle,host=serverB value=92.7,another=2 0000000007
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.0,another=6 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverB value=96.0,another=6 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.4,another=3 0000000009
+dbname
+rpname
+cpu,type=idle,host=serverB value=93.4,another=3 0000000009
+dbname
+rpname
+disk,type=sda,host=serverB value=42,another=23  0000000009
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.3,another=5 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.3,another=5 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.4,another=6 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverB value=96.4,another=6 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1,another=5 0000000012
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.1,another=5 0000000012

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -3619,7 +3619,7 @@ stream
 	}
 }
 
-func TestStream_SelectorsPreserveTags(t *testing.T) {
+func TestStream_Selectors(t *testing.T) {
 
 	var script = `
 stream
@@ -3629,23 +3629,24 @@ stream
 		.period(10s)
 		.every(10s)
 	|last('value')
-	|httpOut('TestStream_SimpleMR')
+	|httpOut('TestStream_Selectors')
 `
 	er := kapacitor.Result{
 		Series: imodels.Rows{
 			{
 				Name:    "cpu",
 				Tags:    map[string]string{"host": "serverA", "type": "idle"},
-				Columns: []string{"time", "last"},
+				Columns: []string{"time", "another", "last"},
 				Values: [][]interface{}{[]interface{}{
 					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					5.0,
 					95.3,
 				}},
 			},
 		},
 	}
 
-	testStreamerWithOutput(t, "TestStream_SimpleMR", script, 15*time.Second, er, nil, false)
+	testStreamerWithOutput(t, "TestStream_Selectors", script, 15*time.Second, er, nil, false)
 }
 
 func TestStream_TopSelector(t *testing.T) {


### PR DESCRIPTION
This finishes up the work to preserve fields along with tags.

The selected field will be renamed as per normal operations. i.e

```
|last('mean')
   .as('last_mean')
```

The mean field will be renamed to last_mean and all other fields will remain the same.