### PR TITLE
fix #628, stop searching for default config location in kapacitord co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
 
 - [#621](https://github.com/influxdata/kapacitor/pull/621): Fix obscure error about single vs double quotes.
 - [#623](https://github.com/influxdata/kapacitor/pull/623): Fix issues with recording metadata missing data url.
-- [#631](https://github.com/influxdata/kapacitor/pull/631): Fix issues with using iterative lambda expressions in an EvalNode.
+- [#631](https://github.com/influxdata/kapacitor/issue/631): Fix issues with using iterative lambda expressions in an EvalNode.
+- [#628](https://github.com/influxdata/kapacitor/issue/628): BREAKING: Change `kapacitord config` to not search default location for configuration files but rather require the `-config` option.
+    Since the `kapacitord run` command behaves this way they should be consistent.
+    Fix issue with `kapacitord config > kapacitor.conf` when the output file was a default location for the config.
 
 
 ## v1.0.0-beta1 [2016-06-06]

--- a/cmd/kapacitord/run/command.go
+++ b/cmd/kapacitord/run/command.go
@@ -251,28 +251,3 @@ type Options struct {
 	LogFile    string
 	LogLevel   string
 }
-
-// GetConfigPath returns the config path from the options.
-// It will return a path by searching in this order:
-//   1. The CLI option in ConfigPath
-//   2. The environment variable KAPACITOR_CONFIG_PATH
-//   3. The first influxdb.conf file on the path:
-//        - ~/.kapacitor
-//        - /etc/kapacitor
-func (opt *Options) GetConfigPath() string {
-	if opt.ConfigPath != "" {
-		return opt.ConfigPath
-	} else if envVar := os.Getenv("KAPACITOR_CONFIG_PATH"); envVar != "" {
-		return envVar
-	}
-
-	for _, path := range []string{
-		os.ExpandEnv("${HOME}/.kapacitor/kapacitor.conf"),
-		"/etc/kapacitor/kapacitor.conf",
-	} {
-		if _, err := os.Stat(path); err == nil {
-			return path
-		}
-	}
-	return ""
-}

--- a/cmd/kapacitord/run/config_command.go
+++ b/cmd/kapacitord/run/config_command.go
@@ -37,8 +37,7 @@ func (cmd *PrintConfigCommand) Run(args ...string) error {
 	}
 
 	// Parse config from path.
-	opt := Options{ConfigPath: *configPath}
-	config, err := cmd.parseConfig(opt.GetConfigPath())
+	config, err := cmd.parseConfig(*configPath)
 	if err != nil {
 		return fmt.Errorf("parse config: %s", err)
 	}


### PR DESCRIPTION
Change the `kapacitord config` command to stop searching default locations for a config file. This makes it consistent for `kapacitor run`.

Also since this command is used to create defaults it is better if using a base config is explicit. i.e. `kapacitord config -config mydefaults.conf > newdefaults.conf`