### PR TITLE
Change alert levels to be independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - [#723](https://github.com/influxdata/kapacitor/pull/723): BREAKING: Search for valid configuration on startup in ~/.kapacitor and /etc/kapacitor/.
     This is so that the -config CLI flag is not required if the configuration is found in a standard location.
     The configuration file being used is always logged to STDERR.
+- [#298](https://github.com/influxdata/kapacitor/issue/298): BREAKING: Change alert level evaluation so each level is independent and not required to be a subset of the previous level.
+    The breaking change is that expression evaluation order changed.
+    As a result stateful expressions that relied on that order are broken.
 
 ## v1.0.0-beta3 [2016-07-09]
 

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -82,13 +82,10 @@ const defaultLogFileMode = 0600
 //           .email().to('oncall@example.com')
 //
 //
-// It is assumed that each successive level filters a subset
-// of the previous level. As a result, the filter will only be applied if
-// a data point passed the previous level.
-// In the above example, if value = 15 then the INFO and
-// WARNING expressions would be evaluated, but not the
-// CRITICAL expression.
 // Each expression maintains its own state.
+// The order of execution for the expressions is not considered to be deterministic.
+// For each point an expression may or may not be evaluated.
+// If no expression is true then the alert is considered to be in the OK state.
 //
 // Available Statistics:
 //


### PR DESCRIPTION
Fixes #298

@beckettsean @rkuchan In reference to this blog post: https://influxdata.com/blog/tldr-influxdb-tech-tips-may-19-2016/ about Alert levels begin subsets. I think it should change, and this PR makes the change so that each alert level is independent of other levels.

Some of my reasons:

* It's initially confusing, since its natural to think in the context of only a single alert level when writing the expression.
* It's become really painful when your data does not follow a continuous domain (aka the data is not sort-able like a set of strings as labels). 

Example of non continuous data:
```
// Data has status flag with values OK, WARN, or CRITICAL
// You have to write the expressions as
|alert()
    .warn(lambda: "status" == 'WARN' OR "status" == 'CRITICAL')
    .crit(lambda: "status" == 'CRITICAL')
```

This change allows the expressions to be simply

```
// Data has status flag with values OK, WARN, or CRITICAL
|alert()
    .warn(lambda: "status" == 'WARN')
    .crit(lambda: "status" == 'CRITICAL')
```

This represent a small breaking change so I want to get it in before the 1.0 official release.
The majority of the uses cases will be unaffected, only uses cases that leveraged the statefulness of expressions and relied on their execution order will break.

Wanted to make you both aware of this change since its been point of discussion before.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
