### PR TITLE
Fix panic on closing failed to open influxdbCluster type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ See the [API docs on technical preview](https://docs.influxdata.com/kapacitor/v1
 - [#1043](https://github.com/influxdata/kapacitor/issues/1043): logrotate.d ignores kapacitor configuration due to bad file mode
 - [#1100](https://github.com/influxdata/kapacitor/issues/1100): Fix issue with the Union node buffering more points than necessary.
 - [#872](https://github.com/influxdata/kapacitor/issues/872): Fix panic during failed aggregate results.
+- [#1087](https://github.com/influxdata/kapacitor/issues/1087): Fix panic during close of failed startup when connecting to InfluxDB.
 
 ## v1.1.1 [2016-12-02]
 

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -500,7 +500,11 @@ func (c *influxdbCluster) Open() error {
 	}
 
 	c.watchSubs()
-	return c.linkSubscriptions(ctx)
+
+	if err := c.linkSubscriptions(ctx); err != nil {
+		return errors.Wrap(err, "failed to link subscription on startup")
+	}
+	return nil
 }
 
 func (c *influxdbCluster) Close() error {
@@ -514,7 +518,9 @@ func (c *influxdbCluster) Close() error {
 	if c.subSyncTicker != nil {
 		c.subSyncTicker.Stop()
 	}
-	c.client.Close()
+	if c.client != nil {
+		c.client.Close()
+	}
 	return c.closeServices()
 }
 


### PR DESCRIPTION
The second stack trace reported in #1087 is caused by closing the `influxdbCluster` type after it has failed to open. This PR fixes the issue

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated