### PR TITLE
Add new query property for aligning group by intervals to start times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ stream
 - [#251](https://github.com/influxdata/kapacitor/issues/251): Enable markdown in slack attachments.
 - [#1095](https://github.com/influxdata/kapacitor/pull/1095): Add new alert API, with support for configuring handlers and topics.
 - [#929](https://github.com/influxdata/kapacitor/pull/929): Add SNMP trap service for alerting
+- [#1110](https://github.com/influxdata/kapacitor/pull/1110): Add new query property for aligning group by intervals to start times.
 
 
 ### Bugfixes

--- a/batch.go
+++ b/batch.go
@@ -165,6 +165,10 @@ func newQueryNode(et *ExecutingTask, n *pipeline.QueryNode, l *log.Logger) (*Que
 	if err != nil {
 		return nil, err
 	}
+	// Set offset alignment
+	if n.AlignGroupFlag {
+		bn.query.AlignGroup()
+	}
 	// Set fill
 	switch fill := n.Fill.(type) {
 	case string:

--- a/query_test.go
+++ b/query_test.go
@@ -109,6 +109,34 @@ func TestQuery_Clone(t *testing.T) {
 		if err := equal(clone, q); err != nil {
 			t.Error(err)
 		}
+
+		// Set group align and dimensions
+		q.AlignGroup()
+		q.Dimensions([]interface{}{kapacitor.TimeDimension{
+			Length: time.Minute,
+			Offset: time.Second,
+		}})
+		if err := equal(clone, q); err == nil {
+			t.Errorf("equal after modification: got %v", clone)
+			return
+		}
+		// Set group align and dimesions on the clone in the same way
+		clone.AlignGroup()
+		clone.Dimensions([]interface{}{kapacitor.TimeDimension{
+			Length: time.Minute,
+			Offset: time.Second,
+		}})
+		if err := equal(clone, q); err != nil {
+			t.Error(err)
+		}
+		// Re-clone
+		clone, err = q.Clone()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := equal(clone, q); err != nil {
+			t.Error(err)
+		}
 	}
 }
 func TestQuery_IsGroupedByTime(t *testing.T) {


### PR DESCRIPTION
Allow QueryNodes to automatically align GROUP BY time intervals to the start time for each query sent to influx.  This leverages the offset argument to `GROUP BY time()` to offset directly to the start time.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
