### PR TITLE
Fix missing dot causes confusing sentence in AlertNode doc

### DIFF
--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -329,7 +329,7 @@ func (n *AlertNode) ChainMethods() map[string]reflect.Value {
 	}
 }
 
-// Indicates an alert should trigger only if all points in a batch match the criteria
+// Indicates an alert should trigger only if all points in a batch match the criteria.
 // Does not apply to stream alerts.
 // tick:property
 func (n *AlertNode) All() *AlertNode {


### PR DESCRIPTION
The missing dot causes the generated doc to include a confusing sentence:

![screenshot from 2016-07-21 16 57 30](https://cloud.githubusercontent.com/assets/4865412/17018937/4f408c34-4f64-11e6-8a5a-e9a763879fb5.png)
