### PR TITLE
Allow Task and Template IDs to be modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,8 @@ batch
 - [#553](https://github.com/influxdata/kapacitor/issues/553): Periodically check if new InfluxDB DBRPs have been created.
 - [#602](https://github.com/influxdata/kapacitor/issues/602): Fix missing To property on email alert handler.
 - [#581](https://github.com/influxdata/kapacitor/issues/581): Record/Replay batch tasks get cluster info from task not API.
+- [#613](https://github.com/influxdata/kapacitor/issues/613): BREAKING: Allow the ID of templates and tasks to be updated via the PATCH method.
+    The breaking change is that now PATCH request return a 200 with the template or task definition, where before they returned 204.
 
 ## v0.13.1 [2016-05-13]
 

--- a/client/API.md
+++ b/client/API.md
@@ -246,7 +246,6 @@ Response with task id and link.
 | Code | Meaning                                  |
 | ---- | -------                                  |
 | 200  | Task created, contains task information. |
-| 204  | Task updated, no content                 |
 | 404  | Task does not exist                      |
 
 ### Get Task
@@ -587,7 +586,6 @@ PATCH /kapacitor/v1/templates/TEMPLATE_ID
 | Code | Meaning                                          |
 | ---- | -------                                          |
 | 200  | Template created, contains template information. |
-| 204  | Template updated, no content                     |
 | 404  | Template does not exist                          |
 
 ### Get Template

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -651,6 +651,7 @@ func (c *Client) CreateTask(opt CreateTaskOptions) (Task, error) {
 }
 
 type UpdateTaskOptions struct {
+	ID         string     `json:"id,omitempty"`
 	TemplateID string     `json:"template-id,omitempty"`
 	Type       TaskType   `json:"type,omitempty"`
 	DBRPs      []DBRP     `json:"dbrps,omitempty"`
@@ -661,16 +662,17 @@ type UpdateTaskOptions struct {
 
 // Update an existing task.
 // Only fields that are not their default value will be updated.
-func (c *Client) UpdateTask(link Link, opt UpdateTaskOptions) error {
+func (c *Client) UpdateTask(link Link, opt UpdateTaskOptions) (Task, error) {
+	t := Task{}
 	if link.Href == "" {
-		return fmt.Errorf("invalid link %v", link)
+		return t, fmt.Errorf("invalid link %v", link)
 	}
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	err := enc.Encode(opt)
 	if err != nil {
-		return err
+		return t, err
 	}
 
 	u := *c.url
@@ -678,14 +680,14 @@ func (c *Client) UpdateTask(link Link, opt UpdateTaskOptions) error {
 
 	req, err := http.NewRequest("PATCH", u.String(), &buf)
 	if err != nil {
-		return err
+		return t, err
 	}
 
-	_, err = c.do(req, nil, http.StatusNoContent)
+	_, err = c.do(req, &t, http.StatusOK)
 	if err != nil {
-		return err
+		return t, err
 	}
-	return nil
+	return t, nil
 }
 
 type TaskOptions struct {
@@ -860,22 +862,24 @@ func (c *Client) CreateTemplate(opt CreateTemplateOptions) (Template, error) {
 }
 
 type UpdateTemplateOptions struct {
+	ID         string   `json:"id,omitempty"`
 	Type       TaskType `json:"type,omitempty"`
 	TICKscript string   `json:"script,omitempty"`
 }
 
 // Update an existing template.
 // Only fields that are not their default value will be updated.
-func (c *Client) UpdateTemplate(link Link, opt UpdateTemplateOptions) error {
+func (c *Client) UpdateTemplate(link Link, opt UpdateTemplateOptions) (Template, error) {
+	t := Template{}
 	if link.Href == "" {
-		return fmt.Errorf("invalid link %v", link)
+		return t, fmt.Errorf("invalid link %v", link)
 	}
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	err := enc.Encode(opt)
 	if err != nil {
-		return err
+		return t, err
 	}
 
 	u := *c.url
@@ -883,14 +887,14 @@ func (c *Client) UpdateTemplate(link Link, opt UpdateTemplateOptions) error {
 
 	req, err := http.NewRequest("PATCH", u.String(), &buf)
 	if err != nil {
-		return err
+		return t, err
 	}
 
-	_, err = c.do(req, nil, http.StatusNoContent)
+	_, err = c.do(req, &t, http.StatusOK)
 	if err != nil {
-		return err
+		return t, err
 	}
-	return nil
+	return t, nil
 }
 
 type TemplateOptions struct {

--- a/client/v1/client_test.go
+++ b/client/v1/client_test.go
@@ -54,7 +54,7 @@ func Test_ReportsErrors(t *testing.T) {
 		{
 			name: "UpdateTask",
 			fnc: func(c *client.Client) error {
-				err := c.UpdateTask(c.TaskLink(""), client.UpdateTaskOptions{})
+				_, err := c.UpdateTask(c.TaskLink(""), client.UpdateTaskOptions{})
 				return err
 			},
 		},
@@ -89,7 +89,7 @@ func Test_ReportsErrors(t *testing.T) {
 		{
 			name: "UpdateTemplate",
 			fnc: func(c *client.Client) error {
-				err := c.UpdateTemplate(c.TemplateLink(""), client.UpdateTemplateOptions{})
+				_, err := c.UpdateTemplate(c.TemplateLink(""), client.UpdateTemplateOptions{})
 				return err
 			},
 		},
@@ -516,7 +516,8 @@ func Test_UpdateTask(t *testing.T) {
 				w.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintf(w, "unexpected UpdateTask body: got:\n%v\nexp:\n%v\n", task, exp)
 			} else {
-				w.WriteHeader(http.StatusNoContent)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"link": {"rel":"self", "href":"/kapacitor/v1/tasks/taskname"}, "id":"taskname"}`)
 			}
 		} else {
 			w.WriteHeader(http.StatusBadRequest)
@@ -528,7 +529,7 @@ func Test_UpdateTask(t *testing.T) {
 	}
 	defer s.Close()
 
-	err = c.UpdateTask(
+	task, err := c.UpdateTask(
 		c.TaskLink("taskname"),
 		client.UpdateTaskOptions{
 			DBRPs: []client.DBRP{{Database: "newdb", RetentionPolicy: "rpname"}},
@@ -547,6 +548,9 @@ func Test_UpdateTask(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if got, exp := task.Link.Href, "/kapacitor/v1/tasks/taskname"; got != exp {
+		t.Errorf("unexpected link.Href got %s exp %s", got, exp)
+	}
 }
 
 func Test_UpdateTask_Enable(t *testing.T) {
@@ -563,7 +567,8 @@ func Test_UpdateTask_Enable(t *testing.T) {
 				w.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintf(w, "unexpected UpdateTask body: got:\n%v\nexp:\n%v\n", task, exp)
 			} else {
-				w.WriteHeader(http.StatusNoContent)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"link": {"rel":"self", "href":"/kapacitor/v1/tasks/taskname"}, "id":"taskname", "status": "enabled"}`)
 			}
 		} else {
 			w.WriteHeader(http.StatusBadRequest)
@@ -575,7 +580,7 @@ func Test_UpdateTask_Enable(t *testing.T) {
 	}
 	defer s.Close()
 
-	err = c.UpdateTask(
+	task, err := c.UpdateTask(
 		c.TaskLink("taskname"),
 		client.UpdateTaskOptions{
 			Status: client.Enabled,
@@ -583,6 +588,12 @@ func Test_UpdateTask_Enable(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if got, exp := task.Link.Href, "/kapacitor/v1/tasks/taskname"; got != exp {
+		t.Errorf("unexpected link.Href got %s exp %s", got, exp)
+	}
+	if got, exp := task.Status, client.Enabled; got != exp {
+		t.Errorf("unexpected task.Status got %s exp %s", got, exp)
 	}
 }
 
@@ -601,7 +612,8 @@ func Test_UpdateTask_Disable(t *testing.T) {
 				w.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintf(w, "unexpected UpdateTask body: got:\n%v\nexp:\n%v\n", task, exp)
 			} else {
-				w.WriteHeader(http.StatusNoContent)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"link": {"rel":"self", "href":"/kapacitor/v1/tasks/taskname"}, "id":"taskname", "status": "disabled"}`)
 			}
 		} else {
 			w.WriteHeader(http.StatusBadRequest)
@@ -613,13 +625,19 @@ func Test_UpdateTask_Disable(t *testing.T) {
 	}
 	defer s.Close()
 
-	err = c.UpdateTask(
+	task, err := c.UpdateTask(
 		c.TaskLink("taskname"),
 		client.UpdateTaskOptions{
 			Status: client.Disabled,
 		})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if got, exp := task.Link.Href, "/kapacitor/v1/tasks/taskname"; got != exp {
+		t.Errorf("unexpected link.Href got %s exp %s", got, exp)
+	}
+	if got, exp := task.Status, client.Disabled; got != exp {
+		t.Errorf("unexpected task.Status got %s exp %s", got, exp)
 	}
 }
 
@@ -990,14 +1008,14 @@ func Test_CreateTemplate(t *testing.T) {
 		Type:       client.StreamTask,
 		TICKscript: tickScript,
 	})
-	if got, exp := string(template.Link.Href), "/kapacitor/v1/templates/templatename"; got != exp {
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := template.Link.Href, "/kapacitor/v1/templates/templatename"; got != exp {
 		t.Errorf("unexpected template link got %s exp %s", got, exp)
 	}
 	if got, exp := template.ID, "templatename"; got != exp {
 		t.Errorf("unexpected template ID got %s exp %s", got, exp)
-	}
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -1015,7 +1033,8 @@ func Test_UpdateTemplate(t *testing.T) {
 				w.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintf(w, "unexpected UpdateTemplate body: got:\n%v\nexp:\n%v\n", template, exp)
 			} else {
-				w.WriteHeader(http.StatusNoContent)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"link": {"rel":"self", "href":"/kapacitor/v1/templates/templatename"}, "id":"templatename"}`)
 			}
 		} else {
 			w.WriteHeader(http.StatusBadRequest)
@@ -1027,7 +1046,7 @@ func Test_UpdateTemplate(t *testing.T) {
 	}
 	defer s.Close()
 
-	err = c.UpdateTemplate(
+	template, err := c.UpdateTemplate(
 		c.TemplateLink("templatename"),
 		client.UpdateTemplateOptions{
 			Type: client.BatchTask,
@@ -1035,6 +1054,12 @@ func Test_UpdateTemplate(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if got, exp := template.Link.Href, "/kapacitor/v1/templates/templatename"; got != exp {
+		t.Errorf("unexpected template link got %s exp %s", got, exp)
+	}
+	if got, exp := template.ID, "templatename"; got != exp {
+		t.Errorf("unexpected template ID got %s exp %s", got, exp)
 	}
 }
 

--- a/client/v1/swagger.yml
+++ b/client/v1/swagger.yml
@@ -100,8 +100,10 @@ paths:
           schema:
             $ref: '#/definitions/Task'
       responses:
-        '204':
+        '200':
           description: Update succeeded
+          schema:
+            $ref: '#/definitions/Task'
         default:
           description: A processing or an unexpected error.
           schema:
@@ -233,8 +235,10 @@ paths:
           schema:
             $ref: '#/definitions/Template'
       responses:
-        '204':
+        '200':
           description: Update succeeded
+          schema:
+            $ref: '#/definitions/Template'
         default:
           description: A processing or an unexpected error.
           schema:

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -652,7 +652,7 @@ func doDefine(args []string) error {
 			Status:     client.Disabled,
 		})
 	} else {
-		err = cli.UpdateTask(
+		_, err = cli.UpdateTask(
 			l,
 			client.UpdateTaskOptions{
 				TemplateID: *dtemplate,
@@ -668,11 +668,11 @@ func doDefine(args []string) error {
 	}
 
 	if !*dnoReload && task.Status == client.Enabled {
-		err := cli.UpdateTask(l, client.UpdateTaskOptions{Status: client.Disabled})
+		_, err := cli.UpdateTask(l, client.UpdateTaskOptions{Status: client.Disabled})
 		if err != nil {
 			return err
 		}
-		err = cli.UpdateTask(l, client.UpdateTaskOptions{Status: client.Enabled})
+		_, err = cli.UpdateTask(l, client.UpdateTaskOptions{Status: client.Enabled})
 		if err != nil {
 			return err
 		}
@@ -761,7 +761,7 @@ func doDefineTemplate(args []string) error {
 			TICKscript: script,
 		})
 	} else {
-		err = cli.UpdateTemplate(
+		_, err = cli.UpdateTemplate(
 			l,
 			client.UpdateTemplateOptions{
 				Type:       ttype,
@@ -1070,7 +1070,7 @@ func doEnable(args []string) error {
 				return errors.Wrap(err, "listing tasks")
 			}
 			for _, task := range tasks {
-				err := cli.UpdateTask(
+				_, err := cli.UpdateTask(
 					task.Link,
 					client.UpdateTaskOptions{Status: client.Enabled},
 				)
@@ -1128,7 +1128,7 @@ func doDisable(args []string) error {
 				return errors.Wrap(err, "listing tasks")
 			}
 			for _, task := range tasks {
-				err := cli.UpdateTask(
+				_, err := cli.UpdateTask(
 					task.Link,
 					client.UpdateTaskOptions{Status: client.Disabled},
 				)

--- a/services/task_store/dao.go
+++ b/services/task_store/dao.go
@@ -466,27 +466,11 @@ func (d *templateKV) Delete(id string) error {
 }
 
 func (d *templateKV) AssociateTask(templateId, taskId string) error {
-	key := d.templateDataKey(templateId)
-	exists, err := d.store.Exists(key)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return ErrNoTemplateExists
-	}
 	akey := d.templateTaskAssociationKey(templateId, taskId)
 	return d.store.Put(akey, []byte(taskId))
 }
 
 func (d *templateKV) DisassociateTask(templateId, taskId string) error {
-	key := d.templateDataKey(templateId)
-	exists, err := d.store.Exists(key)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return ErrNoTemplateExists
-	}
 	akey := d.templateTaskAssociationKey(templateId, taskId)
 	return d.store.Delete(akey)
 }


### PR DESCRIPTION
Fixes #613 
A small breaking change to the API was introduced where the PATCH requests new return the complete object definition instead of a 204. This allows for the client to update its link if the ID changed.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
