### PR TITLE
Help with adding a kafka alert

### DIFF
--- a/LICENSE_OF_DEPENDENCIES.md
+++ b/LICENSE_OF_DEPENDENCIES.md
@@ -19,4 +19,5 @@ Dependencies
 * github.com/stretchr/testify [MIT](https://github.com/stretchr/testify/blob/master/LICENSE)
 * github.com/twinj/uuid [MIT](https://github.com/twinj/uuid/blob/master/LICENSE)
 * gopkg.in/gomail.v2 [MIT](https://github.com/go-gomail/gomail/blob/v2/LICENSE)
+* github.com/Shopfiy/sarama [MIT](https://github.com/Shopify/sarama/blob/master/MIT-LICENSE)
 

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -366,6 +366,18 @@ data_dir = "/var/lib/kapacitor"
   # The default authorName.
   author_name = "Kapacitor"
 
+[kafka]
+  # Configure Kafka
+  enabled = false
+  # Kafka brokers, comma separated with ports
+  brokers = "broker1.kafka.example.com:9092,broker2.kafka.example.com:9092"
+  # Topics to send messages to
+  topics = ["topic 1", "topic 2"]
+  # SASL authentication, TLS is not at this time supported
+  sasl_enabled = false
+  sasl_user = "user"
+  sasl_password = "password"
+
 ##################################
 # Input Methods, same as InfluxDB
 #

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -49,6 +49,7 @@ const defaultLogFileMode = 0600
 //    * PagerDuty -- Send alert to PagerDuty.
 //    * Talk -- Post alert message to Talk client.
 //    * Telegram -- Post alert message to Telegram client.
+//    *	Kafka -- Send alert message to a Kafka instance
 //
 // See below for more details on configuring each handler.
 //
@@ -339,6 +340,10 @@ type AlertNode struct {
 	// Send alert to Talk.
 	// tick:ignore
 	TalkHandlers []*TalkHandler `tick:"Talk"`
+
+	// Send alert to Kafka
+	// tick:ignore
+	KafkaHandlers []*KafkaHandler `tick:"Kafka"`
 }
 
 func newAlertNode(wants EdgeType) *AlertNode {
@@ -1253,4 +1258,38 @@ func (a *AlertNode) Talk() *TalkHandler {
 // tick:embedded:AlertNode.Talk
 type TalkHandler struct {
 	*AlertNode
+}
+
+// Send the alert to Kafka.
+// To use Kafka alerting you must have a kafka instance running.
+// Add the url, port and the brokers that alerts should go to.
+// You can also optionally enable SASL or TLS authentication.
+//
+// Example:
+//    [kafka]
+//      enabled = true
+//      brokers = "kafka.example.com:9092,kafka2.example.com:8080"
+//
+// Example:
+//    stream
+//         |alert()
+//             .kafka("topic1", "topic2", ..., "topicN")
+//
+// Send alerts to Kafka.
+//
+// tick:property
+func (a *AlertNode) Kafka(topics ...string) *KafkaHandler {
+	kafka := &KafkaHandler{
+		AlertNode: a,
+		Topics:    topics,
+	}
+	a.KafkaHandlers = append(a.KafkaHandlers, kafka)
+	return kafka
+}
+
+// tick:embedded:AlertNode.Kafka
+type KafkaHandler struct {
+	*AlertNode
+
+	Topics []string
 }

--- a/server/config.go
+++ b/server/config.go
@@ -11,11 +11,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/influxdata/influxdb/services/collectd"
+	"github.com/influxdata/influxdb/services/graphite"
+	"github.com/influxdata/influxdb/services/opentsdb"
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/deadman"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/influxdb"
+	"github.com/influxdata/kapacitor/services/kafka"
 	"github.com/influxdata/kapacitor/services/logging"
 	"github.com/influxdata/kapacitor/services/opsgenie"
 	"github.com/influxdata/kapacitor/services/pagerduty"
@@ -32,10 +36,6 @@ import (
 	"github.com/influxdata/kapacitor/services/udf"
 	"github.com/influxdata/kapacitor/services/udp"
 	"github.com/influxdata/kapacitor/services/victorops"
-
-	"github.com/influxdata/influxdb/services/collectd"
-	"github.com/influxdata/influxdb/services/graphite"
-	"github.com/influxdata/influxdb/services/opentsdb"
 )
 
 // Config represents the configuration format for the kapacitord binary.
@@ -65,6 +65,7 @@ type Config struct {
 	UDF       udf.Config        `toml:"udf"`
 	Deadman   deadman.Config    `toml:"deadman"`
 	Talk      talk.Config       `toml:"talk"`
+	Kafka     kafka.Config      `toml:"kafka"`
 
 	Hostname string `toml:"hostname"`
 	DataDir  string `toml:"data_dir"`
@@ -101,6 +102,7 @@ func NewConfig() *Config {
 	c.UDF = udf.NewConfig()
 	c.Deadman = deadman.NewConfig()
 	c.Talk = talk.NewConfig()
+	c.Kafka = kafka.NewConfig()
 
 	return c
 }

--- a/services/kafka/config.go
+++ b/services/kafka/config.go
@@ -1,0 +1,29 @@
+package kafka
+
+const DefaultTopic = "Important"
+const DefaultSasl = false
+
+type Config struct {
+	Topics  []string `toml:"topics"`
+	Enabled bool     `toml:"enabled"`
+	// Comma separated kafka brokers
+	Brokers string `toml:"brokers"`
+	// Whether all alerts should trigger an email.
+
+	//SASL enabled
+	SaslEnabled bool	`toml:"sasl_enabled"`
+	SaslUser string		`toml:"sasl_user"`
+	SaslPassword string	`toml:"sasl_password"`
+
+	Global bool `toml:"global"`
+	// Whether all alerts should automatically use stateChangesOnly mode.
+	// Only applies if global is also set.
+	StateChangesOnly bool `toml:"state-changes-only"`
+}
+
+func NewConfig() Config {
+	return Config{
+		Topics: []string{DefaultTopic},
+		SaslEnabled: DefaultSasl,
+	}
+}

--- a/services/kafka/service.go
+++ b/services/kafka/service.go
@@ -1,0 +1,73 @@
+package kafka
+
+import (
+	"github.com/Shopify/sarama"
+	"github.com/influxdata/kapacitor"
+	"log"
+	"strings"
+)
+
+type Service struct {
+	topics           []string
+	global           bool
+	stateChangesOnly bool
+	producer         sarama.SyncProducer
+	logger           *log.Logger
+}
+
+func NewService(c Config, l *log.Logger) *Service {
+	brokers := strings.Split(c.Brokers, ",")
+	conf := sarama.NewConfig()
+	conf.Producer.RequiredAcks = sarama.WaitForAll
+	conf.Producer.Retry.Max = 10
+	// SASL
+	conf.Net.SASL.Enable = c.SaslEnabled
+	conf.Net.SASL.User = c.SaslUser
+	conf.Net.SASL.Password = c.SaslPassword
+	producer, err := sarama.NewSyncProducer(brokers, conf)
+
+	if err != nil {
+		return err
+	}
+
+	return &Service{
+		topics:           c.Topics,
+		global:           c.Global,
+		stateChangesOnly: c.StateChangesOnly,
+		producer:         producer,
+		logger:           l,
+	}
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+
+func (s *Service) Close() error {
+	s.producer.Close()
+	return nil
+}
+
+func (s *Service) Global() bool {
+	return s.global
+}
+func (s *Service) StateChangesOnly() bool {
+	return s.stateChangesOnly
+}
+
+func (s *Service) Alert(topics []string, message string, level kapacitor.AlertLevel) error {
+	if len(topics) == 0 {
+		topics = s.topics
+	}
+	for _, topic := range topics {
+		_, _, err := s.producer.SendMessage(&sarama.ProducerMessage{
+			Topic: topic,
+			Value: sarama.StringEncoder(message)})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/task_master.go
+++ b/task_master.go
@@ -82,6 +82,11 @@ type TaskMaster struct {
 		StateChangesOnly() bool
 		Alert(channel, message string, level AlertLevel) error
 	}
+	KafkaService interface {
+		Global() bool
+		StateChangesOnly() bool
+		Alert(topics []string, message string, level AlertLevel) error
+	}
 	TelegramService interface {
 		Global() bool
 		StateChangesOnly() bool
@@ -187,6 +192,7 @@ func (tm *TaskMaster) New(id string) *TaskMaster {
 	n.TalkService = tm.TalkService
 	n.TimingService = tm.TimingService
 	n.TelegramService = tm.TelegramService
+	n.KafkaService = tm.KafkaService
 	return n
 }
 

--- a/vendor.list
+++ b/vendor.list
@@ -18,6 +18,7 @@ github.com/shurcooL/markdownfmt
 github.com/shurcooL/sanitized_anchor_name
 github.com/twinj/uuid
 golang.org/x/crypto master
+github.com/Shopify/sarama
 gopkg.in/gomail.v2
 # Generate deps
 github.com/benbjohnson/tmpl


### PR DESCRIPTION
I will preface this by saying this is my first time writing Go so mistakes could easily be made.

I am trying to add a kafka alert node and I think I have followed the same pattern other new alert nodes have. But I am stuck on getting the following message when I try to create a tick script using it:

`invalid TICKscript: line 13 char 3: no method or property "kafka" on *pipeline.AlertNode`

Any help or guidance would be greatly appreciated.

Tick script:
```
stream
    // Select just the cpu measurement from our example database.
    |from()
        .measurement('cpu')
    |alert()
	.id('{{ index .Tags "cpu" }} on {{ index .Tags "host" }}')
	.message('{{ .ID }} has remaining idle {{ index .Fields "usage_idle" }}')
        .crit(lambda: "usage_idle" <  70)
	.kafka()

```


###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
