### PR TITLE
Improve log readability by using json log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bugfixes
 
 - [#889](https://github.com/influxdata/kapacitor/issues/889): Some typo in the default config file
+- [#914](https://github.com/influxdata/kapacitor/pull/914): Change |log() output to be in JSON format so its self documenting structure.
 
 ## v1.0.0 [2016-09-02]
 


### PR DESCRIPTION
The previous output of `|log()` node in TICKscript was the Go representation of the struct, which required that you know both the field names and order to understand. 

This switches the output to JSON, its more verbose and as a result self documenting.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated