### PR TITLE
Use BasicAuth + special user for subscriptions instead of custom headers

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,6 +12,7 @@ type Interface interface {
 	User(username string) (User, error)
 	SubscriptionUser(token string) (User, error)
 	GrantSubscriptionAccess(token, db, rp string) error
+	ListSubscriptionTokens() ([]string, error)
 	RevokeSubscriptionAccess(token string) error
 }
 
@@ -162,6 +163,10 @@ func (u User) AuthorizeAction(action Action) error {
 		}
 	}
 	return fmt.Errorf("user %s does not have \"%v\" privilege for resource %q", u.name, action.Privilege, action.Resource)
+}
+
+func APIResource(p string) string {
+	return path.Join("/api", p)
 }
 
 func DatabaseResource(database string) string {

--- a/services/noauth/service.go
+++ b/services/noauth/service.go
@@ -48,6 +48,10 @@ func (s *Service) GrantSubscriptionAccess(token, db, rp string) error {
 	return nil
 }
 
+func (s *Service) ListSubscriptionTokens() ([]string, error) {
+	return nil, nil
+}
+
 func (s *Service) RevokeSubscriptionAccess(token string) error {
 	return nil
 }


### PR DESCRIPTION
Changes the subscription auth to use Basic Auth instead of custom headers and such.