### PR TITLE
add StateDuration node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#922](https://github.com/influxdata/kapacitor/issues/922): Expose server specific information in alert templates.
 - [#1162](https://github.com/influxdata/kapacitor/pulls/1162): Add Pushover integration.
 - [#1221](https://github.com/influxdata/kapacitor/pull/1221): Add `working_cardinality` stat to each node type that tracks the number of groups per node.
+- [#1211](https://github.com/influxdata/kapacitor/issues/1211): Add StateDuration node.
 
 ### Bugfixes
 

--- a/integrations/data/TestBatch_StateTracking.0.brpl
+++ b/integrations/data/TestBatch_StateTracking.0.brpl
@@ -1,0 +1,4 @@
+{"name":"cpu","tags":{"host":"serverA"},"points":[{"time":"1971-01-01T00:00:00Z","fields":{"value":100}}]}
+{"name":"cpu","tags":{"host":"serverB"},"points":[{"time":"1971-01-01T00:00:00Z","fields":{"value":100}}]}
+{"name":"cpu","tags":{"host":"serverA"},"points":[{"time":"1971-01-01T00:00:04Z","fields":{"value":97.1}},{"time":"1971-01-01T00:00:05Z","fields":{"value":96.6}},{"time":"1971-01-01T00:00:06Z","fields":{"value":83.6}},{"time":"1971-01-01T00:00:07Z","fields":{"value":99.1}}]}
+{"name":"cpu","tags":{"host":"serverB"},"points":[{"time":"1971-01-01T00:00:04Z","fields":{"value":47}},{"time":"1971-01-01T00:00:05Z","fields":{"value":95.1}},{"time":"1971-01-01T00:00:06Z","fields":{"value":null}},{"time":"1971-01-01T00:00:07Z","fields":{"value":96.1}}]}

--- a/integrations/data/TestStream_StateTracking.srpl
+++ b/integrations/data/TestStream_StateTracking.srpl
@@ -1,0 +1,30 @@
+dbname
+rpname
+cpu,host=serverA value=97.1 0000000001
+dbname
+rpname
+cpu,host=serverB value=47.0 0000000001
+dbname
+rpname
+cpu,host=serverA value=96.6 0000000002
+dbname
+rpname
+cpu,host=serverB value=95.1 0000000002
+dbname
+rpname
+cpu,host=serverA value=83.6 0000000003
+dbname
+rpname
+cpu,host=serverB x=95.6 0000000003
+dbname
+rpname
+cpu,host=serverA value=99.1 0000000004
+dbname
+rpname
+cpu,host=serverB value=96.1 0000000004
+dbname
+rpname
+cpu,host=serverA value=0 0000000005
+dbname
+rpname
+cpu,host=serverB value=0 0000000005

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -451,3 +451,17 @@ func (n *chainnode) K8sAutoscale() *K8sAutoscaleNode {
 	n.linkChild(k)
 	return k
 }
+
+// Create a node that tracks duration in a given state.
+func (n *chainnode) StateDuration(expression *ast.LambdaNode) *StateDurationNode {
+	sd := newStateDurationNode(n.provides, expression)
+	n.linkChild(sd)
+	return sd
+}
+
+// Create a node that tracks number of consecutive points in a given state.
+func (n *chainnode) StateCount(expression *ast.LambdaNode) *StateCountNode {
+	sc := newStateCountNode(n.provides, expression)
+	n.linkChild(sc)
+	return sc
+}

--- a/pipeline/state_tracking.go
+++ b/pipeline/state_tracking.go
@@ -1,0 +1,101 @@
+package pipeline
+
+import (
+	"time"
+
+	"github.com/influxdata/kapacitor/tick/ast"
+)
+
+// Compute the duration of a given state.
+// The state is defined via a lambda expression. For each consecutive point for
+// which the expression evaluates as true, the state duration will be
+// incremented by the duration between points. When a point evaluates as false,
+// the state duration is reset.
+//
+// The state duration will be added as an additional field to each point. If the
+// expression evaluates as false, the value will be -1. If the expression
+// generates an error during evaluation, the point is discarded, and does not
+// affect the state duration.
+//
+// Example:
+//     stream
+//         |from()
+//             .measurement('cpu')
+//         |where(lambda: "cpu" == 'cpu-total')
+//         |groupBy('host')
+//         |stateDuration(lambda: "usage_idle" <= 10)
+//             .unit(1m)
+//         |alert()
+//             // Warn after 1 minute
+//             .warn(lambda: "state_duration" >= 1)
+//             // Critical after 5 minutes
+//             .crit(lambda: "state_duration" >= 5)
+//
+// Note that as the first point in the given state has no previous point, its
+// state duration will be 0.
+type StateDurationNode struct {
+	chainnode
+
+	// Expression to determine whether state is active.
+	// tick:ignore
+	Lambda *ast.LambdaNode
+
+	// The new name of the resulting duration field.
+	// Default: 'state_duration'
+	As string
+
+	// The time unit of the resulting duration value.
+	// Default: 1s.
+	Unit time.Duration
+}
+
+func newStateDurationNode(wants EdgeType, predicate *ast.LambdaNode) *StateDurationNode {
+	return &StateDurationNode{
+		chainnode: newBasicChainNode("state_duration", wants, wants),
+		Lambda:    predicate,
+		As:        "state_duration",
+		Unit:      time.Second,
+	}
+}
+
+// Compute the number of consecutive points in a given state.
+// The state is defined via a lambda expression. For each consecutive point for
+// which the expression evaluates as true, the state count will be incremented
+// When a point evaluates as false, the state count is reset.
+//
+// The state count will be added as an additional field to each point. If the
+// expression evaluates as false, the value will be -1. If the expression
+// generates an error during evaluation, the point is discarded, and does not
+// affect the state count.
+//
+// Example:
+//     stream
+//         |from()
+//             .measurement('cpu')
+//         |where(lambda: "cpu" == 'cpu-total')
+//         |groupBy('host')
+//         |stateCount(lambda: "usage_idle" <= 10)
+//         |alert()
+//             // Warn after 1 point
+//             .warn(lambda: "state_count" >= 1)
+//             // Critical after 5 points
+//             .crit(lambda: "state_count" >= 5)
+type StateCountNode struct {
+	chainnode
+
+	// Expression to determine whether state is active.
+	// tick:ignore
+	Lambda *ast.LambdaNode
+
+	// The new name of the resulting duration field.
+	// Default: 'state_count'
+	As string
+}
+
+func newStateCountNode(wants EdgeType, predicate *ast.LambdaNode) *StateCountNode {
+	return &StateCountNode{
+		chainnode: newBasicChainNode("state_count", wants, wants),
+		Lambda:    predicate,
+		As:        "state_count",
+	}
+}

--- a/state_tracking.go
+++ b/state_tracking.go
@@ -1,0 +1,190 @@
+package kapacitor
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/influxdata/kapacitor/models"
+	"github.com/influxdata/kapacitor/pipeline"
+	"github.com/influxdata/kapacitor/tick/ast"
+	"github.com/influxdata/kapacitor/tick/stateful"
+)
+
+type stateTracker interface {
+	track(p models.BatchPoint, inState bool) interface{}
+	reset()
+}
+
+type stateTrackingGroup struct {
+	stateful.Expression
+	stateful.ScopePool
+	tracker stateTracker
+}
+
+type StateTrackingNode struct {
+	node
+	lambda *ast.LambdaNode
+	as     string
+
+	newTracker func() stateTracker
+	groups     map[models.GroupID]*stateTrackingGroup
+}
+
+func (stn *StateTrackingNode) group(g models.GroupID) (*stateTrackingGroup, error) {
+	stg := stn.groups[g]
+	if stg == nil {
+		stg = &stateTrackingGroup{}
+
+		var err error
+		stg.Expression, err = stateful.NewExpression(stn.lambda.Expression)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to compile expression: %v", err)
+		}
+
+		stg.ScopePool = stateful.NewScopePool(stateful.FindReferenceVariables(stn.lambda.Expression))
+
+		stg.tracker = stn.newTracker()
+
+		stn.groups[g] = stg
+	}
+	return stg, nil
+}
+
+func (stn *StateTrackingNode) runStateTracking(_ []byte) error {
+	switch stn.Provides() {
+	case pipeline.StreamEdge:
+		for p, ok := stn.ins[0].NextPoint(); ok; p, ok = stn.ins[0].NextPoint() {
+			stn.timer.Start()
+			stg, err := stn.group(p.Group)
+			if err != nil {
+				return err
+			}
+
+			pass, err := EvalPredicate(stg.Expression, stg.ScopePool, p.Time, p.Fields, p.Tags)
+			if err != nil {
+				stn.incrementErrorCount()
+				stn.logger.Println("E! error while evaluating expression:", err)
+				stn.timer.Stop()
+				continue
+			}
+
+			p.Fields = p.Fields.Copy()
+			p.Fields[stn.as] = stg.tracker.track(models.BatchPointFromPoint(p), pass)
+
+			stn.timer.Stop()
+			for _, child := range stn.outs {
+				err := child.CollectPoint(p)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	case pipeline.BatchEdge:
+		for b, ok := stn.ins[0].NextBatch(); ok; b, ok = stn.ins[0].NextBatch() {
+			stn.timer.Start()
+
+			stg, err := stn.group(b.Group)
+			if err != nil {
+				return err
+			}
+			stg.tracker.reset()
+
+			for i := 0; i < len(b.Points); {
+				p := &b.Points[i]
+				pass, err := EvalPredicate(stg.Expression, stg.ScopePool, p.Time, p.Fields, p.Tags)
+				if err != nil {
+					stn.incrementErrorCount()
+					stn.logger.Println("E! error while evaluating epression:", err)
+					b.Points = append(b.Points[:i], b.Points[i+1:]...)
+					continue
+				}
+				i++
+
+				p.Fields = p.Fields.Copy()
+				p.Fields[stn.as] = stg.tracker.track(*p, pass)
+			}
+
+			stn.timer.Stop()
+			for _, child := range stn.outs {
+				err := child.CollectBatch(b)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type stateDurationTracker struct {
+	sd *pipeline.StateDurationNode
+
+	startTime time.Time
+}
+
+func (sdt *stateDurationTracker) reset() {
+	sdt.startTime = time.Time{}
+}
+
+func (sdt *stateDurationTracker) track(p models.BatchPoint, inState bool) interface{} {
+	if !inState {
+		sdt.startTime = time.Time{}
+		return float64(-1)
+	}
+
+	if sdt.startTime.IsZero() {
+		sdt.startTime = p.Time
+	}
+	return float64(p.Time.Sub(sdt.startTime)) / float64(sdt.sd.Unit)
+}
+
+func newStateDurationNode(et *ExecutingTask, sd *pipeline.StateDurationNode, l *log.Logger) (*StateTrackingNode, error) {
+	if sd.Lambda == nil {
+		return nil, fmt.Errorf("nil expression passed to StateDurationNode")
+	}
+	stn := &StateTrackingNode{
+		node:   node{Node: sd, et: et, logger: l},
+		lambda: sd.Lambda,
+		as:     sd.As,
+
+		groups:     make(map[models.GroupID]*stateTrackingGroup),
+		newTracker: func() stateTracker { return &stateDurationTracker{sd: sd} },
+	}
+	stn.node.runF = stn.runStateTracking
+	return stn, nil
+}
+
+type stateCountTracker struct {
+	count int64
+}
+
+func (sct *stateCountTracker) reset() {
+	sct.count = 0
+}
+
+func (sct *stateCountTracker) track(p models.BatchPoint, inState bool) interface{} {
+	if !inState {
+		sct.count = 0
+		return int64(-1)
+	}
+
+	sct.count++
+	return sct.count
+}
+
+func newStateCountNode(et *ExecutingTask, sc *pipeline.StateCountNode, l *log.Logger) (*StateTrackingNode, error) {
+	if sc.Lambda == nil {
+		return nil, fmt.Errorf("nil expression passed to StateCountNode")
+	}
+	stn := &StateTrackingNode{
+		node:   node{Node: sc, et: et, logger: l},
+		lambda: sc.Lambda,
+		as:     sc.As,
+
+		groups:     make(map[models.GroupID]*stateTrackingGroup),
+		newTracker: func() stateTracker { return &stateCountTracker{} },
+	}
+	stn.node.runF = stn.runStateTracking
+	return stn, nil
+}

--- a/task.go
+++ b/task.go
@@ -492,6 +492,10 @@ func (et *ExecutingTask) createNode(p pipeline.Node, l *log.Logger) (n Node, err
 		n, err = newCombineNode(et, t, l)
 	case *pipeline.K8sAutoscaleNode:
 		n, err = newK8sAutoscaleNode(et, t, l)
+	case *pipeline.StateDurationNode:
+		n, err = newStateDurationNode(et, t, l)
+	case *pipeline.StateCountNode:
+		n, err = newStateCountNode(et, t, l)
 	default:
 		return nil, fmt.Errorf("unknown pipeline node type %T", p)
 	}


### PR DESCRIPTION
This is a proposal for a solution to #1211 
It provides a node which evaluates an expression, and adds a field which tracks how long the expression has evaluated as true.

Example usage which alerts when a host has not had any primary ntp peers for over 5 minutes looks like:
```
stream
  |from().measurement('ntpq')|default().tag('state_prefix',' ')
  |groupBy('host')
  |stateDuration(lambda: "state_prefix" != '*').unit(1m)
  |alert()
    .warn(lambda: "state_duration" > 5)
    .crit(lambda: "state_duration" > 60)
```

If this is an acceptable solution to the problem, I can finish up the PR by adding tests, docs, etc.

Closes #1211 #1225 

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
