### PR TITLE
Fixes issues with socket UDFs getting a read error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     Since the `kapacitord run` command behaves this way they should be consistent.
     Fix issue with `kapacitord config > kapacitor.conf` when the output file was a default location for the config.
 - [#626](https://github.com/influxdata/kapacitor/issue/626): Fix issues when changing the ID of an enabled task.
+- [#624](https://github.com/influxdata/kapacitor/pull/624): Fix issues where you could get a read error on a closed UDF socket.
 
 
 ## v1.0.0-beta1 [2016-06-06]

--- a/services/udf/service.go
+++ b/services/udf/service.go
@@ -69,7 +69,7 @@ func (s *Service) Create(
 	if conf.Socket != "" {
 		// Create socket UDF
 		return kapacitor.NewUDFSocket(
-			kapacitor.NewSocket(conf.Socket),
+			kapacitor.NewSocketConn(conf.Socket),
 			l,
 			time.Duration(conf.Timeout),
 			abortCallback,
@@ -115,10 +115,10 @@ func (s *Service) loadUDFInfo(name string) (udf.Info, error) {
 	if err != nil {
 		return udf.Info{}, err
 	}
+	defer u.Close()
 	info, err := u.Info()
 	if err != nil {
 		return udf.Info{}, err
 	}
-	u.Close()
 	return info, nil
 }

--- a/udf/agent/agent.go
+++ b/udf/agent/agent.go
@@ -92,7 +92,7 @@ func (a *Agent) Start() error {
 		if err != nil {
 			a.outResponses <- &udf.Response{
 				Message: &udf.Response_Error{
-					Error: &udf.ErrorResponse{err.Error()},
+					Error: &udf.ErrorResponse{Error: err.Error()},
 				},
 			}
 		}
@@ -103,7 +103,10 @@ func (a *Agent) Start() error {
 	}()
 
 	a.outGroup.Add(1)
-	go a.forwardResponses()
+	go func() {
+		defer a.outGroup.Done()
+		a.forwardResponses()
+	}()
 
 	return nil
 }
@@ -229,7 +232,6 @@ func (a *Agent) writeLoop() error {
 }
 
 func (a *Agent) forwardResponses() {
-	defer a.outGroup.Done()
 	for r := range a.responses {
 		a.outResponses <- r
 	}

--- a/udf/agent/py/agent.py
+++ b/udf/agent/py/agent.py
@@ -65,6 +65,8 @@ class Agent(object):
     # The Agent will terminate if STDIN is closed or an error occurs
     def wait(self):
         self._thread.join()
+        self._in.close()
+        self._out.close()
 
     # Write a response to STDOUT.
     # This method is thread safe.


### PR DESCRIPTION
Now when using a socket UDF the write and read ends of the socket are closed separately so they can cause error for each other.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
