### PR TITLE
Move alerta api token to header and add option to skip TLS verification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ stream
 - [#327](https://github.com/influxdata/kapacitor/issues/327): You can now window based on count in addition to time.
 - [#913](https://github.com/influxdata/kapacitor/issues/913): Add fillPeriod option to Window node, so that the first emit waits till the period has elapsed before emitting.
 - [#898](https://github.com/influxdata/kapacitor/issues/898): Now when the Window node every value is zero, the window will be emitted immediately for each new point.
+- [#1052](https://github.com/influxdata/kapacitor/issues/1052): Move alerta api token to header and add option to skip TLS verification.
 
 ### Bugfixes
 

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -6790,8 +6790,11 @@ func TestStream_AlertAlerta(t *testing.T) {
 		dec.Decode(&pd)
 
 		if rc := atomic.LoadInt32(&requestCount); rc == 1 {
-			if exp := "/alert?api-key=testtoken1234567"; r.URL.String() != exp {
+			if exp := "/alert"; r.URL.String() != exp {
 				t.Errorf("unexpected url got %s exp %s", r.URL.String(), exp)
+			}
+			if exp := "Bearer testtoken1234567"; r.Header.Get("Authorization") != exp {
+				t.Errorf("unexpected token in header got %s exp %s", r.Header.Get("Authorization"), exp)
 			}
 			if exp := "cpu"; pd.Resource != exp {
 				t.Errorf("unexpected resource got %s exp %s", pd.Resource, exp)
@@ -6815,8 +6818,11 @@ func TestStream_AlertAlerta(t *testing.T) {
 				t.Errorf("unexpected origin got %s exp %s", pd.Origin, exp)
 			}
 		} else {
-			if exp := "/alert?api-key=anothertesttoken"; r.URL.String() != exp {
+			if exp := "/alert"; r.URL.String() != exp {
 				t.Errorf("unexpected url got %s exp %s", r.URL.String(), exp)
+			}
+			if exp := "Bearer anothertesttoken"; r.Header.Get("Authorization") != exp {
+				t.Errorf("unexpected token in header got %s exp %s", r.Header.Get("Authorization"), exp)
 			}
 			if exp := "resource: serverA"; pd.Resource != exp {
 				t.Errorf("unexpected resource got %s exp %s", pd.Resource, exp)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5296,6 +5296,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 						"origin":      "",
 						"token":       false,
 						"url":         "http://alerta.example.com",
+						"insecure-skip-verify": false,
 					},
 					Redacted: []string{
 						"token",
@@ -5310,6 +5311,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 					"origin":      "",
 					"token":       false,
 					"url":         "http://alerta.example.com",
+					"insecure-skip-verify": false,
 				},
 				Redacted: []string{
 					"token",
@@ -5333,6 +5335,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 								"origin":      "kapacitor",
 								"token":       true,
 								"url":         "http://alerta.example.com",
+								"insecure-skip-verify": false,
 							},
 							Redacted: []string{
 								"token",
@@ -5347,6 +5350,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 							"origin":      "kapacitor",
 							"token":       true,
 							"url":         "http://alerta.example.com",
+							"insecure-skip-verify": false,
 						},
 						Redacted: []string{
 							"token",

--- a/services/alerta/config.go
+++ b/services/alerta/config.go
@@ -11,6 +11,8 @@ type Config struct {
 	Enabled bool `toml:"enabled" override:"enabled"`
 	// The Alerta URL.
 	URL string `toml:"url" override:"url"`
+	// Whether to skip the tls verification of the alerta host
+	InsecureSkipVerify bool `toml:"insecure-skip-verify" override:"insecure-skip-verify"`
 	// The authentication token for this notification, can be overridden per alert.
 	Token string `toml:"token" override:"token,redact"`
 	// The environment in which to raise the alert.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Resolves issue #1052 

I have tested this change live with the custom kapacitor docker image allen13/kapacitor:latest

