### PR TITLE
Example Foo alert handler

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -190,6 +190,15 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 		an.handlers = append(an.handlers, h)
 	}
 
+	for _, f := range n.FooHandlers {
+		c := et.tm.FooService.DefaultHandlerConfig()
+		if f.Room != "" {
+			c.Room = f.Room
+		}
+		h := et.tm.FooService.Handler(c, l)
+		an.handlers = append(an.handlers, h)
+	}
+
 	for _, pd := range n.PagerDutyHandlers {
 		c := pagerduty.HandlerConfig{
 			ServiceKey: pd.ServiceKey,

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/influxdata/kapacitor/services/alert/alerttest"
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/alerta/alertatest"
+	"github.com/influxdata/kapacitor/services/foo"
+	"github.com/influxdata/kapacitor/services/foo/footest"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/hipchat/hipchattest"
 	k8s "github.com/influxdata/kapacitor/services/k8s/client"
@@ -6676,6 +6678,66 @@ stream
 	ts.Close()
 	var got []interface{}
 	for _, g := range ts.Data() {
+		got = append(got, g)
+	}
+
+	if err := compareListIgnoreOrder(got, exp, nil); err != nil {
+		t.Error(err)
+	}
+}
+func TestStream_AlertFoo(t *testing.T) {
+	ts := footest.NewServer()
+	defer ts.Close()
+
+	var script = `
+stream
+	|from()
+		.measurement('cpu')
+		.where(lambda: "host" == 'serverA')
+		.groupBy('host')
+	|window()
+		.period(10s)
+		.every(10s)
+	|count('value')
+	|alert()
+		.id('kapacitor/{{ .Name }}/{{ index .Tags "host" }}')
+		.info(lambda: "count" > 6.0)
+		.warn(lambda: "count" > 7.0)
+		.crit(lambda: "count" > 8.0)
+		.foo()
+			.room('general')
+		.foo()
+`
+	tmInit := func(tm *kapacitor.TaskMaster) {
+		c := foo.NewConfig()
+		c.Enabled = true
+		c.URL = ts.URL
+		c.Room = "alerts"
+		sl := foo.NewService(c, logService.NewLogger("[test_foo] ", log.LstdFlags))
+		tm.FooService = sl
+	}
+	testStreamerNoOutput(t, "TestStream_Alert", script, 13*time.Second, tmInit)
+
+	exp := []interface{}{
+		footest.Request{
+			URL: "/",
+			PostData: footest.PostData{
+				Room:    "general",
+				Message: "kapacitor/cpu/serverA is CRITICAL",
+			},
+		},
+		footest.Request{
+			URL: "/",
+			PostData: footest.PostData{
+				Room:    "alerts",
+				Message: "kapacitor/cpu/serverA is CRITICAL",
+			},
+		},
+	}
+
+	ts.Close()
+	var got []interface{}
+	for _, g := range ts.Requests() {
 		got = append(got, g)
 	}
 

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -44,6 +44,7 @@ const defaultDetailsTmpl = "{{ json . }}"
 //    * PagerDuty -- Send alert to PagerDuty.
 //    * Talk -- Post alert message to Talk client.
 //    * Telegram -- Post alert message to Telegram client.
+//    * Foo -- Send alert to a Foo server.
 //
 // See below for more details on configuring each handler.
 //
@@ -304,6 +305,10 @@ type AlertNode struct {
 	// Send alert to VictorOps.
 	// tick:ignore
 	VictorOpsHandlers []*VictorOpsHandler `tick:"VictorOps"`
+
+	// Send alert to Foo.
+	// tick:ignore
+	FooHandlers []*FooHandler `tick:"Foo"`
 
 	// Send alert to PagerDuty.
 	// tick:ignore
@@ -690,6 +695,25 @@ type VictorOpsHandler struct {
 	// The routing key to use for the alert.
 	// Defaults to the value in the configuration if empty.
 	RoutingKey string
+}
+
+// Send alert to a Foo server.
+// tick:property
+func (a *AlertNode) Foo() *FooHandler {
+	f := &FooHandler{
+		AlertNode: a,
+	}
+	a.FooHandlers = append(a.FooHandlers, f)
+	return f
+}
+
+// tick:embedded:AlertNode.Foo
+type FooHandler struct {
+	*AlertNode
+
+	// The room for the messages.
+	// Defaults to the room in the configuration if empty.
+	Room string
 }
 
 // Send the alert to PagerDuty.

--- a/server/config.go
+++ b/server/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/config"
 	"github.com/influxdata/kapacitor/services/deadman"
+	"github.com/influxdata/kapacitor/services/foo"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/influxdb"
@@ -70,6 +71,7 @@ type Config struct {
 	Talk      talk.Config      `toml:"talk" override:"talk"`
 	Telegram  telegram.Config  `toml:"telegram" override:"telegram"`
 	VictorOps victorops.Config `toml:"victorops" override:"victorops"`
+	Foo       foo.Config       `toml:"foo" override:"foo"`
 
 	// Third-party integrations
 	Kubernetes k8s.Config `toml:"kubernetes" override:"kubernetes"`
@@ -117,6 +119,7 @@ func NewConfig() *Config {
 	c.Talk = talk.NewConfig()
 	c.Telegram = telegram.NewConfig()
 	c.VictorOps = victorops.NewConfig()
+	c.Foo = foo.NewConfig()
 
 	c.Reporting = reporting.NewConfig()
 	c.Stats = stats.NewConfig()
@@ -235,6 +238,9 @@ func (c *Config) Validate() error {
 		return err
 	}
 	if err := c.VictorOps.Validate(); err != nil {
+		return err
+	}
+	if err := c.Foo.Validate(); err != nil {
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/config"
 	"github.com/influxdata/kapacitor/services/deadman"
+	"github.com/influxdata/kapacitor/services/foo"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/influxdb"
@@ -190,6 +191,7 @@ func New(c *Config, buildInfo BuildInfo, logService logging.Interface) (*Server,
 	s.appendTalkService()
 	s.appendTelegramService()
 	s.appendVictorOpsService()
+	s.appendFooService()
 
 	// Append third-party integrations
 	if err := s.appendK8sService(); err != nil {
@@ -405,6 +407,18 @@ func (s *Server) appendVictorOpsService() {
 
 	s.SetDynamicService("victorops", srv)
 	s.AppendService("victorops", srv)
+}
+
+func (s *Server) appendFooService() {
+	c := s.config.Foo
+	l := s.LogService.NewLogger("[foo] ", log.LstdFlags)
+	srv := foo.NewService(c, l)
+
+	s.TaskMaster.FooService = srv
+	s.AlertService.FooService = srv
+
+	s.SetDynamicService("foo", srv)
+	s.AppendService("foo", srv)
 }
 
 func (s *Server) appendPagerDutyService() {

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -16,6 +16,7 @@ import (
 	client "github.com/influxdata/kapacitor/client/v1"
 	"github.com/influxdata/kapacitor/command"
 	"github.com/influxdata/kapacitor/services/alerta"
+	"github.com/influxdata/kapacitor/services/foo"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	"github.com/influxdata/kapacitor/services/opsgenie"
@@ -91,6 +92,10 @@ type Service struct {
 	AlertaService interface {
 		DefaultHandlerConfig() alerta.HandlerConfig
 		Handler(alerta.HandlerConfig, *log.Logger) (alert.Handler, error)
+	}
+	FooService interface {
+		DefaultHandlerConfig() foo.HandlerConfig
+		Handler(foo.HandlerConfig, *log.Logger) alert.Handler
 	}
 	HipChatService interface {
 		Handler(hipchat.HandlerConfig, *log.Logger) alert.Handler
@@ -915,6 +920,14 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := NewExecHandler(c, s.logger)
+		ha = newPassThroughHandler(h)
+	case "foo":
+		c := s.FooService.DefaultHandlerConfig()
+		err = decodeOptions(spec.Options, &c)
+		if err != nil {
+			return
+		}
+		h := s.FooService.Handler(c, s.logger)
 		ha = newPassThroughHandler(h)
 	case "hipchat":
 		c := hipchat.HandlerConfig{}

--- a/services/foo/config.go
+++ b/services/foo/config.go
@@ -1,0 +1,24 @@
+package foo
+
+import "errors"
+
+// Config declares the needed configuration options for the service Foo.
+type Config struct {
+	// Enabled indicates whether the service should be enabled.
+	Enabled bool `toml:"enabled" override:"enabled"`
+	// URL of the Foo server.
+	URL string `toml:"url" override:"url"`
+	// Room specifies the default room to use for all handlers.
+	Room string `toml:"room" override:"room"`
+}
+
+func NewConfig() Config {
+	return Config{}
+}
+
+func (c Config) Validate() error {
+	if c.Enabled && c.URL == "" {
+		return errors.New("must specify the Foo server URL")
+	}
+	return nil
+}

--- a/services/foo/footest/footest.go
+++ b/services/foo/footest/footest.go
@@ -1,0 +1,56 @@
+package footest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+)
+
+type Server struct {
+	mu       sync.Mutex
+	ts       *httptest.Server
+	URL      string
+	requests []Request
+	closed   bool
+}
+
+func NewServer() *Server {
+	s := new(Server)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fr := Request{
+			URL: r.URL.String(),
+		}
+		dec := json.NewDecoder(r.Body)
+		dec.Decode(&fr.PostData)
+		s.mu.Lock()
+		s.requests = append(s.requests, fr)
+		s.mu.Unlock()
+	}))
+	s.ts = ts
+	s.URL = ts.URL
+	return s
+}
+
+func (s *Server) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requests
+}
+func (s *Server) Close() {
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.ts.Close()
+}
+
+type Request struct {
+	URL      string
+	PostData PostData
+}
+
+type PostData struct {
+	Room    string `json:"room"`
+	Message string `json:"message"`
+}

--- a/services/foo/service.go
+++ b/services/foo/service.go
@@ -1,0 +1,142 @@
+package foo
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/influxdata/kapacitor/alert"
+)
+
+type Service struct {
+	configValue atomic.Value
+	logger      *log.Logger
+}
+
+func NewService(c Config, l *log.Logger) *Service {
+	s := &Service{
+		logger: l,
+	}
+	s.configValue.Store(c)
+	return s
+}
+
+func (s *Service) Open() error {
+	// Perform any initialization needed here
+	return nil
+}
+
+func (s *Service) Close() error {
+	// Perform any actions needed to properly close the service here.
+	// For example signal and wait for all go routines to finish.
+	return nil
+}
+
+func (s *Service) Update(newConfig []interface{}) error {
+	if l := len(newConfig); l != 1 {
+		return fmt.Errorf("expected only one new config object, got %d", l)
+	}
+	if c, ok := newConfig[0].(Config); !ok {
+		return fmt.Errorf("expected config object to be of type %T, got %T", c, newConfig[0])
+	} else {
+		s.configValue.Store(c)
+	}
+	return nil
+}
+
+// config loads the config struct stored in the configValue field.
+func (s *Service) config() Config {
+	return s.configValue.Load().(Config)
+}
+
+// Alert sends a message to the specified room.
+func (s *Service) Alert(room, message string) error {
+	c := s.config()
+	if !c.Enabled {
+		return errors.New("service is not enabled")
+	}
+	type postMessage struct {
+		Room    string `json:"room"`
+		Message string `json:"message"`
+	}
+	data, err := json.Marshal(postMessage{
+		Room:    room,
+		Message: message,
+	})
+	if err != nil {
+		return err
+	}
+	r, err := http.Post(c.URL, "application/json", bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response code %d from Foo service", r.StatusCode)
+	}
+	return nil
+}
+
+type HandlerConfig struct {
+	//Room specifies the destination room for the chat messages.
+	Room string `mapstructure:"room"`
+}
+
+// handler provides the implementation of the alert.Handler interface for the Foo service.
+type handler struct {
+	s      *Service
+	c      HandlerConfig
+	logger *log.Logger
+}
+
+// DefaultHandlerConfig returns a HandlerConfig struct with defaults applied.
+func (s *Service) DefaultHandlerConfig() HandlerConfig {
+	// return a handler config populated with the default room from the service config.
+	c := s.config()
+	return HandlerConfig{
+		Room: c.Room,
+	}
+}
+
+// Handler creates a handler from the config.
+func (s *Service) Handler(c HandlerConfig, l *log.Logger) alert.Handler {
+	// handlers can operate in differing contexts, as a result a logger is passed
+	// in so that logs from this handler can be correctly associatied with a given context.
+	return &handler{
+		s:      s,
+		c:      c,
+		logger: l,
+	}
+}
+
+// Handle takes an event and posts its message to the Foo service chat room.
+func (h *handler) Handle(event alert.Event) {
+	if err := h.s.Alert(h.c.Room, event.State.Message); err != nil {
+		h.logger.Println("E! failed to handle event", err)
+	}
+}
+
+type testOptions struct {
+	Room    string `json:"room"`
+	Message string `json:"message"`
+}
+
+func (s *Service) TestOptions() interface{} {
+	c := s.config()
+	return &testOptions{
+		Room:    c.Room,
+		Message: "test foo message",
+	}
+}
+
+func (s *Service) Test(o interface{}) error {
+	options, ok := o.(*testOptions)
+	if !ok {
+		return fmt.Errorf("unexpected options type %T", options)
+	}
+	return s.Alert(options.Room, options.Message)
+}

--- a/task_master.go
+++ b/task_master.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 	"github.com/influxdata/kapacitor/services/alerta"
+	"github.com/influxdata/kapacitor/services/foo"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
 	k8s "github.com/influxdata/kapacitor/services/k8s/client"
@@ -89,6 +90,10 @@ type TaskMaster struct {
 	VictorOpsService interface {
 		Global() bool
 		Handler(victorops.HandlerConfig, *log.Logger) alert.Handler
+	}
+	FooService interface {
+		DefaultHandlerConfig() foo.HandlerConfig
+		Handler(foo.HandlerConfig, *log.Logger) alert.Handler
 	}
 	PagerDutyService interface {
 		Global() bool
@@ -196,6 +201,7 @@ func (tm *TaskMaster) New(id string) *TaskMaster {
 	n.SMTPService = tm.SMTPService
 	n.OpsGenieService = tm.OpsGenieService
 	n.VictorOpsService = tm.VictorOpsService
+	n.FooService = tm.FooService
 	n.PagerDutyService = tm.PagerDutyService
 	n.SlackService = tm.SlackService
 	n.TelegramService = tm.TelegramService


### PR DESCRIPTION
The PR provides an example of adding an new alert handler to Kapacitor.

For an explanation of what is going on in this PR see https://github.com/influxdata/kapacitor/blob/master/alert/HANDLERS.md


This PR is not meant to actually be merged.