### PR TITLE
Track ingress stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ In order to know if subscription writes are being dropped you should monitor the
 - [#562](https://github.com/influxdata/kapacitor/pull/562): HTTP based subscriptions.
 - [#595](https://github.com/influxdata/kapacitor/pull/595): Support counting and summing empty batches to 0.
 - [#596](https://github.com/influxdata/kapacitor/pull/596): Support new group by time offset i.e. time(30s, 5s)
+- [#416](https://github.com/influxdata/kapacitor/issues/416): Track ingress counts by database, retention policy, and measurement. Expose stats via cli.
 
 
 ### Bugfixes

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -119,7 +119,7 @@ func NewServer(c *Config, buildInfo *BuildInfo, logService logging.Interface) (*
 	s.Logger.Printf("I! ClusterID: %s ServerID: %s", s.ClusterID, s.ServerID)
 
 	// Start Task Master
-	s.TaskMaster = kapacitor.NewTaskMaster(logService)
+	s.TaskMaster = kapacitor.NewTaskMaster("main", logService)
 	if err := s.TaskMaster.Open(); err != nil {
 		return nil, err
 	}

--- a/expvar/expvar.go
+++ b/expvar/expvar.go
@@ -22,7 +22,7 @@ type FloatVar interface {
 }
 
 type StringVar interface {
-	StringValue() float64
+	StringValue() string
 }
 
 // Int is a 64-bit integer variable that satisfies the expvar.Var interface.

--- a/integrations/batcher_test.go
+++ b/integrations/batcher_test.go
@@ -1015,7 +1015,7 @@ func testBatcher(t *testing.T, name, script string) (clock.Setter, *kapacitor.Ex
 	}
 
 	// Create a new execution env
-	tm := kapacitor.NewTaskMaster(logService)
+	tm := kapacitor.NewTaskMaster("testBatcher", logService)
 	tm.HTTPDService = httpService
 	tm.TaskStore = taskStore{}
 	tm.DeadmanService = deadman{}

--- a/integrations/benchmark_test.go
+++ b/integrations/benchmark_test.go
@@ -144,7 +144,7 @@ func Bench(b *testing.B, tasksCount, pointCount int, db, rp, measurement, tickSc
 	for i := 0; i < b.N; i++ {
 		// Do not time setup
 		b.StopTimer()
-		tm := kapacitor.NewTaskMaster(&LogService{})
+		tm := kapacitor.NewTaskMaster("bench", &LogService{})
 		tm.HTTPDService = httpdService
 		tm.UDFService = nil
 		tm.TaskStore = taskStore{}

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -4673,7 +4673,7 @@ func testStreamer(
 	}
 
 	// Create a new execution env
-	tm := kapacitor.NewTaskMaster(logService)
+	tm := kapacitor.NewTaskMaster("testStreamer", logService)
 	tm.HTTPDService = httpService
 	tm.UDFService = udfService
 	tm.TaskStore = taskStore{}

--- a/node.go
+++ b/node.go
@@ -233,10 +233,16 @@ func (n *node) edot(buf *bytes.Buffer, labels bool) {
 			),
 		))
 		n.statMap.DoSorted(func(kv expvar.KeyValue) {
+			var s string
+			if sv, ok := kv.Value.(kexpvar.StringVar); ok {
+				s = sv.StringValue()
+			} else {
+				s = kv.Value.String()
+			}
 			buf.Write([]byte(
 				fmt.Sprintf("%s=\"%s\" ",
 					kv.Key,
-					kv.Value.String(),
+					s,
 				),
 			))
 		})
@@ -329,6 +335,10 @@ type MaxDuration struct {
 }
 
 func (v *MaxDuration) String() string {
+	return `"` + v.StringValue() + `"`
+}
+
+func (v *MaxDuration) StringValue() string {
 	return time.Duration(v.IntValue()).String()
 }
 


### PR DESCRIPTION
Track ingress stats. Fixes #416

Kapacitor now counts all points received independent of a task listening for the data.
This helps debug issues with Kapacitor subscriptions etc.

There are three ways to access these stats:

1. Via the API at /debug/vars
2. Via the `_kapacitor` internal db
3. Via the cli  `kapacitor stats ingress`

>NOTE: Since there can be multiple task_masters internal to Kapacitor for recordings/replays etc, the stats tagged with `task_master=main` are the stats for normal operation.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated