### PR TITLE
Change alerta auth token prefix from Bearer to Key.

### DIFF
--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -6793,7 +6793,7 @@ func TestStream_AlertAlerta(t *testing.T) {
 			if exp := "/alert"; r.URL.String() != exp {
 				t.Errorf("unexpected url got %s exp %s", r.URL.String(), exp)
 			}
-			if exp := "Bearer testtoken1234567"; r.Header.Get("Authorization") != exp {
+			if exp := "Key testtoken1234567"; r.Header.Get("Authorization") != exp {
 				t.Errorf("unexpected token in header got %s exp %s", r.Header.Get("Authorization"), exp)
 			}
 			if exp := "cpu"; pd.Resource != exp {
@@ -6821,7 +6821,7 @@ func TestStream_AlertAlerta(t *testing.T) {
 			if exp := "/alert"; r.URL.String() != exp {
 				t.Errorf("unexpected url got %s exp %s", r.URL.String(), exp)
 			}
-			if exp := "Bearer anothertesttoken"; r.Header.Get("Authorization") != exp {
+			if exp := "Key anothertesttoken"; r.Header.Get("Authorization") != exp {
 				t.Errorf("unexpected token in header got %s exp %s", r.Header.Get("Authorization"), exp)
 			}
 			if exp := "resource: serverA"; pd.Resource != exp {

--- a/services/alerta/service.go
+++ b/services/alerta/service.go
@@ -191,7 +191,7 @@ func (s *Service) preparePost(token, resource, event, environment, severity, gro
 	}
 
 	req, err := http.NewRequest("POST", u.String(), &post)
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Key "+token)
 	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X ] Rebased/mergable
- [ X] Tests pass
- [ X] CHANGELOG.md updated
- [ X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This address the alerta token failure reported here https://github.com/influxdata/kapacitor/issues/1076

