### PR TITLE
Make the alerta auth token prefix configurable and default it to Bearer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1164](https://github.com/influxdata/kapacitor/pull/1164): Fix hang in config API to update a config section.
     Now if the service update process takes too long the request will timeout and return an error.
     Previously the request would block forever.
+- [#1165](https://github.com/influxdata/kapacitor/issues/1165): Make the alerta auth token prefix configurable and default it to Bearer.
 
 
 

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -335,6 +335,9 @@ default-retention-policy = ""
   url = ""
   # Default authentication token.
   token = ""
+  # Default token prefix
+  # If you are on older versions of alerta you may need to change this to "Key"
+  token-prefix = "Bearer"
   # Default environment.
   environment = ""
   # Default origin.

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -6968,7 +6968,7 @@ stream
 	exp := []interface{}{
 		alertatest.Request{
 			URL:           "/alert",
-			Authorization: "Key testtoken1234567",
+			Authorization: "Bearer testtoken1234567",
 			PostData: alertatest.PostData{
 				Resource:    "cpu",
 				Event:       "serverA",
@@ -6981,7 +6981,7 @@ stream
 		},
 		alertatest.Request{
 			URL:           "/alert",
-			Authorization: "Key anothertesttoken",
+			Authorization: "Bearer anothertesttoken",
 			PostData: alertatest.PostData{
 				Resource:    "resource: serverA",
 				Event:       "event: TestStream_Alert",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5413,11 +5413,12 @@ func TestServer_UpdateConfig(t *testing.T) {
 				Elements: []client.ConfigElement{{
 					Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/config/alerta/"},
 					Options: map[string]interface{}{
-						"enabled":     false,
-						"environment": "",
-						"origin":      "",
-						"token":       false,
-						"url":         "http://alerta.example.com",
+						"enabled":      false,
+						"environment":  "",
+						"origin":       "",
+						"token":        false,
+						"token-prefix": "",
+						"url":          "http://alerta.example.com",
 						"insecure-skip-verify": false,
 					},
 					Redacted: []string{
@@ -5428,11 +5429,12 @@ func TestServer_UpdateConfig(t *testing.T) {
 			expDefaultElement: client.ConfigElement{
 				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/config/alerta/"},
 				Options: map[string]interface{}{
-					"enabled":     false,
-					"environment": "",
-					"origin":      "",
-					"token":       false,
-					"url":         "http://alerta.example.com",
+					"enabled":      false,
+					"environment":  "",
+					"origin":       "",
+					"token":        false,
+					"token-prefix": "",
+					"url":          "http://alerta.example.com",
 					"insecure-skip-verify": false,
 				},
 				Redacted: []string{
@@ -5452,11 +5454,12 @@ func TestServer_UpdateConfig(t *testing.T) {
 						Elements: []client.ConfigElement{{
 							Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/config/alerta/"},
 							Options: map[string]interface{}{
-								"enabled":     false,
-								"environment": "",
-								"origin":      "kapacitor",
-								"token":       true,
-								"url":         "http://alerta.example.com",
+								"enabled":      false,
+								"environment":  "",
+								"origin":       "kapacitor",
+								"token":        true,
+								"token-prefix": "",
+								"url":          "http://alerta.example.com",
 								"insecure-skip-verify": false,
 							},
 							Redacted: []string{
@@ -5467,11 +5470,12 @@ func TestServer_UpdateConfig(t *testing.T) {
 					expElement: client.ConfigElement{
 						Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/config/alerta/"},
 						Options: map[string]interface{}{
-							"enabled":     false,
-							"environment": "",
-							"origin":      "kapacitor",
-							"token":       true,
-							"url":         "http://alerta.example.com",
+							"enabled":      false,
+							"environment":  "",
+							"origin":       "kapacitor",
+							"token":        true,
+							"token-prefix": "",
+							"url":          "http://alerta.example.com",
 							"insecure-skip-verify": false,
 						},
 						Redacted: []string{
@@ -7108,10 +7112,11 @@ func TestServer_AlertHandlers(t *testing.T) {
 			handlerAction: client.HandlerAction{
 				Kind: "alerta",
 				Options: map[string]interface{}{
-					"token":       "testtoken1234567",
-					"origin":      "kapacitor",
-					"group":       "test",
-					"environment": "env",
+					"token":        "testtoken1234567",
+					"token-prefix": "Bearer",
+					"origin":       "kapacitor",
+					"group":        "test",
+					"environment":  "env",
 				},
 			},
 			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
@@ -7128,7 +7133,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 				got := ts.Requests()
 				exp := []alertatest.Request{{
 					URL:           "/alert",
-					Authorization: "Key testtoken1234567",
+					Authorization: "Bearer testtoken1234567",
 					PostData: alertatest.PostData{
 						Resource:    "alert",
 						Event:       "id",

--- a/services/alerta/config.go
+++ b/services/alerta/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	InsecureSkipVerify bool `toml:"insecure-skip-verify" override:"insecure-skip-verify"`
 	// The authentication token for this notification, can be overridden per alert.
 	Token string `toml:"token" override:"token,redact"`
+	// The prefix for the Authentication field where the token is stored
+	// This defaults to Bearer but you may need to set this to "Key" for older versions of alerta
+	TokenPrefix string `toml:"token-prefix" override:"token-prefix"`
 	// The environment in which to raise the alert.
 	Environment string `toml:"environment" override:"environment"`
 	// The origin of the alert.

--- a/services/alerta/service.go
+++ b/services/alerta/service.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	defaultResource = "{{ .Name }}"
-	defaultEvent    = "{{ .ID }}"
-	defaultGroup    = "{{ .Group }}"
+	defaultResource    = "{{ .Name }}"
+	defaultEvent       = "{{ .ID }}"
+	defaultGroup       = "{{ .Group }}"
+	defaultTokenPrefix = "Bearer"
 )
 
 type Service struct {
@@ -77,6 +78,7 @@ func (s *Service) Test(options interface{}) error {
 	c := s.config()
 	return s.Alert(
 		c.Token,
+		c.TokenPrefix,
 		o.Resource,
 		o.Event,
 		o.Environment,
@@ -120,12 +122,12 @@ func (s *Service) Update(newConfig []interface{}) error {
 	return nil
 }
 
-func (s *Service) Alert(token, resource, event, environment, severity, group, value, message, origin string, service []string, data interface{}) error {
+func (s *Service) Alert(token, tokenPrefix, resource, event, environment, severity, group, value, message, origin string, service []string, data interface{}) error {
 	if resource == "" || event == "" {
 		return errors.New("Resource and Event are required to send an alert")
 	}
 
-	req, err := s.preparePost(token, resource, event, environment, severity, group, value, message, origin, service, data)
+	req, err := s.preparePost(token, tokenPrefix, resource, event, environment, severity, group, value, message, origin, service, data)
 	if err != nil {
 		return err
 	}
@@ -153,7 +155,7 @@ func (s *Service) Alert(token, resource, event, environment, severity, group, va
 	return nil
 }
 
-func (s *Service) preparePost(token, resource, event, environment, severity, group, value, message, origin string, service []string, data interface{}) (*http.Request, error) {
+func (s *Service) preparePost(token, tokenPrefix, resource, event, environment, severity, group, value, message, origin string, service []string, data interface{}) (*http.Request, error) {
 	c := s.config()
 
 	if !c.Enabled {
@@ -162,6 +164,14 @@ func (s *Service) preparePost(token, resource, event, environment, severity, gro
 
 	if token == "" {
 		token = c.Token
+	}
+
+	if tokenPrefix == "" {
+		if c.TokenPrefix == "" {
+			tokenPrefix = defaultTokenPrefix
+		} else {
+			tokenPrefix = c.TokenPrefix
+		}
 	}
 
 	if environment == "" {
@@ -200,7 +210,7 @@ func (s *Service) preparePost(token, resource, event, environment, severity, gro
 	}
 
 	req, err := http.NewRequest("POST", u.String(), &post)
-	req.Header.Add("Authorization", "Key "+token)
+	req.Header.Add("Authorization", tokenPrefix+" "+token)
 	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
@@ -213,6 +223,10 @@ type HandlerConfig struct {
 	// Alerta authentication token.
 	// If empty uses the token from the configuration.
 	Token string `mapstructure:"token"`
+
+	// Alerta authentication token prefix.
+	// If empty uses Bearer.
+	TokenPrefix string `mapstructure:"token-prefix"`
 
 	// Alerta resource.
 	// Can be a template and has access to the same data as the AlertNode.Details property.
@@ -388,6 +402,7 @@ func (h *handler) Handle(event alert.Event) {
 
 	if err := h.s.Alert(
 		h.c.Token,
+		h.c.TokenPrefix,
 		resource,
 		eventStr,
 		environment,


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [x] Tests pass
- [X] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Addresses this issue: https://github.com/influxdata/kapacitor/issues/1165
