### PR TITLE
Update union node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,8 @@ stream
 ### Bugfixes
 
 - [#1045](https://github.com/influxdata/kapacitor/issues/1045): Fix panic during replays.
-
 - [#1043](https://github.com/influxdata/kapacitor/issues/1043): logrotate.d ignores kapacitor configuration due to bad file mode
+- [#1100](https://github.com/influxdata/kapacitor/issues/1100): Fix issue with the Union node buffering more points than necessary.
 
 ## v1.1.1 [2016-12-02]
 

--- a/integrations/data/TestStream_Union_Stepped.srpl
+++ b/integrations/data/TestStream_Union_Stepped.srpl
@@ -1,0 +1,78 @@
+dbname
+rpname
+cpu,cpu=0 value=91 0000000000
+dbname
+rpname
+cpu,cpu=1 value=97 0000000000
+dbname
+rpname
+cpu,cpu=0 value=98 0000000001
+dbname
+rpname
+cpu,cpu=1 value=98 0000000001
+dbname
+rpname
+cpu,cpu=total value=92 0000000002
+dbname
+rpname
+cpu,cpu=1 value=92 0000000002
+dbname
+rpname
+cpu,cpu=0 value=95 0000000003
+dbname
+rpname
+cpu,cpu=1 value=95 0000000003
+dbname
+rpname
+cpu,cpu=total value=93 0000000004
+dbname
+rpname
+cpu,cpu=1 value=93 0000000004
+dbname
+rpname
+cpu,cpu=1 value=92 0000000005
+dbname
+rpname
+cpu,cpu=0 value=92 0000000005
+dbname
+rpname
+cpu,cpu=0 value=95 0000000006
+dbname
+rpname
+cpu,cpu=total value=95 0000000006
+dbname
+rpname
+cpu,cpu=0 value=92 0000000007
+dbname
+rpname
+cpu,cpu=1 value=92 0000000007
+dbname
+rpname
+cpu,cpu=total value=96 0000000008
+dbname
+rpname
+cpu,cpu=1 value=96 0000000008
+dbname
+rpname
+cpu,cpu=1 value=93 0000000009
+dbname
+rpname
+cpu,cpu=0 value=93 0000000009
+dbname
+rpname
+cpu,cpu=0 value=95 0000000010
+dbname
+rpname
+cpu,cpu=total value=95 0000000010
+dbname
+rpname
+cpu,cpu=total value=96 0000000011
+dbname
+rpname
+cpu,cpu=0 value=96 0000000011
+dbname
+rpname
+cpu,cpu=1 value=95 0000000012
+dbname
+rpname
+cpu,cpu=0 value=95 0000000012

--- a/test.sh
+++ b/test.sh
@@ -83,8 +83,8 @@ function run_test_docker {
          -e "INFLUXDB_DATA_ENGINE=$INFLUXDB_DATA_ENGINE" \
          -e "GORACE=$GORACE" \
          -e "GO_CHECKOUT=$GO_CHECKOUT" \
-	 -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-	 -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+         -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+         -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
          "$imagename" \
          "--parallel=$PARALLELISM" \
          "--timeout=$TIMEOUT" \


### PR DESCRIPTION
The union node was caching points for too long. This change makes it so that the union node emits points as soon as possible. 

Writing a test for this has been a bit challenging as the change in behavior is only related to the timing of emits, and cannot be easily tested with the existing integration tests.

I have put together a hacky test for now to demonstrate its working, but it probably shouldn't be merged in this state.

The ideal way to test this would be either: clean up the `ExecutingTask` code such that it is easier to setup a single node in isolation, or enhance the edge communication so it can carry metadata messages as well and add `barrier` messages. The reality is both probably need to happen.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #1100 