### PR TITLE
Fix case-sensitivity of Telegram parse mode values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugfixes
 
+- [#1133](https://github.com/influxdata/kapacitor/issues/1133): Fix case-sensitivity for Telegram `parseMode` value. 
 - [#1147](https://github.com/influxdata/kapacitor/issues/1147): Fix pprof debug endpoint
 - [#1164](https://github.com/influxdata/kapacitor/pull/1164): Fix hang in config API to update a config section.
     Now if the service update process takes too long the request will timeout and return an error.

--- a/services/telegram/service.go
+++ b/services/telegram/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/influxdata/kapacitor/alert"
 	"github.com/pkg/errors"
+	"strings"
 )
 
 type Service struct {
@@ -143,7 +144,7 @@ func (s *Service) preparePost(chatId, parseMode, message string, disableWebPageP
 		parseMode = c.ParseMode
 	}
 
-	if parseMode != "" && parseMode != "Markdown" && parseMode != "HTML" {
+	if parseMode != "" && strings.ToLower(parseMode) != "markdown" && strings.ToLower(parseMode) != "html" {
 		return "", nil, fmt.Errorf("parseMode %s is not valid, please use 'Markdown' or 'HTML'", parseMode)
 	}
 


### PR DESCRIPTION
This PR fixes the case-sensitivity of Telegram `parseMode` values. This is done by lower-casing those values before validation.

I don't know where and how to test this, so I left that out of this PR. Let me know if this is required and how I can add them.

Fixes #1133 

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

