### PR TITLE
Add `config` global function to allow getting string vars from a config section

### DIFF
--- a/server/config_internal_test.go
+++ b/server/config_internal_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestConfig_applyEnvOverridesToMap(t *testing.T) {
+	testCases := []struct {
+		env    [][]string
+		prefix string
+		expMap map[string]string
+	}{
+		{
+			prefix: "VARS",
+			env: [][]string{
+				{"VARS_VAR1", "foo"},
+				{"VARS_VAR2", "bar"},
+				{"VARS_EMPTY", ""},
+			},
+			expMap: map[string]string{
+				"VAR1":  "foo",
+				"VAR2":  "bar",
+				"EMPTY": "",
+			},
+		},
+		{
+			prefix: "KAPACITOR_VARS",
+			env: [][]string{
+				{"KAPACITOR_VARS_MY_NAMED_VAR", "foo=with=equals=chars"},
+				{"KAPACITOR_VARS_SOME_OTHER_VAR", "bar"},
+				{"SKIP_ME_VAR", "should be skipped"},
+			},
+			expMap: map[string]string{
+				"MY_NAMED_VAR":   "foo=with=equals=chars",
+				"SOME_OTHER_VAR": "bar",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		for _, kv := range tc.env {
+			os.Setenv(kv[0], kv[1])
+		}
+		m := make(map[string]string)
+		err := applyEnvOverridesToMap(tc.prefix, reflect.ValueOf(m))
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(m, tc.expMap) {
+			t.Errorf("unexpected map: got %v exp %v", m, tc.expMap)
+		}
+		for _, kv := range tc.env {
+			os.Unsetenv(kv[0])
+		}
+	}
+}
+func TestConfig_applyEnvOverridesToMap_InvalidMap(t *testing.T) {
+	testCases := []struct {
+		m   interface{}
+		err string
+	}{
+		{
+			m:   (map[string]string)(nil),
+			err: "cannot apply env to nil map",
+		},
+		{
+			m: map[int]int{
+				1: 1,
+			},
+			err: "map is not a map[string]string",
+		},
+		{
+			m: map[string]int{
+				"1": 1,
+			},
+			err: "map is not a map[string]string",
+		},
+		{
+			m: map[int]string{
+				1: "1",
+			},
+			err: "map is not a map[string]string",
+		},
+	}
+	for _, tc := range testCases {
+		err := applyEnvOverridesToMap("", reflect.ValueOf(tc.m))
+		if got, exp := fmt.Sprintf("%v", err), tc.err; got != exp {
+			t.Errorf("expected error: got %s, exp %s", got, exp)
+		}
+	}
+}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -43,6 +43,10 @@ dir = "/tmp/replay"
 
 [storage]
 boltdb = "/tmp/kapacitor.db"
+
+[vars]
+my_custom_var = "42"
+override_me = "please?"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -59,6 +63,14 @@ boltdb = "/tmp/kapacitor.db"
 		t.Fatalf("failed to set env var: %v", err)
 	}
 
+	if err := os.Setenv("KAPACITOR_VARS_override_me", "ok"); err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+
+	if err := os.Setenv("KAPACITOR_VARS_my_other_custom_var", "6*9"); err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+
 	if err := c.ApplyEnvOverrides(); err != nil {
 		t.Fatalf("failed to apply env overrides: %v", err)
 	}
@@ -66,9 +78,21 @@ boltdb = "/tmp/kapacitor.db"
 	// Validate configuration.
 	if c.Replay.Dir != "/var/lib/kapacitor/replay" {
 		t.Fatalf("unexpected replay dir: %s", c.Replay.Dir)
-	} else if c.Storage.BoltDBPath != "/var/lib/kapacitor/kapacitor.db" {
+	}
+	if c.Storage.BoltDBPath != "/var/lib/kapacitor/kapacitor.db" {
 		t.Fatalf("unexpected storage boltdb-path: %s", c.Storage.BoltDBPath)
-	} else if c.InfluxDB[0].URLs[0] != "http://localhost:18086" {
+	}
+	if c.InfluxDB[0].URLs[0] != "http://localhost:18086" {
 		t.Fatalf("unexpected url 0: %s", c.InfluxDB[0].URLs[0])
 	}
+	if c.Vars["my_custom_var"] != "42" {
+		t.Fatalf("unexpected my_custom_var: %s", c.Vars["my_custom_var"])
+	}
+	if c.Vars["override_me"] != "ok" {
+		t.Fatalf("unexpected override_me: %s", c.Vars["override_me"])
+	}
+	if c.Vars["my_other_custom_var"] != "6*9" {
+		t.Fatalf("unexpected my_other_custom_var: %s", c.Vars["my_other_custom_var"])
+	}
+
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1464,6 +1464,88 @@ test value=1 0000000011
 		t.Error(err)
 	}
 }
+
+func TestServer_StreamTask_Config(t *testing.T) {
+	c := NewConfig()
+	c.Vars["HTTP_ENDPOINT"] = "count"
+	c.Vars["FIELD_NAME"] = "value"
+	s := OpenServer(c)
+	cli := Client(s)
+	defer s.Close()
+
+	id := "testStreamTask"
+	ttype := client.StreamTask
+	dbrps := []client.DBRP{{
+		Database:        "mydb",
+		RetentionPolicy: "myrp",
+	}}
+	tick := `
+var out = configVar('HTTP_ENDPOINT')
+stream
+    |from()
+        .measurement('test')
+    |window()
+        .period(10s)
+        .every(10s)
+    |count(configVar('FIELD_NAME'))
+    |httpOut(out)
+`
+
+	task, err := cli.CreateTask(client.CreateTaskOptions{
+		ID:         id,
+		Type:       ttype,
+		DBRPs:      dbrps,
+		TICKscript: tick,
+		Status:     client.Disabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = cli.UpdateTask(task.Link, client.UpdateTaskOptions{
+		Status: client.Enabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint := fmt.Sprintf("%s/tasks/%s/count", s.URL(), id)
+
+	// Request data before any writes and expect null responses
+	nullResponse := `{}`
+	err = s.HTTPGetRetry(endpoint, nullResponse, 100, time.Millisecond*5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	points := `test value=1 0000000000
+test value=1 0000000001
+test value=1 0000000001
+test value=1 0000000002
+test value=1 0000000002
+test value=1 0000000003
+test value=1 0000000003
+test value=1 0000000004
+test value=1 0000000005
+test value=1 0000000005
+test value=1 0000000005
+test value=1 0000000006
+test value=1 0000000007
+test value=1 0000000008
+test value=1 0000000009
+test value=1 0000000010
+test value=1 0000000011
+`
+	v := url.Values{}
+	v.Add("precision", "s")
+	s.MustWrite("mydb", "myrp", points, v)
+
+	exp := `{"series":[{"name":"test","columns":["time","count"],"values":[["1970-01-01T00:00:10Z",15]]}]}`
+	err = s.HTTPGetRetry(endpoint, exp, 100, time.Millisecond*5)
+	if err != nil {
+		t.Error(err)
+	}
+}
 func TestServer_StreamTemplateTask_MissingVar(t *testing.T) {
 	s, cli := OpenDefaultServer()
 	defer s.Close()

--- a/services/vars/config.go
+++ b/services/vars/config.go
@@ -1,0 +1,7 @@
+package vars
+
+type Config map[string]string
+
+func NewConfig() Config {
+	return make(Config)
+}

--- a/services/vars/service.go
+++ b/services/vars/service.go
@@ -1,0 +1,39 @@
+package vars
+
+import (
+	"log"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type Service struct {
+	mu     sync.Mutex
+	vars   Config
+	logger *log.Logger
+}
+
+func NewService(c Config, l *log.Logger) (*Service, error) {
+	if c == nil {
+		return nil, errors.New("must pass non nil config")
+	}
+	s := &Service{
+		vars:   c,
+		logger: l,
+	}
+	return s, nil
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+func (s *Service) Close() error {
+	return nil
+}
+
+func (s *Service) Get(key string) string {
+	s.mu.Lock()
+	str := s.vars[key]
+	s.mu.Unlock()
+	return str
+}

--- a/task_master.go
+++ b/task_master.go
@@ -114,6 +114,10 @@ type TaskMaster struct {
 	TimingService interface {
 		NewTimer(timer.Setter) timer.Timer
 	}
+	VarsService interface {
+		Get(string) string
+	}
+
 	LogService LogService
 
 	// Incoming streams
@@ -187,6 +191,7 @@ func (tm *TaskMaster) New(id string) *TaskMaster {
 	n.TalkService = tm.TalkService
 	n.TimingService = tm.TimingService
 	n.TelegramService = tm.TelegramService
+	n.VarsService = tm.VarsService
 	return n
 }
 
@@ -318,6 +323,7 @@ func (tm *TaskMaster) waitForForks() {
 func (tm *TaskMaster) CreateTICKScope() *stateful.Scope {
 	scope := stateful.NewScope()
 	scope.Set("time", groupByTime)
+	scope.Set("configVar", tm.VarsService.Get)
 	// Add dynamic methods to the scope for UDFs
 	if tm.UDFService != nil {
 		for _, f := range tm.UDFService.List() {

--- a/tick/eval.go
+++ b/tick/eval.go
@@ -392,9 +392,16 @@ func evalDeclaration(node *ast.DeclarationNode, scope *stateful.Scope, stck *sta
 		return fmt.Errorf("attempted to redefine %s, vars are immutable", name)
 	}
 	value := stck.Pop()
-	if i, ok := value.(*ast.IdentifierNode); ok {
+	switch n := value.(type) {
+	case *ast.IdentifierNode:
 		// Resolve identifier
-		v, err := scope.Get(i.Ident)
+		v, err := scope.Get(n.Ident)
+		if err != nil {
+			return err
+		}
+		value = v
+	case unboundFunc:
+		v, err := n(nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #742 
Now in your config you can add a `vars` section and then access those vars in TICKscripts:

```
[vars]
PD_PROD = 'prod key'
PD_DEV = 'dev-key'
```

Then in a TICKscript:

```
|...
|alert()
   .pagerduty()
      .service(configVar('PD_PROD'))
```

or 
```
|...
|alert()
   .pagerduty()
      .service(configVar('PD_DEV'))
```

Now you can also change your key in the config and globally change all your tasks.

The only aspect of this addition I don't like is that it make TICKscript less portable since they now have a dependency on the config in order to function.

- [x] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated