### PR TITLE
Add missing strLength function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ See the API docs for more details.
 - [#955](https://github.com/influxdata/kapacitor/issues/955): Fix the number of subscriptions statistic.
 - [#999](https://github.com/influxdata/kapacitor/issues/999): Fix inconsistency with InfluxDB by adding config option to set a default retention policy.
 - [#1018](https://github.com/influxdata/kapacitor/pull/1018): Sort and dynamically adjust column width in CLI output. Fixes #785
+- [#1019](https://github.com/influxdata/kapacitor/pull/1019): Adds missing strLength function.
 
 ## v1.0.2 [2016-10-06]
 

--- a/tick/stateful/functions.go
+++ b/tick/stateful/functions.go
@@ -90,6 +90,7 @@ func init() {
 	statelessFuncs["strIndexAny"] = newString2Int("strIndexAny", strings.IndexAny)
 	statelessFuncs["strLastIndex"] = newString2Int("strLastIndex", strings.LastIndex)
 	statelessFuncs["strLastIndexAny"] = newString2Int("strLastIndexAny", strings.LastIndexAny)
+	statelessFuncs["strLength"] = strLength{}
 	statelessFuncs["strReplace"] = strReplace{}
 	statelessFuncs["strSubstring"] = strSubstring{}
 	statelessFuncs["strToLower"] = newString1String("strToLower", strings.ToLower)
@@ -382,6 +383,24 @@ func (m string1String) Call(args ...interface{}) (v interface{}, err error) {
 }
 
 func (m string1String) Reset() {}
+
+type strLength struct {
+}
+
+func (m strLength) Call(args ...interface{}) (v interface{}, err error) {
+	if len(args) != 1 {
+		return 0, errors.New("strLength expects exactly one argument")
+	}
+	str, ok := args[0].(string)
+	if !ok {
+		err = fmt.Errorf("cannot pass %T as first arg to strLength, must be string", args[0])
+		return
+	}
+	v = int64(len(str))
+	return
+}
+
+func (m strLength) Reset() {}
 
 type strReplace struct {
 }

--- a/tick/stateful/functions_test.go
+++ b/tick/stateful/functions_test.go
@@ -692,6 +692,26 @@ func Test_StatelessFuncs(t *testing.T) {
 			err:  errors.New("strLastIndexAny expects exactly two arguments"),
 		},
 		{
+			name: "strLength",
+			args: []interface{}{""},
+			exp:  int64(0),
+		},
+		{
+			name: "strLength",
+			args: []interface{}{"abxyzc"},
+			exp:  int64(6),
+		},
+		{
+			name: "strLength",
+			args: []interface{}{},
+			err:  errors.New("strLength expects exactly one argument"),
+		},
+		{
+			name: "strLength",
+			args: []interface{}{1},
+			err:  errors.New("cannot pass int as first arg to strLength, must be string"),
+		},
+		{
 			name: "strReplace",
 			args: []interface{}{"abxyzc", "xyz", "", int64(1)},
 			exp:  "abc",


### PR DESCRIPTION
The strings functions was missing a way to get the length of a string. It has now been added.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated