### PR TITLE
Add fillPeriod option to Window node that wait till the period has el…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.1.1 [unreleased]
+
+### Release Notes
+
+### Features
+
+- [#913](https://github.com/influxdata/kapacitor/issues/913): Add fillPeriod option to Window node, so that the first emit waits till the period has elapsed before emitting.
+
+### Bugfixes
+
+
+
 ## v1.1.0 [2016-10-07]
 
 ### Release Notes

--- a/integrations/data/TestStream_Window_FillPeriod.srpl
+++ b/integrations/data/TestStream_Window_FillPeriod.srpl
@@ -1,0 +1,48 @@
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.1 0000000000
+dbname
+rpname
+cpu,type=idle,host=serverA value=97.1 0000000001
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.6 0000000002
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.6 0000000003
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.1 0000000004
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.6 0000000005
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.8 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.7 0000000007
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.0 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.4 0000000009
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.3 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.4 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1 0000000012
+dbname
+rpname
+cpu,type=idle,host=serverA value=91.1 0000000013
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.7 0000000014
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.2 0000000015

--- a/integrations/data/TestStream_Window_FillPeriod_Aligned.srpl
+++ b/integrations/data/TestStream_Window_FillPeriod_Aligned.srpl
@@ -1,0 +1,63 @@
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.1 0000000000
+dbname
+rpname
+cpu,type=idle,host=serverA value=97.1 0000000001
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.6 0000000002
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.6 0000000003
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.1 0000000004
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.6 0000000005
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.8 0000000006
+dbname
+rpname
+cpu,type=idle,host=serverA value=92.7 0000000007
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.0 0000000008
+dbname
+rpname
+cpu,type=idle,host=serverA value=93.4 0000000009
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.3 0000000010
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.4 0000000011
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1 0000000012
+dbname
+rpname
+cpu,type=idle,host=serverA value=91.1 0000000013
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.7 0000000014
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.2 0000000015
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.6 0000000016
+dbname
+rpname
+cpu,type=idle,host=serverA value=91.2 0000000017
+dbname
+rpname
+cpu,type=idle,host=serverA value=98.2 0000000018
+dbname
+rpname
+cpu,type=idle,host=serverA value=96.1 0000000019
+dbname
+rpname
+cpu,type=idle,host=serverA value=97.2 0000000020

--- a/pipeline/window.go
+++ b/pipeline/window.go
@@ -32,9 +32,12 @@ type WindowNode struct {
 	Period time.Duration
 	// How often the current window is emitted into the pipeline.
 	Every time.Duration
-	// Wether to align the window edges with the zero time
+	// Whether to align the window edges with the zero time
 	// tick:ignore
 	AlignFlag bool `tick:"Align"`
+	// Whether to wait till the period is full before the first emit.
+	// tick:ignore
+	FillPeriodFlag bool `tick:"FillPeriod"`
 }
 
 func newWindowNode() *WindowNode {
@@ -52,5 +55,13 @@ func newWindowNode() *WindowNode {
 // tick:property
 func (w *WindowNode) Align() *WindowNode {
 	w.AlignFlag = true
+	return w
+}
+
+// FillPeriod instructs the WindowNode to wait till the period has elapsed before emitting the first batch.
+// This only applies if the period is greater than the every value.
+// tick:property
+func (w *WindowNode) FillPeriod() *WindowNode {
+	w.FillPeriodFlag = true
 	return w
 }


### PR DESCRIPTION
Fixes #913

Adds `fillPeriod` option to the WindowNode that waits to emit the first window until after the period has elapsed.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

