### PR TITLE
Add string manipulation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#854](https://github.com/influxdata/kapacitor/issues/854): Add `.create` property to InfluxDBOut node, which when set will create the database
     and retention policy on task start.
 - [#909](https://github.com/influxdata/kapacitor/pull/909): Allow duration / duration in TICKscript.
+- [#777](https://github.com/influxdata/kapacitor/issues/777): Add support for string manipulation functions.
 
 ### Bugfixes
 

--- a/tick/ast/lex_test.go
+++ b/tick/ast/lex_test.go
@@ -42,94 +42,120 @@ func TestLexer(t *testing.T) {
 			},
 		},
 		{
-			in: "+",
+			in: "a + b",
 			tokens: []token{
-				token{TokenPlus, 0, "+"},
-				token{TokenEOF, 1, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenPlus, 2, "+"},
+				token{TokenIdent, 4, "b"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
-			in: "-",
+			in: "a - b",
 			tokens: []token{
-				token{TokenMinus, 0, "-"},
-				token{TokenEOF, 1, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenMinus, 2, "-"},
+				token{TokenIdent, 4, "b"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
-			in: "*",
+			in: "a * b",
 			tokens: []token{
-				token{TokenMult, 0, "*"},
-				token{TokenEOF, 1, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenMult, 2, "*"},
+				token{TokenIdent, 4, "b"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
-			in: "/",
+			in: "a / b",
 			tokens: []token{
-				token{TokenDiv, 0, "/"},
-				token{TokenEOF, 1, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenDiv, 2, "/"},
+				token{TokenIdent, 4, "b"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
-			in: "=",
+			in: "a = b",
 			tokens: []token{
-				token{TokenAsgn, 0, "="},
-				token{TokenEOF, 1, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenAsgn, 2, "="},
+				token{TokenIdent, 4, "b"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
-			in: "==",
+			in: "a == b",
 			tokens: []token{
-				token{TokenEqual, 0, "=="},
-				token{TokenEOF, 2, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenEqual, 2, "=="},
+				token{TokenIdent, 5, "b"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
-			in: "!=",
+			in: "a != b",
 			tokens: []token{
-				token{TokenNotEqual, 0, "!="},
-				token{TokenEOF, 2, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenNotEqual, 2, "!="},
+				token{TokenIdent, 5, "b"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
-			in: ">",
+			in: "a > b",
 			tokens: []token{
-				token{TokenGreater, 0, ">"},
-				token{TokenEOF, 1, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenGreater, 2, ">"},
+				token{TokenIdent, 4, "b"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
-			in: ">=",
+			in: "a >= b",
 			tokens: []token{
-				token{TokenGreaterEqual, 0, ">="},
-				token{TokenEOF, 2, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenGreaterEqual, 2, ">="},
+				token{TokenIdent, 5, "b"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
-			in: "<",
+			in: "a < b",
 			tokens: []token{
-				token{TokenLess, 0, "<"},
-				token{TokenEOF, 1, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenLess, 2, "<"},
+				token{TokenIdent, 4, "b"},
+				token{TokenEOF, 5, ""},
 			},
 		},
 		{
-			in: "<=",
+			in: "a <= b",
 			tokens: []token{
-				token{TokenLessEqual, 0, "<="},
-				token{TokenEOF, 2, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenLessEqual, 2, "<="},
+				token{TokenIdent, 5, "b"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
-			in: "=~",
+			in: "a =~ b",
 			tokens: []token{
-				token{TokenRegexEqual, 0, "=~"},
-				token{TokenEOF, 2, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenRegexEqual, 2, "=~"},
+				token{TokenIdent, 5, "b"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
-			in: "!~",
+			in: "a !~ b",
 			tokens: []token{
-				token{TokenRegexNotEqual, 0, "!~"},
-				token{TokenEOF, 2, ""},
+				token{TokenIdent, 0, "a"},
+				token{TokenRegexNotEqual, 2, "!~"},
+				token{TokenIdent, 5, "b"},
+				token{TokenEOF, 6, ""},
 			},
 		},
 		{
@@ -397,37 +423,26 @@ func TestLexer(t *testing.T) {
 				token{TokenEOF, 9, ""},
 			},
 		},
-		// Regex -- can only be lexed within context
+		// Regex
 		{
-			in: `=~ //`,
+			in: `/.*/`,
 			tokens: []token{
-				token{TokenRegexEqual, 0, "=~"},
-				token{TokenRegex, 3, "//"},
-				token{TokenEOF, 5, ""},
-			},
-		},
-		{
-			in: `!~ //`,
-			tokens: []token{
-				token{TokenRegexNotEqual, 0, "!~"},
-				token{TokenRegex, 3, "//"},
-				token{TokenEOF, 5, ""},
-			},
-		},
-		{
-			in: `= //`,
-			tokens: []token{
-				token{TokenAsgn, 0, "="},
-				token{TokenRegex, 2, "//"},
+				token{TokenRegex, 0, "/.*/"},
 				token{TokenEOF, 4, ""},
 			},
 		},
 		{
-			in: `= /^((.*)[a-z]+\S{0,2})|cat\/\/$/`,
+			in: `/^abc$/`,
 			tokens: []token{
-				token{TokenAsgn, 0, "="},
-				token{TokenRegex, 2, `/^((.*)[a-z]+\S{0,2})|cat\/\/$/`},
-				token{TokenEOF, 33, ""},
+				token{TokenRegex, 0, "/^abc$/"},
+				token{TokenEOF, 7, ""},
+			},
+		},
+		{
+			in: `/^((.*)[a-z]+\S{0,2})|cat\/\/$/`,
+			tokens: []token{
+				token{TokenRegex, 0, `/^((.*)[a-z]+\S{0,2})|cat\/\/$/`},
+				token{TokenEOF, 31, ""},
 			},
 		},
 

--- a/tick/ast/parser.go
+++ b/tick/ast/parser.go
@@ -387,10 +387,10 @@ func (p *parser) stringItem() (n Node) {
 		n = p.identifier()
 	case TokenString:
 		n = p.string()
-	case TokenMult:
+	case TokenStar:
 		n = p.star()
 	default:
-		p.unexpected(t, TokenIdent, TokenString, TokenMult)
+		p.unexpected(t, TokenIdent, TokenString, TokenStar)
 	}
 	return
 }
@@ -508,7 +508,7 @@ func (p *parser) primary() Node {
 		return p.duration()
 	case tok.typ == TokenRegex:
 		return p.regex()
-	case tok.typ == TokenMult:
+	case tok.typ == TokenStar:
 		return p.star()
 	case tok.typ == TokenReference:
 		return p.reference()
@@ -580,7 +580,7 @@ func (p *parser) regex() Node {
 
 // parse '*' literal
 func (p *parser) star() Node {
-	tok := p.expect(TokenMult)
+	tok := p.expect(TokenStar)
 	return newStar(p.position(tok.pos), p.consumeComment())
 }
 

--- a/tick/ast/parser_test.go
+++ b/tick/ast/parser_test.go
@@ -1067,6 +1067,69 @@ var y = x * 2`,
 			},
 		},
 		{
+			script: `var x = a.f(/.*/)`,
+			Root: &ProgramNode{
+				position: position{
+					pos:  0,
+					line: 1,
+					char: 1,
+				},
+				Nodes: []Node{
+					&DeclarationNode{
+						position: position{
+							pos:  0,
+							line: 1,
+							char: 1,
+						},
+						Left: &IdentifierNode{
+							position: position{
+								pos:  4,
+								line: 1,
+								char: 5,
+							},
+							Ident: "x",
+						},
+						Right: &ChainNode{
+							position: position{
+								pos:  9,
+								line: 1,
+								char: 10,
+							},
+							Operator: TokenDot,
+							Left: &IdentifierNode{
+								position: position{
+									pos:  8,
+									line: 1,
+									char: 9,
+								},
+								Ident: "a",
+							},
+							Right: &FunctionNode{
+								position: position{
+									pos:  10,
+									line: 1,
+									char: 11,
+								},
+								Type: PropertyFunc,
+								Func: "f",
+								Args: []Node{
+									&RegexNode{
+										position: position{
+											pos:  12,
+											line: 1,
+											char: 13,
+										},
+										Regex:   regexp.MustCompile(".*"),
+										Literal: `.*`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			script: `var x = int(sqrt(16.0)) + 4`,
 			Root: &ProgramNode{
 				position: position{

--- a/tick/stateful/functions.go
+++ b/tick/stateful/functions.go
@@ -30,11 +30,11 @@ var statelessFuncs Funcs
 func init() {
 	statelessFuncs = make(Funcs)
 	// Conversion functions
-	statelessFuncs["bool"] = &boolean{}
-	statelessFuncs["int"] = &integer{}
-	statelessFuncs["float"] = &float{}
-	statelessFuncs["string"] = &str{}
-	statelessFuncs["duration"] = &duration{}
+	statelessFuncs["bool"] = boolean{}
+	statelessFuncs["int"] = integer{}
+	statelessFuncs["float"] = float{}
+	statelessFuncs["string"] = str{}
+	statelessFuncs["duration"] = duration{}
 
 	// Math functions
 	statelessFuncs["abs"] = newMath1("abs", math.Abs)
@@ -90,8 +90,8 @@ func init() {
 	statelessFuncs["strIndexAny"] = newString2Int("strIndexAny", strings.IndexAny)
 	statelessFuncs["strLastIndex"] = newString2Int("strLastIndex", strings.LastIndex)
 	statelessFuncs["strLastIndexAny"] = newString2Int("strLastIndexAny", strings.LastIndexAny)
-	statelessFuncs["strReplace"] = &strReplace{}
-	statelessFuncs["strSubstring"] = &strSubstring{}
+	statelessFuncs["strReplace"] = strReplace{}
+	statelessFuncs["strSubstring"] = strSubstring{}
 	statelessFuncs["strToLower"] = newString1String("strToLower", strings.ToLower)
 	statelessFuncs["strToUpper"] = newString1String("strToUpper", strings.ToUpper)
 	statelessFuncs["strTrim"] = newString2String("strTrim", strings.Trim)
@@ -102,21 +102,21 @@ func init() {
 	statelessFuncs["strTrimSuffix"] = newString2String("strTrimSuffix", strings.TrimSuffix)
 
 	// Regex functions
-	statelessFuncs["regexReplace"] = &regexReplace{}
+	statelessFuncs["regexReplace"] = regexReplace{}
 
 	// Time functions
-	statelessFuncs["minute"] = &minute{}
-	statelessFuncs["hour"] = &hour{}
-	statelessFuncs["weekday"] = &weekday{}
-	statelessFuncs["day"] = &day{}
-	statelessFuncs["month"] = &month{}
-	statelessFuncs["year"] = &year{}
+	statelessFuncs["minute"] = minute{}
+	statelessFuncs["hour"] = hour{}
+	statelessFuncs["weekday"] = weekday{}
+	statelessFuncs["day"] = day{}
+	statelessFuncs["month"] = month{}
+	statelessFuncs["year"] = year{}
 
 	// Humanize functions
-	statelessFuncs["humanBytes"] = &humanBytes{}
+	statelessFuncs["humanBytes"] = humanBytes{}
 
 	// Conditionals
-	statelessFuncs["if"] = &ifFunc{}
+	statelessFuncs["if"] = ifFunc{}
 }
 
 // Return set of built-in Funcs
@@ -140,14 +140,14 @@ type math1 struct {
 	f    math1Func
 }
 
-func newMath1(name string, f math1Func) *math1 {
-	return &math1{
+func newMath1(name string, f math1Func) math1 {
+	return math1{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *math1) Call(args ...interface{}) (v interface{}, err error) {
+func (m math1) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New(m.name + " expects exactly one argument")
 	}
@@ -160,7 +160,7 @@ func (m *math1) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *math1) Reset() {}
+func (m math1) Reset() {}
 
 type math2Func func(float64, float64) float64
 type math2 struct {
@@ -168,14 +168,14 @@ type math2 struct {
 	f    math2Func
 }
 
-func newMath2(name string, f math2Func) *math2 {
-	return &math2{
+func newMath2(name string, f math2Func) math2 {
+	return math2{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *math2) Call(args ...interface{}) (v interface{}, err error) {
+func (m math2) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 2 {
 		return 0, errors.New(m.name + " expects exactly two arguments")
 	}
@@ -193,7 +193,7 @@ func (m *math2) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *math2) Reset() {}
+func (m math2) Reset() {}
 
 type mathIFunc func(int) float64
 type mathI struct {
@@ -201,14 +201,14 @@ type mathI struct {
 	f    mathIFunc
 }
 
-func newMathI(name string, f mathIFunc) *mathI {
-	return &mathI{
+func newMathI(name string, f mathIFunc) mathI {
+	return mathI{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *mathI) Call(args ...interface{}) (v interface{}, err error) {
+func (m mathI) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New(m.name + " expects exactly two arguments")
 	}
@@ -221,7 +221,7 @@ func (m *mathI) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *mathI) Reset() {}
+func (m mathI) Reset() {}
 
 type mathIFFunc func(int, float64) float64
 type mathIF struct {
@@ -229,14 +229,14 @@ type mathIF struct {
 	f    mathIFFunc
 }
 
-func newMathIF(name string, f mathIFFunc) *mathIF {
-	return &mathIF{
+func newMathIF(name string, f mathIFFunc) mathIF {
+	return mathIF{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *mathIF) Call(args ...interface{}) (v interface{}, err error) {
+func (m mathIF) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 2 {
 		return 0, errors.New(m.name + " expects exactly two arguments")
 	}
@@ -254,7 +254,7 @@ func (m *mathIF) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *mathIF) Reset() {}
+func (m mathIF) Reset() {}
 
 type string2BoolFunc func(string, string) bool
 type string2Bool struct {
@@ -262,14 +262,14 @@ type string2Bool struct {
 	f    string2BoolFunc
 }
 
-func newString2Bool(name string, f string2BoolFunc) *string2Bool {
-	return &string2Bool{
+func newString2Bool(name string, f string2BoolFunc) string2Bool {
+	return string2Bool{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *string2Bool) Call(args ...interface{}) (v interface{}, err error) {
+func (m string2Bool) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 2 {
 		return 0, errors.New(m.name + " expects exactly two arguments")
 	}
@@ -287,7 +287,7 @@ func (m *string2Bool) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *string2Bool) Reset() {}
+func (m string2Bool) Reset() {}
 
 type string2IntFunc func(string, string) int
 type string2Int struct {
@@ -295,14 +295,14 @@ type string2Int struct {
 	f    string2IntFunc
 }
 
-func newString2Int(name string, f string2IntFunc) *string2Int {
-	return &string2Int{
+func newString2Int(name string, f string2IntFunc) string2Int {
+	return string2Int{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *string2Int) Call(args ...interface{}) (v interface{}, err error) {
+func (m string2Int) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 2 {
 		return 0, errors.New(m.name + " expects exactly two arguments")
 	}
@@ -320,7 +320,7 @@ func (m *string2Int) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *string2Int) Reset() {}
+func (m string2Int) Reset() {}
 
 type string2StringFunc func(string, string) string
 type string2String struct {
@@ -328,14 +328,14 @@ type string2String struct {
 	f    string2StringFunc
 }
 
-func newString2String(name string, f string2StringFunc) *string2String {
-	return &string2String{
+func newString2String(name string, f string2StringFunc) string2String {
+	return string2String{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *string2String) Call(args ...interface{}) (v interface{}, err error) {
+func (m string2String) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 2 {
 		return 0, errors.New(m.name + " expects exactly two arguments")
 	}
@@ -353,7 +353,7 @@ func (m *string2String) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *string2String) Reset() {}
+func (m string2String) Reset() {}
 
 type string1StringFunc func(string) string
 type string1String struct {
@@ -361,14 +361,14 @@ type string1String struct {
 	f    string1StringFunc
 }
 
-func newString1String(name string, f string1StringFunc) *string1String {
-	return &string1String{
+func newString1String(name string, f string1StringFunc) string1String {
+	return string1String{
 		name: name,
 		f:    f,
 	}
 }
 
-func (m *string1String) Call(args ...interface{}) (v interface{}, err error) {
+func (m string1String) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New(m.name + " expects exactly one argument")
 	}
@@ -381,12 +381,12 @@ func (m *string1String) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *string1String) Reset() {}
+func (m string1String) Reset() {}
 
 type strReplace struct {
 }
 
-func (m *strReplace) Call(args ...interface{}) (v interface{}, err error) {
+func (m strReplace) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 4 {
 		return 0, errors.New("strReplace expects exactly four arguments")
 	}
@@ -414,12 +414,12 @@ func (m *strReplace) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *strReplace) Reset() {}
+func (m strReplace) Reset() {}
 
 type strSubstring struct {
 }
 
-func (m *strSubstring) Call(args ...interface{}) (v interface{}, err error) {
+func (m strSubstring) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 3 {
 		return 0, errors.New("strSubstring expects exactly three arguments")
 	}
@@ -452,12 +452,12 @@ func (m *strSubstring) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *strSubstring) Reset() {}
+func (m strSubstring) Reset() {}
 
 type regexReplace struct {
 }
 
-func (m *regexReplace) Call(args ...interface{}) (v interface{}, err error) {
+func (m regexReplace) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 3 {
 		return 0, errors.New("regexReplace expects exactly three arguments")
 	}
@@ -480,16 +480,16 @@ func (m *regexReplace) Call(args ...interface{}) (v interface{}, err error) {
 	return
 }
 
-func (m *regexReplace) Reset() {}
+func (m regexReplace) Reset() {}
 
 type boolean struct {
 }
 
-func (*boolean) Reset() {
+func (boolean) Reset() {
 }
 
 // Converts the value to a boolean
-func (*boolean) Call(args ...interface{}) (v interface{}, err error) {
+func (boolean) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("bool expects exactly one argument")
 	}
@@ -525,11 +525,11 @@ func (*boolean) Call(args ...interface{}) (v interface{}, err error) {
 type integer struct {
 }
 
-func (*integer) Reset() {
+func (integer) Reset() {
 }
 
 // Converts the value to a integer
-func (*integer) Call(args ...interface{}) (v interface{}, err error) {
+func (integer) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("int expects exactly one argument")
 	}
@@ -557,11 +557,11 @@ func (*integer) Call(args ...interface{}) (v interface{}, err error) {
 type float struct {
 }
 
-func (*float) Reset() {
+func (float) Reset() {
 }
 
 // Converts the value to a float
-func (*float) Call(args ...interface{}) (v interface{}, err error) {
+func (float) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("float expects exactly one argument")
 	}
@@ -587,11 +587,11 @@ func (*float) Call(args ...interface{}) (v interface{}, err error) {
 type str struct {
 }
 
-func (*str) Reset() {
+func (str) Reset() {
 }
 
 // Converts the value to a str
-func (*str) Call(args ...interface{}) (v interface{}, err error) {
+func (str) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("string expects exactly one argument")
 	}
@@ -615,11 +615,11 @@ func (*str) Call(args ...interface{}) (v interface{}, err error) {
 type duration struct {
 }
 
-func (*duration) Reset() {
+func (duration) Reset() {
 }
 
 // Converts the value to a duration in the given units
-func (*duration) Call(args ...interface{}) (v interface{}, err error) {
+func (duration) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 && len(args) != 2 {
 		return time.Duration(0), errors.New("duration expects one or two arguments duration(value, unit) where unit is optional depending on the type of value.")
 	}
@@ -738,11 +738,11 @@ func (s *spread) Call(args ...interface{}) (interface{}, error) {
 type minute struct {
 }
 
-func (*minute) Reset() {
+func (minute) Reset() {
 }
 
 // Return the minute within the hour for the given time, within the range [0,59].
-func (*minute) Call(args ...interface{}) (v interface{}, err error) {
+func (minute) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("minute expects exactly one argument")
 	}
@@ -758,11 +758,11 @@ func (*minute) Call(args ...interface{}) (v interface{}, err error) {
 type hour struct {
 }
 
-func (*hour) Reset() {
+func (hour) Reset() {
 }
 
 // Return the hour within the day for the given time, within the range [0,23].
-func (*hour) Call(args ...interface{}) (v interface{}, err error) {
+func (hour) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("hour expects exactly one argument")
 	}
@@ -778,11 +778,11 @@ func (*hour) Call(args ...interface{}) (v interface{}, err error) {
 type weekday struct {
 }
 
-func (*weekday) Reset() {
+func (weekday) Reset() {
 }
 
 // Return the weekday within the week for the given time, within the range [0,6] where 0 is Sunday.
-func (*weekday) Call(args ...interface{}) (v interface{}, err error) {
+func (weekday) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("weekday expects exactly one argument")
 	}
@@ -798,11 +798,11 @@ func (*weekday) Call(args ...interface{}) (v interface{}, err error) {
 type day struct {
 }
 
-func (*day) Reset() {
+func (day) Reset() {
 }
 
 // Return the day within the month for the given time, within the range [1,31] depending on the month.
-func (*day) Call(args ...interface{}) (v interface{}, err error) {
+func (day) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("day expects exactly one argument")
 	}
@@ -818,11 +818,11 @@ func (*day) Call(args ...interface{}) (v interface{}, err error) {
 type month struct {
 }
 
-func (*month) Reset() {
+func (month) Reset() {
 }
 
 // Return the month within the year for the given time, within the range [1,12].
-func (*month) Call(args ...interface{}) (v interface{}, err error) {
+func (month) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("month expects exactly one argument")
 	}
@@ -838,11 +838,11 @@ func (*month) Call(args ...interface{}) (v interface{}, err error) {
 type year struct {
 }
 
-func (*year) Reset() {
+func (year) Reset() {
 }
 
 // Return the year for the given time.
-func (*year) Call(args ...interface{}) (v interface{}, err error) {
+func (year) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("year expects exactly one argument")
 	}
@@ -858,11 +858,11 @@ func (*year) Call(args ...interface{}) (v interface{}, err error) {
 type humanBytes struct {
 }
 
-func (*humanBytes) Reset() {
+func (humanBytes) Reset() {
 
 }
 
-func (*humanBytes) Call(args ...interface{}) (v interface{}, err error) {
+func (humanBytes) Call(args ...interface{}) (v interface{}, err error) {
 	if len(args) != 1 {
 		return 0, errors.New("humanBytes expects exactly one argument")
 	}
@@ -880,11 +880,11 @@ func (*humanBytes) Call(args ...interface{}) (v interface{}, err error) {
 type ifFunc struct {
 }
 
-func (*ifFunc) Reset() {
+func (ifFunc) Reset() {
 
 }
 
-func (*ifFunc) Call(args ...interface{}) (interface{}, error) {
+func (ifFunc) Call(args ...interface{}) (interface{}, error) {
 	if len(args) != 3 {
 		return nil, errors.New("if expects exactly three arguments")
 	}

--- a/tick/stateful/functions_test.go
+++ b/tick/stateful/functions_test.go
@@ -2,6 +2,7 @@ package stateful
 
 import (
 	"errors"
+	"regexp"
 	"testing"
 	"time"
 )
@@ -545,4 +546,350 @@ func Test_If(t *testing.T) {
 		}
 
 	}
+}
+
+func Test_StatelessFuncs(t *testing.T) {
+
+	testCases := []struct {
+		name string
+		args []interface{}
+		exp  interface{}
+		err  error
+	}{
+		{
+			name: "strContains",
+			args: []interface{}{"aabbc", "bc"},
+			exp:  true,
+		},
+		{
+			name: "strContains",
+			args: []interface{}{"aabbc", "bx"},
+			exp:  false,
+		},
+		{
+			name: "strContains",
+			args: []interface{}{""},
+			err:  errors.New("strContains expects exactly two arguments"),
+		},
+		{
+			name: "strContainsAny",
+			args: []interface{}{"aabbc", "bx"},
+			exp:  true,
+		},
+		{
+			name: "strContainsAny",
+			args: []interface{}{"aabbc", "xy"},
+			exp:  false,
+		},
+		{
+			name: "strContainsAny",
+			args: []interface{}{""},
+			err:  errors.New("strContainsAny expects exactly two arguments"),
+		},
+		{
+			name: "strCount",
+			args: []interface{}{"aababc", "a"},
+			exp:  int64(3),
+		},
+		{
+			name: "strCount",
+			args: []interface{}{"aabbc", "x"},
+			exp:  int64(0),
+		},
+		{
+			name: "strCount",
+			args: []interface{}{""},
+			err:  errors.New("strCount expects exactly two arguments"),
+		},
+		{
+			name: "strHasPrefix",
+			args: []interface{}{"aababc", "aab"},
+			exp:  true,
+		},
+		{
+			name: "strHasPrefix",
+			args: []interface{}{"aabbc", "aax"},
+			exp:  false,
+		},
+		{
+			name: "strHasPrefix",
+			args: []interface{}{""},
+			err:  errors.New("strHasPrefix expects exactly two arguments"),
+		},
+		{
+			name: "strHasSuffix",
+			args: []interface{}{"aababc", "bc"},
+			exp:  true,
+		},
+		{
+			name: "strHasSuffix",
+			args: []interface{}{"aabbc", "xbc"},
+			exp:  false,
+		},
+		{
+			name: "strHasSuffix",
+			args: []interface{}{""},
+			err:  errors.New("strHasSuffix expects exactly two arguments"),
+		},
+		{
+			name: "strIndex",
+			args: []interface{}{"aababc", "ba"},
+			exp:  int64(2),
+		},
+		{
+			name: "strIndex",
+			args: []interface{}{"aabbc", "xbc"},
+			exp:  int64(-1),
+		},
+		{
+			name: "strIndex",
+			args: []interface{}{""},
+			err:  errors.New("strIndex expects exactly two arguments"),
+		},
+		{
+			name: "strIndexAny",
+			args: []interface{}{"aababc", "bax"},
+			exp:  int64(0),
+		},
+		{
+			name: "strIndexAny",
+			args: []interface{}{"aabbc", "xy"},
+			exp:  int64(-1),
+		},
+		{
+			name: "strIndexAny",
+			args: []interface{}{""},
+			err:  errors.New("strIndexAny expects exactly two arguments"),
+		},
+		{
+			name: "strLastIndex",
+			args: []interface{}{"aababa", "ba"},
+			exp:  int64(4),
+		},
+		{
+			name: "strLastIndex",
+			args: []interface{}{"aabbc", "xbc"},
+			exp:  int64(-1),
+		},
+		{
+			name: "strLastIndex",
+			args: []interface{}{""},
+			err:  errors.New("strLastIndex expects exactly two arguments"),
+		},
+		{
+			name: "strLastIndexAny",
+			args: []interface{}{"aababc", "bax"},
+			exp:  int64(4),
+		},
+		{
+			name: "strLastIndexAny",
+			args: []interface{}{"aabbc", "xy"},
+			exp:  int64(-1),
+		},
+		{
+			name: "strLastIndexAny",
+			args: []interface{}{""},
+			err:  errors.New("strLastIndexAny expects exactly two arguments"),
+		},
+		{
+			name: "strReplace",
+			args: []interface{}{"abxyzc", "xyz", "", int64(1)},
+			exp:  "abc",
+		},
+		{
+			name: "strReplace",
+			args: []interface{}{"abxaza", "a", "z", int64(-1)},
+			exp:  "zbxzzz",
+		},
+		{
+			name: "strReplace",
+			args: []interface{}{"", "", ""},
+			err:  errors.New("strReplace expects exactly four arguments"),
+		},
+		{
+			name: "strSubstring",
+			args: []interface{}{"abcdefg", int64(1), int64(5)},
+			exp:  "bcde",
+		},
+		{
+			name: "strSubstring",
+			args: []interface{}{""},
+			err:  errors.New("strSubstring expects exactly three arguments"),
+		},
+		{
+			name: "strSubstring",
+			args: []interface{}{"abcdefg", int64(0), int64(10)},
+			err:  errors.New("stop index too large for string in strSubstring: 10"),
+		},
+		{
+			name: "strSubstring",
+			args: []interface{}{"abcdefg", int64(-1), int64(3)},
+			err:  errors.New("found negative index for strSubstring: -1"),
+		},
+		{
+			name: "strSubstring",
+			args: []interface{}{"abcdefg", int64(0), int64(-3)},
+			err:  errors.New("found negative index for strSubstring: -3"),
+		},
+		{
+			name: "strToLower",
+			args: []interface{}{"ABC"},
+			exp:  "abc",
+		},
+		{
+			name: "strToLower",
+			args: []interface{}{"abc"},
+			exp:  "abc",
+		},
+		{
+			name: "strToLower",
+			args: []interface{}{"", "", ""},
+			err:  errors.New("strToLower expects exactly one argument"),
+		},
+		{
+			name: "strToUpper",
+			args: []interface{}{"ABC"},
+			exp:  "ABC",
+		},
+		{
+			name: "strToUpper",
+			args: []interface{}{"abc"},
+			exp:  "ABC",
+		},
+		{
+			name: "strToUpper",
+			args: []interface{}{"", "", ""},
+			err:  errors.New("strToUpper expects exactly one argument"),
+		},
+		{
+			name: "strTrim",
+			args: []interface{}{"abba", "a"},
+			exp:  "bb",
+		},
+		{
+			name: "strTrim",
+			args: []interface{}{"aabbaa", "a"},
+			exp:  "bb",
+		},
+		{
+			name: "strTrim",
+			args: []interface{}{""},
+			err:  errors.New("strTrim expects exactly two arguments"),
+		},
+		{
+			name: "strTrimLeft",
+			args: []interface{}{"abba", "a"},
+			exp:  "bba",
+		},
+		{
+			name: "strTrimLeft",
+			args: []interface{}{"aabbaa", "a"},
+			exp:  "bbaa",
+		},
+		{
+			name: "strTrimLeft",
+			args: []interface{}{""},
+			err:  errors.New("strTrimLeft expects exactly two arguments"),
+		},
+		{
+			name: "strTrimPrefix",
+			args: []interface{}{"abba", "a"},
+			exp:  "bba",
+		},
+		{
+			name: "strTrimPrefix",
+			args: []interface{}{"aabbaa", "a"},
+			exp:  "abbaa",
+		},
+		{
+			name: "strTrimPrefix",
+			args: []interface{}{""},
+			err:  errors.New("strTrimPrefix expects exactly two arguments"),
+		},
+		{
+			name: "strTrimRight",
+			args: []interface{}{"abba", "a"},
+			exp:  "abb",
+		},
+		{
+			name: "strTrimRight",
+			args: []interface{}{"aabbaa", "a"},
+			exp:  "aabb",
+		},
+		{
+			name: "strTrimRight",
+			args: []interface{}{""},
+			err:  errors.New("strTrimRight expects exactly two arguments"),
+		},
+		{
+			name: "strTrimSuffix",
+			args: []interface{}{"abba", "a"},
+			exp:  "abb",
+		},
+		{
+			name: "strTrimSuffix",
+			args: []interface{}{"aabbaa", "a"},
+			exp:  "aabba",
+		},
+		{
+			name: "strTrimSuffix",
+			args: []interface{}{""},
+			err:  errors.New("strTrimSuffix expects exactly two arguments"),
+		},
+		{
+			name: "regexReplace",
+			args: []interface{}{regexp.MustCompile("a(x*)b"), "-ab-axxb-", "T"},
+			exp:  "-T-T-",
+		},
+		{
+			name: "regexReplace",
+			args: []interface{}{regexp.MustCompile("a(x*)b"), "-ab-axxb-", "$1"},
+			exp:  "--xx-",
+		},
+		{
+			name: "regexReplace",
+			args: []interface{}{regexp.MustCompile("a(x*)b"), "-ab-axxb-", "$1W"},
+			exp:  "---",
+		},
+		{
+			name: "regexReplace",
+			args: []interface{}{regexp.MustCompile("a(x*)b"), "-ab-axxb-", "${1}W"},
+			exp:  "-W-xxW-",
+		},
+		{
+			name: "regexReplace",
+			args: []interface{}{regexp.MustCompile("a(?P<middle>x*)b"), "-ab-axxb-", "${middle}W"},
+			exp:  "-W-xxW-",
+		},
+		{
+			name: "regexReplace",
+			args: []interface{}{""},
+			err:  errors.New("regexReplace expects exactly three arguments"),
+		},
+	}
+
+	for _, tc := range testCases {
+		f, ok := statelessFuncs[tc.name]
+		if !ok {
+			t.Fatalf("unknown function %s", tc.name)
+		}
+		result, err := f.Call(tc.args...)
+		if tc.err != nil {
+			if err == nil {
+				t.Errorf("%s: expected error got: nil exp: %s", tc.name, tc.err)
+			} else if got, exp := err.Error(), tc.err.Error(); got != exp {
+				t.Errorf("%s: unexpected error\ngot:\n%s\nexp:\n%s", tc.name, got, exp)
+			}
+			continue
+		} else if err != nil {
+			t.Errorf("%s: unexpected error: %s", tc.name, err)
+			continue
+		}
+
+		if result != tc.exp {
+			t.Errorf("%s: unexpected result\ngot: %+v\nexp: %+v", tc.name, result, tc.exp)
+		}
+
+	}
+
 }


### PR DESCRIPTION
Fixes #777 

There are three major changes in this PR:

1. Add a set of functions to the lambda expressions for string manipulation
2. Update the lexer/parser to allow for regex literals to be function arguments, (this was needed for one of the string manipulation functions).
3. Convert all stateless function objects to value receivers.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated