### PR TITLE
Remove http auth option from default configuration

### DIFF
--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -21,7 +21,6 @@ default-retention-policy = ""
   # and as the API endpoint for all other
   # Kapacitor calls.
   bind-address = ":9092"
-  auth-enabled = false
   log-enabled = true
   write-tracing = false
   pprof-enabled = false


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
