### PR TITLE
fix typo

### DIFF
--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -354,7 +354,7 @@ func (n *chainnode) Join(others ...Node) *JoinNode {
 	return j
 }
 
-// Combine this node with itself. The data is combine on timestamp.
+// Combine this node with itself. The data is combined on timestamp.
 func (n *chainnode) Combine(expressions ...*ast.LambdaNode) *CombineNode {
 	c := newCombineNode(n.provides, expressions)
 	n.linkChild(c)


### PR DESCRIPTION
pulled from https://github.com/influxdata/docs.influxdata.com/pull/625

When I was in academia, people were pretty serious about data being plural, but a google search suggests that either is acceptable. I'll leave the grammar decisions up to you.

