### PR TITLE
Change the batch record/replay actions to get the cluster info from t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ batch
 - [#584](https://github.com/influxdata/kapacitor/issues/584): Do not block during startup to send usage stats.
 - [#553](https://github.com/influxdata/kapacitor/issues/553): Periodically check if new InfluxDB DBRPs have been created.
 - [#602](https://github.com/influxdata/kapacitor/issues/602): Fix missing To property on email alert handler.
+- [#581](https://github.com/influxdata/kapacitor/issues/581): Record/Replay batch tasks get cluster info from task not API.
 
 ## v0.13.1 [2016-05-13]
 

--- a/batch.go
+++ b/batch.go
@@ -94,10 +94,19 @@ func (s *BatchNode) Abort() {
 	}
 }
 
-func (s *BatchNode) Queries(start, stop time.Time) [][]string {
-	queries := make([][]string, len(s.children))
+type BatchQueries struct {
+	Queries []string
+	Cluster string
+}
+
+func (s *BatchNode) Queries(start, stop time.Time) []BatchQueries {
+	queries := make([]BatchQueries, len(s.children))
 	for i, b := range s.children {
-		queries[i] = b.(*QueryNode).Queries(start, stop)
+		qn := b.(*QueryNode)
+		queries[i] = BatchQueries{
+			Queries: qn.Queries(start, stop),
+			Cluster: qn.Cluster(),
+		}
 	}
 	return queries
 }
@@ -204,6 +213,10 @@ func (b *QueryNode) Start() {
 
 func (b *QueryNode) Abort() {
 	close(b.aborting)
+}
+
+func (b *QueryNode) Cluster() string {
+	return b.b.Cluster
 }
 
 func (b *QueryNode) Queries(start, stop time.Time) []string {

--- a/client/API.md
+++ b/client/API.md
@@ -791,7 +791,6 @@ A recording ID is returned to later identify the recording.
 | task      | ID of a task, records the results of the queries defined in the task.                                            |
 | start     | Earliest date for which data will be recorded. RFC3339Nano formatted.                                            |
 | stop      | Latest date for which data will be recorded. If not specified uses the current time. RFC3339Nano formatted data. |
-| cluster   | Name of a configured InfluxDB cluster. If empty uses the default cluster.                                        |
 
 ##### Query
 
@@ -1121,7 +1120,6 @@ and so is not supported.
 | task           |         | ID of a task, replays the results of the queries defined in the task against the task.                                                                                                                                                                            |
 | start          |         | Earliest date for which data will be replayed. RFC3339Nano formatted.                                                                                                                                                                            |
 | stop           | now     | Latest date for which data will be replayed. If not specified uses the current time. RFC3339Nano formatted data.                                                                                                                                 |
-| cluster        |         | Name of a configured InfluxDB cluster. If empty uses the default cluster.                                                                                                                                                                        |
 | recording-time | false   | If true, use the times in the recording, otherwise adjust times relative to the current time.                                                                                                                                                    |
 | clock          | fast    | One of `fast` or `real`. If `real` wait for real time to pass corresponding with the time in the recordings. If `fast` replay data without delay. For example, if clock is `real` then a stream recording of duration 5m will take 5m to replay. |
 

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -1073,11 +1073,10 @@ func (c *Client) RecordStream(opt RecordStreamOptions) (Recording, error) {
 }
 
 type RecordBatchOptions struct {
-	ID      string    `json:"id,omitempty"`
-	Task    string    `json:"task"`
-	Start   time.Time `json:"start"`
-	Stop    time.Time `json:"stop"`
-	Cluster string    `json:"cluster,omitempty"`
+	ID    string    `json:"id,omitempty"`
+	Task  string    `json:"task"`
+	Start time.Time `json:"start"`
+	Stop  time.Time `json:"stop"`
 }
 
 // Record the batch queries for a task.
@@ -1260,7 +1259,6 @@ type ReplayBatchOptions struct {
 	Task          string    `json:"task"`
 	Start         time.Time `json:"start"`
 	Stop          time.Time `json:"stop"`
-	Cluster       string    `json:"cluster,omitempty"`
 	RecordingTime bool      `json:"recording-time"`
 	Clock         Clock     `json:"clock"`
 }

--- a/client/v1/client_test.go
+++ b/client/v1/client_test.go
@@ -1215,8 +1215,7 @@ func Test_RecordBatch(t *testing.T) {
 		if r.URL.Path == "/kapacitor/v1/recordings/batch" && r.Method == "POST" &&
 			opts.Task == "taskname" &&
 			opts.Start == start &&
-			opts.Stop == stop &&
-			opts.Cluster == "" {
+			opts.Stop == stop {
 			w.WriteHeader(http.StatusCreated)
 			fmt.Fprintf(w, `{"link": {"rel":"self", "href":"/kapacitor/v1/recordings/rid1"}, "id":"rid1"}`)
 		} else {
@@ -1663,7 +1662,6 @@ func Test_ReplayBatch(t *testing.T) {
 		Task:          "taskname",
 		Start:         start,
 		Stop:          stop,
-		Cluster:       "mycluster",
 		Clock:         client.Real,
 		RecordingTime: true,
 	})

--- a/client/v1/swagger.yml
+++ b/client/v1/swagger.yml
@@ -376,8 +376,6 @@ paths:
               stop:
                 type: string
                 format: dateTime
-              cluster:
-                type: string
             required:
               - task
               - start
@@ -605,8 +603,6 @@ paths:
               stop:
                 type: string
                 format: dateTime
-              cluster:
-                type: string
               recording-time:
                 type: boolean
                 default: false

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -269,7 +269,6 @@ var (
 	rbStart          = recordBatchFlags.String("start", "", "The start time for the set of queries.")
 	rbStop           = recordBatchFlags.String("stop", "", "The stop time for the set of queries (default now).")
 	rbPast           = recordBatchFlags.String("past", "", "Set start time via 'now - past'.")
-	rbCluster        = recordBatchFlags.String("cluster", "", "Optional named InfluxDB cluster from configuration.")
 	rbNowait         = recordBatchFlags.Bool("no-wait", false, "Do not wait for the recording to finish.")
 	rbId             = recordBatchFlags.String("recording-id", "", "The ID to give to this recording. If not set an random ID is chosen.")
 
@@ -430,11 +429,10 @@ func doRecord(args []string) error {
 		}
 		noWait = *rbNowait
 		recording, err = cli.RecordBatch(client.RecordBatchOptions{
-			ID:      *rbId,
-			Task:    *rbTask,
-			Cluster: *rbCluster,
-			Start:   start,
-			Stop:    stop,
+			ID:    *rbId,
+			Task:  *rbTask,
+			Start: start,
+			Stop:  stop,
 		})
 		if err != nil {
 			return err
@@ -859,7 +857,6 @@ var (
 	rlbStart             = replayLiveBatchFlags.String("start", "", "The start time for the set of queries.")
 	rlbStop              = replayLiveBatchFlags.String("stop", "", "The stop time for the set of queries (default now).")
 	rlbPast              = replayLiveBatchFlags.String("past", "", "Set start time via 'now - past'.")
-	rlbCluster           = replayLiveBatchFlags.String("cluster", "", "Optional named InfluxDB cluster from configuration.")
 
 	replayLiveQueryFlags = flag.NewFlagSet("replay-live-query", flag.ExitOnError)
 	rlqTask              = replayLiveQueryFlags.String("task", "", "The task ID.")
@@ -980,7 +977,6 @@ func doReplayLive(args []string) error {
 			Task:          *rlbTask,
 			Start:         start,
 			Stop:          stop,
-			Cluster:       *rlbCluster,
 			RecordingTime: *rlbRec,
 			Clock:         clk,
 		})

--- a/task.go
+++ b/task.go
@@ -271,7 +271,7 @@ func (et *ExecutingTask) BatchCount() (int, error) {
 }
 
 // Get the next `num` batch queries that the batcher will run starting at time `start`.
-func (et *ExecutingTask) BatchQueries(start, stop time.Time) ([][]string, error) {
+func (et *ExecutingTask) BatchQueries(start, stop time.Time) ([]BatchQueries, error) {
 	if et.Task.Type != BatchTask {
 		return nil, ErrWrongTaskType
 	}


### PR DESCRIPTION
Fixes #581 

The cluster option has been removed from the batch record/replay-live options. The cluster information is retrieved directly from the task.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
