### PR TITLE
update batch group stats to be by len(b.Points)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,8 @@ batch
 - [#586](https://github.com/influxdata/kapacitor/pull/586): Add spread stateful function. thanks @upccup!
 - [#600](https://github.com/influxdata/kapacitor/pull/600): Add close http response after handler laert post, thanks @jsvisa!
 - [#606](https://github.com/influxdata/kapacitor/pull/606): Add Holt-Winters forecasting method.
+- [#605](https://github.com/influxdata/kapacitor/pull/605): BREAKING: StatsNode for batch edge now count the number of points in a batch instead of count batches as a whole.
+    This is only breaking if you have a deadman switch configured on a batch edge.
 
 ### Bugfixes
 


### PR DESCRIPTION
So there are several stats that Kapacitor keeps track of, and they have different uses. 

1. Every edge has an emitted/collected counters.  These are the stats printed in the `kapacitor show ` command under processed.
2. Every edge has emitted/collected counters for each group of the source node. These are the stats used for deadman's switch aka the StatsNode.

Depending on the edge type the counters count different things.

For Stream edges its simple. The counters always count the number of points emitted or collected.

For batch its different. You can count the number of batches or the number of points in each batch. Both counts are important as such this PR changes the behavior so we can capture both values.

Above first counters count the number of batches the edge has processed. The second counters by group count the number of points per batch. Which if an empty batch is emitted means the counter will not increase. (NOTE: empty batches are preserved now from `where` filters etc, but still not produced from QueryNodes , see #595) 

In summary if the StatsNode will report the number of points processed for each group independent of edge type. The basic edge counters report number of points for stream and number of batches for batch edges.

This change makes it so you can consume the StatsNode consistently independent of edge type.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
