### PR TITLE
Fix parse dbrp param

### DIFF
--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -561,7 +561,7 @@ func (d *dbrps) Set(value string) error {
 	if value[0] == '"' {
 		dbrp.Database, n = parseQuotedStr(value)
 	} else {
-		n = strings.IndexRune(value, '.')
+		n = strings.LastIndexByte(value, '.')
 		if n == -1 {
 			return errors.New("does not contain a '.', it must be in the form \"dbname\".\"rpname\" where the quotes are optional.")
 		}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

If the database name is `collect.dev.test.com`, and the RP name is `default`.

exec:
```
/usr/bin/kapacitor define cpu_idel_alert -type batch -tick /data/tick/cpu-idel.tick -dbrp "collect.dev.test.com"."default"
```
the result:

```
ID                        Type      Status    Executing Databases and Retention Policies
cpu_idel_alert            batch     disabled  false     ["collect"."dev.test.com.default"]
```

After fixed:

```
ID                        Type      Status    Executing Databases and Retention Policies
cpu_idel_alert            batch     disabled  false     ["collect.dev.test.com"."default"]
```

