### PR TITLE
Fix name of kapacitor error log in log rotate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     Now if the service update process takes too long the request will timeout and return an error.
     Previously the request would block forever.
 - [#1165](https://github.com/influxdata/kapacitor/issues/1165): Make the alerta auth token prefix configurable and default it to Bearer.
+- [#1184](https://github.com/influxdata/kapacitor/pull/1184#issuecomment-278697177): Fix logrotate file to correctly rotate error log.
 
 
 

--- a/etc/logrotate.d/kapacitor
+++ b/etc/logrotate.d/kapacitor
@@ -1,5 +1,5 @@
 /var/log/kapacitor/kapacitor.log 
-/var/log/kapacitor/kapacitor.err
+/var/log/kapacitor/kapacitord.err
 {
     daily
     rotate 7
@@ -8,4 +8,3 @@
     copytruncate
     compress
 }
-


### PR DESCRIPTION
The logrotate execution won't work because the proper name of the error log is `kapacitord.err`.

###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


