### PR TITLE
Add link to event handler setup guide for telegram and hipchat

### DIFF
--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -769,6 +769,7 @@ type PagerDutyHandler struct {
 }
 
 // Send the alert to HipChat.
+// For step-by-step instructions on setting up Kapacitor with HipChat, see the Event Handler Setup Guide (https://docs.influxdata.com//kapacitor/latest/guides/event-handler-setup/#hipchat-setup).
 // To allow Kapacitor to post to HipChat,
 // go to the URL https://www.hipchat.com/docs/apiv2 for
 // information on how to get your room id and tokens.
@@ -1046,6 +1047,7 @@ type SlackHandler struct {
 }
 
 // Send the alert to Telegram.
+// For step-by-step instructions on setting up Kapacitor with Telegram, see the Event Handler Setup Guide (https://docs.influxdata.com//kapacitor/latest/guides/event-handler-setup/#telegram-setup).
 // To allow Kapacitor to post to Telegram,
 //
 // Example:


### PR DESCRIPTION
Adds a link to the event handler setup guide created in https://github.com/influxdata/docs.influxdata.com/pull/996. So far, this is only for HipChat and Telegram.
