### PR TITLE
Sort and dynamically adjust column widths in CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ See the API docs for more details.
 - [#984](https://github.com/influxdata/kapacitor/issues/984): Fix bug where keeping a list of fields that where not referenced in the eval expressions would cause an error.
 - [#955](https://github.com/influxdata/kapacitor/issues/955): Fix the number of subscriptions statistic.
 - [#999](https://github.com/influxdata/kapacitor/issues/999): Fix inconsistency with InfluxDB by adding config option to set a default retention policy.
+- [#1018](https://github.com/influxdata/kapacitor/pull/1018): Sort and dynamically adjust column width in CLI output. Fixes #785
 
 ## v1.0.2 [2016-10-06]
 


### PR DESCRIPTION
Fixes #785 

Having inconsistent sorting and ID that ran over columns is painful. This simple change fixes both of those issues.

Not that the recordings/replays did not get the sorting change since they are naturally sorted by time in the API.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
