### PR TITLE
Add API endpoint to refresh subscriptions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ The corresponding alert states are:
 
 - [#740](https://github.com/influxdata/kapacitor/pull/740): Support reset expressions to prevent an alert from being lowered in severity. Thanks @minhdanh!
 - [#670](https://github.com/influxdata/kapacitor/issues/670): Add ability to supress OK recovery alert events.
-- [#](https://github.com/influxdata/kapacitor/pull/): Add API endpoint for refreshing subscriptions.
+- [#804](https://github.com/influxdata/kapacitor/pull/804): Add API endpoint for refreshing subscriptions.
+    Also fixes issue where subs were not relinked if the sub was deleted.
+    UDP listen ports are closed when a database is dropped.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The corresponding alert states are:
 
 - [#740](https://github.com/influxdata/kapacitor/pull/740): Support reset expressions to prevent an alert from being lowered in severity. Thanks @minhdanh!
 - [#670](https://github.com/influxdata/kapacitor/issues/670): Add ability to supress OK recovery alert events.
+- [#](https://github.com/influxdata/kapacitor/pull/): Add API endpoint for refreshing subscriptions.
 
 ### Bugfixes
 

--- a/server/server.go
+++ b/server/server.go
@@ -217,6 +217,7 @@ func (s *Server) appendInfluxDBService() error {
 			return errors.Wrap(err, "failed to get http port")
 		}
 		srv := influxdb.NewService(c, s.config.defaultInfluxDB, httpPort, s.config.Hostname, s.config.HTTP.AuthEnabled, l)
+		srv.HTTPDService = s.HTTPDService
 		srv.PointsWriter = s.TaskMaster
 		srv.LogService = s.LogService
 		srv.AuthService = s.AuthService

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -116,6 +116,7 @@ func NewService(configs []Config, defaultInfluxDB, httpPort int, hostname string
 		}
 		runningSubs := make(map[subEntry]bool, len(c.Subscriptions))
 		clusters[c.Name] = &influxdbCluster{
+			name:                     c.Name,
 			configs:                  urls,
 			configSubs:               subs,
 			exConfigSubs:             exSubs,
@@ -212,6 +213,7 @@ func (s *Service) NewNamedClient(name string) (influxdb.Client, error) {
 }
 
 type influxdbCluster struct {
+	name                     string
 	configs                  []influxdb.HTTPConfig
 	i                        int
 	configSubs               map[subEntry]bool
@@ -329,7 +331,7 @@ func (s *influxdbCluster) NewClient() (c influxdb.Client, err error) {
 }
 
 func (s *influxdbCluster) linkSubscriptions() error {
-	s.logger.Println("D! linking subscriptions")
+	s.logger.Println("D! linking subscriptions for cluster", s.name)
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = s.startupTimeout
 	ticker := backoff.NewTicker(b)

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -276,7 +276,6 @@ type subInfo struct {
 
 func (s *influxdbCluster) Open() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if !s.disableSubs {
 		if s.subscriptionSyncInterval != 0 {
 			s.subSyncTicker = time.NewTicker(s.subscriptionSyncInterval)
@@ -287,6 +286,8 @@ func (s *influxdbCluster) Open() error {
 			}()
 		}
 	}
+	// Release lock so we can call linkSubscriptions.
+	s.mu.Unlock()
 	return s.linkSubscriptions()
 }
 

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -337,6 +337,8 @@ func (s *influxdbCluster) linkSubscriptions() error {
 	if s.disableSubs {
 		return nil
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.logger.Println("D! linking subscriptions for cluster", s.name)
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = s.startupTimeout
@@ -586,6 +588,7 @@ func (s *influxdbCluster) linkSubscriptions() error {
 			}
 		}
 	}
+	// Close any subs for dbs that have been dropped
 	for se, running := range s.runningSubs {
 		if !running {
 			continue


### PR DESCRIPTION
This fixes some subscription linking bugs as well as adds an API endpoint to trigger a linking event.

The fixes:
* Subscriptions will be recreated if they were manually deleted.
* UDP listen ports will be closed if a database is dropped.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated