### PR TITLE
check if replay file has an extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
     we decided it would be best to fix the issue now and make it consistent for all future builds.
     Specifically in the JSON result data the old key `Series` is always `series`, and the old key `Err` is now always `error` instead of for only some of the outputs.
 - [#1181](https://github.com/influxdata/kapacitor/pull/1181): Fix bug parsing dbrp values with quotes.
-
+- [#1228](https://github.com/influxdata/kapacitor/pull/1228): Fix panic on loading replay files without a file extension.
 
 ## v1.2.0 [2017-01-23]
 

--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -218,6 +218,10 @@ func (s *Service) syncRecordingMetadata() error {
 		}
 		name := info.Name()
 		i := strings.LastIndex(name, ".")
+		if i == -1 {
+			s.logger.Println("E! file without extension in replay dir", name)
+			continue
+		}
 		ext := name[i:]
 		id := name[:i]
 


### PR DESCRIPTION
Adding a check, if the filenames inside the replay folder contain an extension, otherwise, Kapacitor will panic on startup.

Seems to be a trivial PR.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
