### PR TITLE
Remove dead code for the `as` property on the outliers example UDF

### DIFF
--- a/udf/agent/examples/outliers/outliers.py
+++ b/udf/agent/examples/outliers/outliers.py
@@ -88,8 +88,6 @@ class OutliersHandler(Handler):
                 self._field = opt.values[0].stringValue
             elif opt.name == 'scale':
                 self._scale = opt.values[0].doubleValue
-            elif opt.name == 'as':
-                self._as = opt.values[0].stringValue
 
         if self._field is None:
             success = False


### PR DESCRIPTION
The outliers UDF has no need for an `as` property as it is essentially a filtering node and outputs the input points, that were outliers,  unmodified.