### PR TITLE
Revert "Fail startup when we fail to save the cluster/server IDs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## v1.0.2 [unreleased]
-
-### Release Notes
-
-### Features
-
-
-### Bugfixes
-
-- [#949](https://github.com/influxdata/kapacitor/pull/949): Fix bug where errors to save cluster/server ID files were ignored.
-
 ## v1.0.1 [2016-09-26]
 
 ### Release Notes

--- a/server/server.go
+++ b/server/server.go
@@ -547,9 +547,7 @@ func (s *Server) setupIDs() error {
 	}
 	if clusterID == "" {
 		clusterID = uuid.NewV4().String()
-		if err := s.writeID(clusterIDPath, clusterID); err != nil {
-			return errors.Wrap(err, "failed to save cluster ID")
-		}
+		s.writeID(clusterIDPath, clusterID)
 	}
 	s.ClusterID = clusterID
 
@@ -560,9 +558,7 @@ func (s *Server) setupIDs() error {
 	}
 	if serverID == "" {
 		serverID = uuid.NewV4().String()
-		if err := s.writeID(serverIDPath, serverID); err != nil {
-			return errors.Wrap(err, "failed to save server ID")
-		}
+		s.writeID(serverIDPath, serverID)
 	}
 	s.ServerID = serverID
 


### PR DESCRIPTION
Reverts influxdata/kapacitor#949