### PR TITLE
Detect unterminated regex when EOF reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfixes
 
+- [#710](https://github.com/influxdata/kapacitor/pull/662): Fix infinite loop when parsing unterminated regex in TICKscript.
+
 ## v1.0.0-beta3 [2016-07-09]
 
 ### Release Notes

--- a/tick/ast/lex.go
+++ b/tick/ast/lex.go
@@ -577,6 +577,8 @@ func lexRegex(l *lexer) stateFn {
 		case r == '/':
 			l.emit(TokenRegex)
 			return lexToken
+		case r == eof:
+			return l.errorf("unterminated regex")
 		default:
 			//absorb
 		}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fixes #709.