### PR TITLE
Bash auto completion: Path fixes

### DIFF
--- a/usr/share/bash-completion/completions/kapacitor
+++ b/usr/share/bash-completion/completions/kapacitor
@@ -1,3 +1,10 @@
+__kapacitor_filter_ticks()
+{
+#$1=cmd
+#$2=word
+#$3=prev
+	return 0
+}
 
 # Bash completion for the kapacitor command.
 _kapacitor()
@@ -49,7 +56,10 @@ _kapacitor()
                         words=$(_kapacitor_dbrps)
                         ;;
                     -tick)
-                        COMPREPLY=($(compgen -o filenames -A file -X '!*.tick' -- "$cur"))
+                        COMPREPLY=($(compgen -o filenames -A file -X '!*.tick' -S ' ' -- "$cur") )
+                        didi=$(compgen -d -S '/' -- "$cur")
+                        COMPREPLY=(${COMPREPLY[@]:-} $didi )
+                        compopt -o nospace
                         ;;
                     -type)
                         words='batch stream'

--- a/usr/share/bash-completion/completions/kapacitor
+++ b/usr/share/bash-completion/completions/kapacitor
@@ -1,11 +1,3 @@
-__kapacitor_filter_ticks()
-{
-#$1=cmd
-#$2=word
-#$3=prev
-	return 0
-}
-
 # Bash completion for the kapacitor command.
 _kapacitor()
 {
@@ -56,10 +48,7 @@ _kapacitor()
                         words=$(_kapacitor_dbrps)
                         ;;
                     -tick)
-                        COMPREPLY=($(compgen -o filenames -A file -X '!*.tick' -S ' ' -- "$cur") )
-                        didi=$(compgen -d -S '/' -- "$cur")
-                        COMPREPLY=(${COMPREPLY[@]:-} $didi )
-                        compopt -o nospace
+			_kapacitor_tick_files "${cur}"
                         ;;
                     -type)
                         words='batch stream'
@@ -68,7 +57,12 @@ _kapacitor()
                         words=$(_kapacitor_list templates "$cur")
                         ;;
                     -vars)
-                        COMPREPLY=($(compgen -o filenames -A file -- "$cur"))
+			local didi
+                        COMPREPLY=($(compgen -o filenames -A file -X '*/' -S ' ' -- "$cur") )
+                        didi=$(compgen -d -S '/' -- "$cur")
+                        COMPREPLY=(${COMPREPLY[@]:-} $didi )
+                        compopt -o nospace
+                        #COMPREPLY=($(compgen -o filenames -A file -- "$cur"))
                         ;;
                     *)
                         words='-dbrp -no-reload -tick -type -template -vars'
@@ -173,6 +167,22 @@ _kapacitor()
     fi
 
     return 0
+}
+
+_kapacitor_tick_files()
+{
+	local c i=0 didi cur="$1"
+        COMPREPLY=($(compgen -o filenames -f -X '!*.tick' -- "$cur") )
+        didi=$(compgen -d -- "$cur")
+        COMPREPLY=(${COMPREPLY[@]:-} $didi )
+	for c in "${COMPREPLY[@]}"; do
+		if [ -d "${c}" ]; then
+			COMPREPLY[i++]="${c}/";
+		else
+			COMPREPLY[i++]="${c} ";
+		fi
+	done
+        compopt -o nospace
 }
 
 _kapacitor_list()

--- a/usr/share/bash-completion/completions/kapacitor
+++ b/usr/share/bash-completion/completions/kapacitor
@@ -57,12 +57,7 @@ _kapacitor()
                         words=$(_kapacitor_list templates "$cur")
                         ;;
                     -vars)
-			local didi
-                        COMPREPLY=($(compgen -o filenames -A file -X '*/' -S ' ' -- "$cur") )
-                        didi=$(compgen -d -S '/' -- "$cur")
-                        COMPREPLY=(${COMPREPLY[@]:-} $didi )
-                        compopt -o nospace
-                        #COMPREPLY=($(compgen -o filenames -A file -- "$cur"))
+			_kapacitor_json_files "${cur}"
                         ;;
                     *)
                         words='-dbrp -no-reload -tick -type -template -vars'
@@ -169,12 +164,10 @@ _kapacitor()
     return 0
 }
 
-_kapacitor_tick_files()
+_kapacitor_files_add_postfix()
 {
-	local c i=0 didi cur="$1"
-        COMPREPLY=($(compgen -o filenames -f -X '!*.tick' -- "$cur") )
-        didi=$(compgen -d -- "$cur")
-        COMPREPLY=(${COMPREPLY[@]:-} $didi )
+	#Add a slash (directories) or space (files except directories) after name
+	local c i=0
 	for c in "${COMPREPLY[@]}"; do
 		if [ -d "${c}" ]; then
 			COMPREPLY[i++]="${c}/";
@@ -183,6 +176,24 @@ _kapacitor_tick_files()
 		fi
 	done
         compopt -o nospace
+}
+
+_kapacitor_tick_files()
+{
+	local didi cur="$1"
+        COMPREPLY=($(compgen -o filenames -f -X '!*.tick' -- "$cur") )
+        didi=$(compgen -d -- "$cur")
+        COMPREPLY=(${COMPREPLY[@]:-} $didi )
+	_kapacitor_files_add_postfix
+}
+
+_kapacitor_json_files()
+{
+	local didi cur="$1"
+        COMPREPLY=($(compgen -o filenames -f -X '!*.json' -- "$cur") )
+        didi=$(compgen -d -- "$cur")
+        COMPREPLY=(${COMPREPLY[@]:-} $didi )
+	_kapacitor_files_add_postfix
 }
 
 _kapacitor_list()


### PR DESCRIPTION
I was annoyed of typing long lines at the CLI, so I started to implement a bash auto completion script for kapacitor, only to find that there is already one, well hidden in the git repo (of course I figured that out *after* I finished my own script). It seems not to be installed by the current .rpm package. Anyhow. I now base on the existing script with improved file name auto completion for ```-tick``` and ```-vars``` parameters of ```kapacitor define```.


###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Comments

- How shall I update the changelog? This pull request does not yet have a number.
- At $packager: The bash auto completion script seems not to be installed by default