### PR TITLE
Fix #626, fixes issues with changing task/template IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#628](https://github.com/influxdata/kapacitor/issue/628): BREAKING: Change `kapacitord config` to not search default location for configuration files but rather require the `-config` option.
     Since the `kapacitord run` command behaves this way they should be consistent.
     Fix issue with `kapacitord config > kapacitor.conf` when the output file was a default location for the config.
+- [#626](https://github.com/influxdata/kapacitor/issue/626): Fix issues when changing the ID of an enabled task.
 
 
 ## v1.0.0-beta1 [2016-06-06]

--- a/cmd/kapacitord/run/server_helper_test.go
+++ b/cmd/kapacitord/run/server_helper_test.go
@@ -35,6 +35,7 @@ func NewServer(c *run.Config) *Server {
 		Commit:  "testCommit",
 		Branch:  "testBranch",
 	}
+	c.HTTP.LogEnabled = testing.Verbose()
 	ls := &LogService{}
 	srv, err := run.NewServer(c, buildInfo, ls)
 	if err != nil {


### PR DESCRIPTION
Fixes #626 where after changing a task ID `kapacitor show` would be inaccurate.

Changing a task ID would leave the original task running under the original name so `kapacitor show` with the new name would report that the task was not running since it couldn't find it.

Now the task is stopped and started again under the new name.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
