### PR TITLE
Expire groups after X number of zero events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,10 @@ batch
 - [#606](https://github.com/influxdata/kapacitor/pull/606): Add Holt-Winters forecasting method.
 - [#605](https://github.com/influxdata/kapacitor/pull/605): BREAKING: StatsNode for batch edge now count the number of points in a batch instead of count batches as a whole.
     This is only breaking if you have a deadman switch configured on a batch edge.
+- [#598](https://github.com/influxdata/kapacitor/pull/598): BREAKING: Change StatsNode to expire groups after X number of points with zero value.
+    This allows for the deadman's switch to expire groups that will never return.
+    This change is only breaking if you relied on the deadman to continually alert on zero values.
+    Now the deadman will alert for only the first X zero values and then stop, effectively setting .stateChangesOnly() for alert node.
 
 ### Bugfixes
 

--- a/edge.go
+++ b/edge.go
@@ -91,6 +91,14 @@ type edgeStat struct {
 	dims      []string
 }
 
+func (e *Edge) expireGroups(groups []models.GroupID) {
+	e.groupMu.Lock()
+	defer e.groupMu.Unlock()
+	for _, group := range groups {
+		delete(e.groupStats, group)
+	}
+}
+
 // Get a snapshot of the current group statistics for this edge
 func (e *Edge) readGroupStats(f func(group models.GroupID, collected, emitted int64, tags models.Tags, dims []string)) {
 	e.groupMu.RLock()

--- a/tick/stateful/evaluation_funcs.go
+++ b/tick/stateful/evaluation_funcs.go
@@ -1208,6 +1208,24 @@ var evaluationFuncs = map[operationKey]*evaluationFnInfo{
 		},
 		returnType: ast.TDuration,
 	},
+	operationKey{operator: ast.TokenDiv, leftType: ast.TDuration, rightType: ast.TDuration}: {
+		f: func(scope *Scope, executionState ExecutionState, leftNode, rightNode NodeEvaluator) (resultContainer, *ErrSide) {
+			var left time.Duration
+			var right time.Duration
+			var err error
+
+			if left, err = leftNode.EvalDuration(scope, executionState); err != nil {
+				return emptyResultContainer, &ErrSide{error: err, IsLeft: true}
+			}
+
+			if right, err = rightNode.EvalDuration(scope, executionState); err != nil {
+				return emptyResultContainer, &ErrSide{error: err, IsRight: true}
+			}
+
+			return resultContainer{Int64Value: int64(left / right), IsInt64Value: true}, nil
+		},
+		returnType: ast.TInt,
+	},
 
 	// -----------------------------------------
 	//	String concatenation func


### PR DESCRIPTION
Expire a group after X number of stats points are received with zero value.

This allows for deaman groups to expire after giving an alert.

TODO
- [ ]  Test inverted deadman, aka alert on high counts
- [ ] Be able to disable expiring alerts for deadman method
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated

Some thoughts:

Maybe we want to extend this kind of logic beyond just the StatsNode. All nodes would benefit from being able to free up resources for expired groups. There should probably be two ways to expire groups.
1. Implicitly via some sort of timeout or zero count (like the PR is already doing)
2. Explicitly via an API call, so it can be managed externally to Kapacitor. (i.e. shutdown hook when a server is being retired)
