### PR TITLE
Fixed install/remove of kapacitor on non-systemd Debian/Ubuntu systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugfixes
 
 - [#1147](https://github.com/influxdata/kapacitor/issues/1147): Fix pprof debug endpoint
-
+- [#1161](https://github.com/influxdata/kapacitor/pull/1161): Fixed install/remove of kapacitor on non-systemd Debian/Ubuntu systems
 
 ## v1.2.0 [2017-01-23]
 

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -44,7 +44,7 @@ if [[ -f /etc/redhat-release ]]; then
         # Assuming SysVinit
         install_init
         # Run update-rc.d or fallback to chkconfig if not available
-        if which update-rc.d >/dev/null; then
+        if which update-rc.d &>/dev/null; then
             install_update_rcd
         else
             install_chkconfig
@@ -58,7 +58,7 @@ elif [[ -f /etc/debian_version ]]; then
         # Assuming SysVinit
         install_init
         # Run update-rc.d or fallback to chkconfig if not available
-        if which update-rc.d >/dev/null; then
+        if which update-rc.d &>/dev/null; then
             install_update_rcd
         else
             install_chkconfig
@@ -70,7 +70,7 @@ elif [[ -f /etc/os-release ]]; then
         # Amazon Linux logic
         install_init
         # Run update-rc.d or fallback to chkconfig if not available
-        if which update-rc.d >/dev/null; then
+        if which update-rc.d &>/dev/null; then
             install_update_rcd
         else
             install_chkconfig

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,11 +1,30 @@
-#!/bin/sh
+#!/bin/bash
+
 BIN_DIR=/usr/bin
 DATA_DIR=/var/lib/kapacitor
 LOG_DIR=/var/log/kapacitor
 SCRIPT_DIR=/usr/lib/kapacitor/scripts
 
+function install_init {
+    cp -f $SCRIPT_DIR/init.sh /etc/init.d/kapacitor
+    chmod +x /etc/init.d/kapacitor
+}
+
+function install_systemd {
+    cp -f $SCRIPT_DIR/kapacitor.service /lib/systemd/system/kapacitor.service
+    systemctl enable kapacitor
+}
+
+function install_update_rcd {
+    update-rc.d kapacitor defaults
+}
+
+function install_chkconfig {
+    chkconfig --add kapacitor
+}
+
 if ! id kapacitor >/dev/null 2>&1; then
-        useradd --system -U -M kapacitor -s /bin/false -d $DATA_DIR
+    useradd --system -U -M kapacitor -s /bin/false -d $DATA_DIR
 fi
 chmod a+rX $BIN_DIR/kapacitor*
 
@@ -16,19 +35,45 @@ chown -R -L kapacitor:kapacitor $DATA_DIR
 
 test -f /etc/default/kapacitor || touch /etc/default/kapacitor
 
-# Systemd
-if which systemctl > /dev/null 2>&1 ; then
-    cp -f $SCRIPT_DIR/kapacitor.service /lib/systemd/system/kapacitor.service
-    systemctl enable kapacitor
-
-# Sysv
-else
-    cp -f $SCRIPT_DIR/init.sh /etc/init.d/kapacitor
-    chmod +x /etc/init.d/kapacitor
-    if which update-rc.d > /dev/null 2>&1 ; then
-        update-rc.d -f kapacitor remove
-        update-rc.d kapacitor defaults
+# Distribution-specific logic
+if [[ -f /etc/redhat-release ]]; then
+    # RHEL-variant logic
+    if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
+        install_systemd
     else
-        chkconfig --add kapacitor
+        # Assuming SysVinit
+        install_init
+        # Run update-rc.d or fallback to chkconfig if not available
+        if which update-rc.d >/dev/null; then
+            install_update_rcd
+        else
+            install_chkconfig
+        fi
+    fi
+elif [[ -f /etc/debian_version ]]; then
+    # Debian/Ubuntu logic
+    if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
+        install_systemd
+    else
+        # Assuming SysVinit
+        install_init
+        # Run update-rc.d or fallback to chkconfig if not available
+        if which update-rc.d >/dev/null; then
+            install_update_rcd
+        else
+            install_chkconfig
+        fi
+    fi
+elif [[ -f /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ $ID = "amzn" ]]; then
+        # Amazon Linux logic
+        install_init
+        # Run update-rc.d or fallback to chkconfig if not available
+        if which update-rc.d >/dev/null; then
+            install_update_rcd
+        else
+            install_chkconfig
+        fi
     fi
 fi

--- a/scripts/post-uninstall.sh
+++ b/scripts/post-uninstall.sh
@@ -1,17 +1,54 @@
-#!/bin/sh
+#!/bin/bash
 
-rm -f /etc/default/kapacitor
-
-# Systemd
-if which systemctl > /dev/null 2>&1 ; then
+function disable_systemd {
     systemctl disable kapacitor
     rm -f /lib/systemd/system/kapacitor.service
-# Sysv
-else
-    if which update-rc.d > /dev/null 2>&1 ; then
-        update-rc.d -f kapacitor remove
-    else
-        chkconfig --del kapacitor
-    fi
+}
+
+function disable_update_rcd {
+    update-rc.d kapacitor remove
     rm -f /etc/init.d/kapacitor
+}
+
+function disable_chkconfig {
+    chkconfig --del kapacitor
+    rm -f /etc/init.d/kapacitor
+}
+
+if [[ -f /etc/redhat-release ]]; then
+    # RHEL-variant logic
+    if [[ "$1" = "0" ]]; then
+        # Kapacitor is no longer installed, remove from init system
+        rm -f /etc/default/kapacitor
+
+        if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
+            disable_systemd
+        else
+            # Assuming sysv
+            disable_chkconfig
+        fi
+    fi
+elif [[ -f /etc/debian_version ]]; then
+    # Debian/Ubuntu logic
+    if [[ "$1" != "upgrade" ]]; then
+        # Remove/purge
+        rm -f /etc/default/kapacitor
+
+        if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
+            disable_systemd
+        else
+            # Assuming sysv
+            disable_update_rcd
+        fi
+    fi
+elif [[ -f /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ $ID = "amzn" ]]; then
+        # Amazon Linux logic
+        if [[ "$1" = "0" ]]; then
+            # Kapacitor is no longer installed, remove from init system
+            rm -f /etc/default/kapacitor
+            disable_chkconfig
+        fi
+    fi
 fi


### PR DESCRIPTION
Also added distribution-specific install/remove logic with code copied from telegraf/influxdb scripts. For more rationale, see: https://github.com/influxdata/telegraf/pull/2360

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
