### PR TITLE
Add optional to be able to show a task in the context of a replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features
 
 - [#636](https://github.com/influxdata/kapacitor/pull/636): Change HTTP logs to be in Common Log format.
+- [#](https://github.com/influxdata/kapacitor/pull/): Add optional replay ID to the task API so that you can get information about a task inside a running replay.
 
 ### Bugfixes
 

--- a/client/API.md
+++ b/client/API.md
@@ -256,6 +256,7 @@ To get information about a task make a GET request to the `/kapacitor/v1/tasks/T
 | --------------- | -------    | -------                                                                                                                          |
 | dot-view        | attributes | One of `labels` or `attributes`. Labels is less readable but will correctly render with all the information contained in labels. |
 | script-format   | formatted  | One of `formatted` or `raw`. Raw will return the script identical to how it was defined. Formatted will first format the script. |
+| replay-id       |            | Optional ID of a running replay. The returned task information will be in the context of the task for the running replay.        |
 
 
 A task has these read only properties in addition to the properties listed [above](#define-task).

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -693,6 +693,7 @@ func (c *Client) UpdateTask(link Link, opt UpdateTaskOptions) (Task, error) {
 type TaskOptions struct {
 	DotView      string
 	ScriptFormat string
+	ReplayID     string
 }
 
 func (o *TaskOptions) Default() {
@@ -708,6 +709,7 @@ func (o *TaskOptions) Values() *url.Values {
 	v := &url.Values{}
 	v.Set("dot-view", o.DotView)
 	v.Set("script-format", o.ScriptFormat)
+	v.Set("replay-id", o.ReplayID)
 	return v
 }
 

--- a/client/v1/swagger.yml
+++ b/client/v1/swagger.yml
@@ -145,6 +145,10 @@ paths:
           required: true
           type: string
           pattern: (formatted|raw)
+        - name: replay-id
+          in: query
+          description: Optional ID of a running replay. The returned task information will be in the context of the task for the running replay.
+          type: string
       responses:
         '200':
           description: Task information

--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -73,6 +73,11 @@ type Service struct {
 		NewDefaultClient() (client.Client, error)
 		NewNamedClient(name string) (client.Client, error)
 	}
+	TaskMasterLookup interface {
+		Get(string) *kapacitor.TaskMaster
+		Set(*kapacitor.TaskMaster)
+		Delete(*kapacitor.TaskMaster)
+	}
 	TaskMaster interface {
 		NewFork(name string, dbrps []kapacitor.DBRP, measurements []string) (*kapacitor.Edge, error)
 		DelFork(name string)
@@ -1165,6 +1170,9 @@ func (r *Service) doLiveQueryReplay(id string, task *kapacitor.Task, clk clock.C
 func (r *Service) doReplay(id string, task *kapacitor.Task, runReplay func(tm *kapacitor.TaskMaster) error) error {
 	// Create new isolated task master
 	tm := r.TaskMaster.New(id)
+	r.TaskMasterLookup.Set(tm)
+	defer r.TaskMasterLookup.Delete(tm)
+
 	tm.Open()
 	defer tm.Close()
 	et, err := tm.StartTask(task)

--- a/services/task_store/service.go
+++ b/services/task_store/service.go
@@ -46,25 +46,11 @@ type Service struct {
 		AddRoutes([]httpd.Route) error
 		DelRoutes([]httpd.Route)
 	}
-	TaskMaster interface {
-		NewTask(
-			name,
-			script string,
-			tt kapacitor.TaskType,
-			dbrps []kapacitor.DBRP,
-			snapshotInterval time.Duration,
-			vars map[string]tick.Var,
-		) (*kapacitor.Task, error)
-		NewTemplate(
-			name,
-			script string,
-			tt kapacitor.TaskType,
-		) (*kapacitor.Template, error)
-		StartTask(t *kapacitor.Task) (*kapacitor.ExecutingTask, error)
-		StopTask(name string) error
-		IsExecuting(name string) bool
-		ExecutionStats(name string) (kapacitor.ExecutionStats, error)
-		ExecutingDot(name string, labels bool) string
+	TaskMasterLookup interface {
+		Main() *kapacitor.TaskMaster
+		Get(string) *kapacitor.TaskMaster
+		Set(*kapacitor.TaskMaster)
+		Delete(*kapacitor.TaskMaster)
 	}
 
 	logger *log.Logger
@@ -461,8 +447,21 @@ func (ts *Service) handleTask(w http.ResponseWriter, r *http.Request) {
 		httpd.HttpError(w, fmt.Sprintf("invalid dot-view parameter %q", dotView), true, http.StatusBadRequest)
 		return
 	}
+	tmID := r.URL.Query().Get("replay-id")
+	if tmID == "" {
+		tmID = kapacitor.MainTaskMaster
+	}
+	tm := ts.TaskMasterLookup.Get(tmID)
+	if tm == nil {
+		httpd.HttpError(w, fmt.Sprintf("no running replay with ID: %s", tmID), true, http.StatusBadRequest)
+		return
+	}
+	if tmID != kapacitor.MainTaskMaster && !tm.IsExecuting(raw.ID) {
+		httpd.HttpError(w, fmt.Sprintf("replay %s is not for task: %s", tmID, raw.ID), true, http.StatusBadRequest)
+		return
+	}
 
-	t, err := ts.convertTask(raw, scriptFormat, dotView)
+	t, err := ts.convertTask(raw, scriptFormat, dotView, tm)
 	if err != nil {
 		httpd.HttpError(w, fmt.Sprintf("invalid task stored in db: %s", err.Error()), true, http.StatusInternalServerError)
 		return
@@ -556,9 +555,11 @@ func (ts *Service) handleListTasks(w http.ResponseWriter, r *http.Request) {
 	rawTasks, err := ts.tasks.List(pattern, int(offset), int(limit))
 	tasks := make([]map[string]interface{}, len(rawTasks))
 
+	tm := ts.TaskMasterLookup.Main()
+
 	for i, task := range rawTasks {
 		tasks[i] = make(map[string]interface{}, len(fields))
-		executing := ts.TaskMaster.IsExecuting(task.ID)
+		executing := tm.IsExecuting(task.ID)
 		for _, field := range fields {
 			var value interface{}
 			switch field {
@@ -596,7 +597,7 @@ func (ts *Service) handleListTasks(w http.ResponseWriter, r *http.Request) {
 				value = executing
 			case "dot":
 				if executing {
-					value = ts.TaskMaster.ExecutingDot(task.ID, dotView == "labels")
+					value = tm.ExecutingDot(task.ID, dotView == "labels")
 				} else {
 					kt, err := ts.newKapacitorTask(task)
 					if err != nil {
@@ -606,7 +607,7 @@ func (ts *Service) handleListTasks(w http.ResponseWriter, r *http.Request) {
 				}
 			case "stats":
 				if executing {
-					s, err := ts.TaskMaster.ExecutionStats(task.ID)
+					s, err := tm.ExecutionStats(task.ID)
 					if err != nil {
 						ts.logger.Printf("E! failed to retrieve stats for task %s: %v", task.ID, err)
 					} else {
@@ -781,7 +782,7 @@ func (ts *Service) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return task info
-	t, err := ts.convertTask(newTask, "formatted", "attributes")
+	t, err := ts.convertTask(newTask, "formatted", "attributes", ts.TaskMasterLookup.Main())
 	if err != nil {
 		httpd.HttpError(w, err.Error(), true, http.StatusInternalServerError)
 		return
@@ -940,7 +941,7 @@ func (ts *Service) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	t, err := ts.convertTask(updated, "formatted", "attributes")
+	t, err := ts.convertTask(updated, "formatted", "attributes", ts.TaskMasterLookup.Main())
 	if err != nil {
 		httpd.HttpError(w, err.Error(), true, http.StatusInternalServerError)
 		return
@@ -949,7 +950,7 @@ func (ts *Service) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 	w.Write(httpd.MarshalJSON(t, true))
 }
 
-func (ts *Service) convertTask(t Task, scriptFormat, dotView string) (client.Task, error) {
+func (ts *Service) convertTask(t Task, scriptFormat, dotView string, tm *kapacitor.TaskMaster) (client.Task, error) {
 	script := t.TICKscript
 	if scriptFormat == "formatted" {
 		// Format TICKscript
@@ -961,15 +962,15 @@ func (ts *Service) convertTask(t Task, scriptFormat, dotView string) (client.Tas
 		}
 	}
 
-	executing := ts.TaskMaster.IsExecuting(t.ID)
+	executing := tm.IsExecuting(t.ID)
 	errMsg := t.Error
 	dot := ""
 	stats := client.ExecutionStats{}
 	task, err := ts.newKapacitorTask(t)
 	if err == nil {
 		if executing {
-			dot = ts.TaskMaster.ExecutingDot(t.ID, dotView == "labels")
-			s, err := ts.TaskMaster.ExecutionStats(t.ID)
+			dot = tm.ExecutingDot(t.ID, dotView == "labels")
+			s, err := tm.ExecutionStats(t.ID)
 			if err != nil {
 				ts.logger.Printf("E! failed to retrieve stats for task %s: %v", t.ID, err)
 			} else {
@@ -1794,7 +1795,7 @@ func (ts *Service) newKapacitorTask(task Task) (*kapacitor.Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ts.TaskMaster.NewTask(task.ID,
+	return ts.TaskMasterLookup.Main().NewTask(task.ID,
 		task.TICKscript,
 		tt,
 		dbrps,
@@ -1811,7 +1812,7 @@ func (ts *Service) templateTask(template Template) (*kapacitor.Template, error) 
 	case BatchTask:
 		tt = kapacitor.BatchTask
 	}
-	t, err := ts.TaskMaster.NewTemplate(template.ID,
+	t, err := ts.TaskMasterLookup.Main().NewTemplate(template.ID,
 		template.TICKscript,
 		tt,
 	)
@@ -1829,8 +1830,9 @@ func (ts *Service) startTask(task Task) error {
 	// Starting task, remove last error
 	ts.saveLastError(t.ID, "")
 
+	tm := ts.TaskMasterLookup.Main()
 	// Start the task
-	et, err := ts.TaskMaster.StartTask(t)
+	et, err := tm.StartTask(t)
 	if err != nil {
 		ts.saveLastError(t.ID, err.Error())
 		return err
@@ -1841,7 +1843,7 @@ func (ts *Service) startTask(task Task) error {
 		err := et.StartBatching()
 		if err != nil {
 			ts.saveLastError(t.ID, err.Error())
-			ts.TaskMaster.StopTask(t.ID)
+			tm.StopTask(t.ID)
 			return err
 		}
 	}
@@ -1853,7 +1855,7 @@ func (ts *Service) startTask(task Task) error {
 
 		if err != nil {
 			// Stop task
-			ts.TaskMaster.StopTask(t.ID)
+			tm.StopTask(t.ID)
 
 			ts.logger.Printf("E! task %s finished with error: %s", et.Task.ID, err)
 			// Save last error from task.
@@ -1867,7 +1869,7 @@ func (ts *Service) startTask(task Task) error {
 }
 
 func (ts *Service) stopTask(id string) {
-	ts.TaskMaster.StopTask(id)
+	ts.TaskMasterLookup.Main().StopTask(id)
 }
 
 // Save last error from task.

--- a/usr/share/bash-completion/completions/kapacitor
+++ b/usr/share/bash-completion/completions/kapacitor
@@ -123,7 +123,18 @@ _kapacitor()
                     ;;
             esac
             ;;
-        enable|disable|reload|show)
+        show)
+            case "$prev" in
+                -replay)
+                    words=$(_kapacitor_list replays "$cur")
+                    ;;
+                *)
+                    words=$(_kapacitor_list tasks "$cur")
+                    words+=' -replay'
+                    ;;
+            esac
+            ;;
+        enable|disable|reload)
             words=$(_kapacitor_list tasks "$cur")
             ;;
         delete|list)


### PR DESCRIPTION
Now you can do this:

```
$ kapacitor replay -recording recordingID -task taskID -no-wait
REPLAY_ID
$ kapacitor show -replay REPLAY_ID taskID
....
```

The show output is now in context of the task running for the replay, not the normal task. This way you can watch a task execute within a replay.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
