### PR TITLE
Fix hang in config API if update failed or takes too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ### Bugfixes
 
 - [#1147](https://github.com/influxdata/kapacitor/issues/1147): Fix pprof debug endpoint
+- [#1164](https://github.com/influxdata/kapacitor/pull/1164): Fix hang in config API to update a config section.
+    Now if the service update process takes too long the request will timeout and return an error.
+    Previously the request would block forever.
+
 
 
 ## v1.2.0 [2017-01-23]

--- a/services/config/service_test.go
+++ b/services/config/service_test.go
@@ -1038,7 +1038,7 @@ func TestService_GetConfig(t *testing.T) {
 			go func() {
 				// Validate we got the update over the chan.
 				// This keeps the chan unblocked.
-				timer := time.NewTimer(10 * time.Millisecond)
+				timer := time.NewTimer(100 * time.Millisecond)
 				defer timer.Stop()
 				select {
 				case cu := <-updates:


### PR DESCRIPTION
This fixes a flaky test. Add defensive measures to handleUpdateSection code, increases timeout in test.

Now if the timeout is reached in the test the test will fail immediately instead of hanging and waiting for the longer test timeout.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated