### PR TITLE
Use ProxyFromEnvironment for all HTTP Transport where needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     The behavior of the node changes slightly in order to provide a consistent fix to the bug.
     The breaking change is that now, the time of the points returned are from the right hand or current point time, instead of the left hand or previous point time.
 - [#1353](https://github.com/influxdata/kapacitor/issues/1353): Fix panic in scraping TargetManager.
+- [#1238](https://github.com/influxdata/kapacitor/pull/1238): Use ProxyFromEnvironment for all outgoing HTTP traffic.
 
 ## v1.3.0-beta2 [2017-05-01]
 

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -149,6 +149,7 @@ func New(conf Config) (*Client, error) {
 	}
 
 	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: conf.InsecureSkipVerify,
 		},

--- a/influxdb/client.go
+++ b/influxdb/client.go
@@ -123,7 +123,9 @@ func NewHTTPClient(conf Config) (*HTTPClient, error) {
 		return nil, errors.Wrap(err, "invalid URLs")
 	}
 	if conf.Transport == nil {
-		conf.Transport = &http.Transport{}
+		conf.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
 	}
 	c := &HTTPClient{
 		config: conf,

--- a/services/alerta/service.go
+++ b/services/alerta/service.go
@@ -38,6 +38,7 @@ func NewService(c Config, l *log.Logger) *Service {
 	s.configValue.Store(c)
 	s.clientValue.Store(&http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify},
 		},
 	})
@@ -115,6 +116,7 @@ func (s *Service) Update(newConfig []interface{}) error {
 		s.configValue.Store(c)
 		s.clientValue.Store(&http.Client{
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify},
 			},
 		})

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -452,6 +452,7 @@ func httpConfig(c Config) (influxdb.Config, error) {
 		return influxdb.Config{}, errors.Wrap(err, "invalid TLS options")
 	}
 	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 	var credentials influxdb.Credentials

--- a/services/k8s/client/client.go
+++ b/services/k8s/client/client.go
@@ -113,6 +113,7 @@ func New(c Config) (Client, error) {
 		urls:   urls,
 		client: &http.Client{
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: c.TLSConfig,
 			},
 		},
@@ -157,6 +158,7 @@ func (c *httpClient) Update(new Config) error {
 	if old.TLSConfig != new.TLSConfig {
 		c.client = &http.Client{
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: new.TLSConfig,
 			},
 		}


### PR DESCRIPTION
Most services and clients throughout Kapacitor use the Default HTTP
Client which uses the Default HTTP Transport, which uses HTTP proxies as
directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy)
environment variables.

For the services that use a custom Transport, we use
http.ProxyFromEnvironment.

The downside to this is that all future implementers will need to copy
this pattern

Fixes #841 (though its not conditional proxy as the issue has requested)

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated