### PR TITLE
Add cardinality stat to each node type

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -56,12 +56,15 @@ type AlertNode struct {
 	messageTmpl *text.Template
 	detailsTmpl *html.Template
 
+	cardinalityMu sync.RWMutex
+
 	alertsTriggered *expvar.Int
 	oksTriggered    *expvar.Int
 	infosTriggered  *expvar.Int
 	warnsTriggered  *expvar.Int
 	critsTriggered  *expvar.Int
 	eventsDropped   *expvar.Int
+	nodeCardinality *expvar.IntFuncGauge
 
 	bufPool sync.Pool
 
@@ -406,6 +409,12 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 		n.History = 2
 	}
 	an.states = make(map[models.GroupID]*alertState)
+	an.nodeCardinality = expvar.NewIntFuncGauge(func() int {
+		an.cardinalityMu.RLock()
+		l := len(an.states)
+		an.cardinalityMu.RUnlock()
+		return l
+	})
 
 	// Configure flapping
 	if n.UseFlapping {
@@ -449,6 +458,9 @@ func (a *AlertNode) runAlert([]byte) error {
 	a.eventsDropped = &expvar.Int{}
 	a.statMap.Set(statsCritsTriggered, a.critsTriggered)
 
+	// a.nodeCardinality is assigned in newAlertNode
+	a.statMap.Set(statsCardinalityGauge, a.nodeCardinality)
+
 	switch a.Wants() {
 	case pipeline.StreamEdge:
 		for p, ok := a.ins[0].NextPoint(); ok; p, ok = a.ins[0].NextPoint() {
@@ -458,7 +470,10 @@ func (a *AlertNode) runAlert([]byte) error {
 				return err
 			}
 			var currentLevel alert.Level
-			if state, ok := a.states[p.Group]; ok {
+			a.cardinalityMu.RLock()
+			state, ok := a.states[p.Group]
+			a.cardinalityMu.RUnlock()
+			if ok {
 				currentLevel = state.currentLevel()
 			} else {
 				// Check for previous state
@@ -471,7 +486,7 @@ func (a *AlertNode) runAlert([]byte) error {
 				}
 			}
 			l := a.determineLevel(p.Time, p.Fields, p.Tags, currentLevel)
-			state := a.updateState(p.Time, l, p.Group)
+			state = a.updateState(p.Time, l, p.Group)
 			if (a.a.UseFlapping && state.flapping) || (a.a.IsStateChangesOnly && !state.changed && !state.expired) {
 				a.timer.Stop()
 				continue
@@ -550,7 +565,10 @@ func (a *AlertNode) runAlert([]byte) error {
 			var highestPoint *models.BatchPoint
 
 			var currentLevel alert.Level
-			if state, ok := a.states[b.Group]; ok {
+			a.cardinalityMu.RLock()
+			state, ok := a.states[b.Group]
+			a.cardinalityMu.RUnlock()
+			if ok {
 				currentLevel = state.currentLevel()
 			} else {
 				// Check for previous state
@@ -586,7 +604,7 @@ func (a *AlertNode) runAlert([]byte) error {
 			}
 
 			// Update state
-			state := a.updateState(t, l, b.Group)
+			state = a.updateState(t, l, b.Group)
 			// Trigger alert if:
 			//  l == OK and state.changed (aka recovery)
 			//    OR
@@ -898,12 +916,16 @@ func (a *alertState) percentChange() float64 {
 }
 
 func (a *AlertNode) updateState(t time.Time, level alert.Level, group models.GroupID) *alertState {
+	a.cardinalityMu.RLock()
 	state, ok := a.states[group]
+	a.cardinalityMu.RUnlock()
 	if !ok {
 		state = &alertState{
 			history: make([]alert.Level, a.a.History),
 		}
+		a.cardinalityMu.Lock()
 		a.states[group] = state
+		a.cardinalityMu.Unlock()
 	}
 	state.addEvent(level)
 

--- a/derivative.go
+++ b/derivative.go
@@ -2,8 +2,10 @@ package kapacitor
 
 import (
 	"log"
+	"sync"
 	"time"
 
+	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 )
@@ -27,12 +29,24 @@ func newDerivativeNode(et *ExecutingTask, n *pipeline.DerivativeNode, l *log.Log
 func (d *DerivativeNode) runDerivative([]byte) error {
 	switch d.Provides() {
 	case pipeline.StreamEdge:
+		var mu sync.RWMutex
 		previous := make(map[models.GroupID]models.Point)
+		cardinalityGauge := expvar.NewIntFuncGauge(func() int {
+			mu.RLock()
+			l := len(previous)
+			mu.RUnlock()
+			return l
+		})
+		d.statMap.Set(statsCardinalityGauge, cardinalityGauge)
 		for p, ok := d.ins[0].NextPoint(); ok; p, ok = d.ins[0].NextPoint() {
 			d.timer.Start()
+			mu.RLock()
 			pr, ok := previous[p.Group]
+			mu.RUnlock()
 			if !ok {
+				mu.Lock()
 				previous[p.Group] = p
+				mu.Unlock()
 				d.timer.Stop()
 				continue
 			}
@@ -51,7 +65,9 @@ func (d *DerivativeNode) runDerivative([]byte) error {
 				}
 				d.timer.Resume()
 			}
+			mu.Lock()
 			previous[p.Group] = p
+			mu.Unlock()
 			d.timer.Stop()
 		}
 	case pipeline.BatchEdge:

--- a/expvar/expvar.go
+++ b/expvar/expvar.go
@@ -46,6 +46,26 @@ func (v *Int) IntValue() int64 {
 	return atomic.LoadInt64(&v.i)
 }
 
+// IntGauge is a 64-bit integer variable that satisfies the expvar.Var interface.
+type IntFuncGauge struct {
+	ValueF func() int
+}
+
+func (v *IntFuncGauge) String() string {
+	return strconv.FormatInt(v.IntValue(), 10)
+}
+
+func (v *IntFuncGauge) Add(delta int64) {}
+func (v *IntFuncGauge) Set(value int64) {}
+
+func (v *IntFuncGauge) IntValue() int64 {
+	return int64(v.ValueF())
+}
+
+func NewIntFuncGauge(fn func() int) *IntFuncGauge {
+	return &IntFuncGauge{fn}
+}
+
 // IntSum is a 64-bit integer variable that consists of multiple different parts
 // and satisfies the expvar.Var interface.
 // The value of the var is the sum of all its parts.

--- a/flatten.go
+++ b/flatten.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 )
@@ -49,13 +50,24 @@ type flattenBatchBuffer struct {
 }
 
 func (n *FlattenNode) runFlatten([]byte) error {
+	var mu sync.RWMutex
 	switch n.Wants() {
 	case pipeline.StreamEdge:
 		flattenBuffers := make(map[models.GroupID]*flattenStreamBuffer)
+		cardinalityGauge := expvar.NewIntFuncGauge(func() int {
+			mu.RLock()
+			l := len(flattenBuffers)
+			mu.RUnlock()
+			return l
+		})
+		n.statMap.Set(statsCardinalityGauge, cardinalityGauge)
+
 		for p, ok := n.ins[0].NextPoint(); ok; p, ok = n.ins[0].NextPoint() {
 			n.timer.Start()
 			t := p.Time.Round(n.f.Tolerance)
+			mu.RLock()
 			currentBuf, ok := flattenBuffers[p.Group]
+			mu.RUnlock()
 			if !ok {
 				currentBuf = &flattenStreamBuffer{
 					Time:       t,
@@ -64,7 +76,9 @@ func (n *FlattenNode) runFlatten([]byte) error {
 					Dimensions: p.Dimensions,
 					Tags:       p.PointTags(),
 				}
+				mu.Lock()
 				flattenBuffers[p.Group] = currentBuf
+				mu.Unlock()
 			}
 			rp := models.RawPoint{
 				Time:   t,
@@ -104,10 +118,19 @@ func (n *FlattenNode) runFlatten([]byte) error {
 		}
 	case pipeline.BatchEdge:
 		allBuffers := make(map[models.GroupID]*flattenBatchBuffer)
+		cardinalityGauge := expvar.NewIntFuncGauge(func() int {
+			mu.RLock()
+			l := len(allBuffers)
+			mu.RUnlock()
+			return l
+		})
+		n.statMap.Set(statsCardinalityGauge, cardinalityGauge)
 		for b, ok := n.ins[0].NextBatch(); ok; b, ok = n.ins[0].NextBatch() {
 			n.timer.Start()
 			t := b.TMax.Round(n.f.Tolerance)
+			mu.RLock()
 			currentBuf, ok := allBuffers[b.Group]
+			mu.RUnlock()
 			if !ok {
 				currentBuf = &flattenBatchBuffer{
 					Time:   t,
@@ -116,7 +139,9 @@ func (n *FlattenNode) runFlatten([]byte) error {
 					Tags:   b.Tags,
 					Points: make(map[time.Time][]models.RawPoint),
 				}
+				mu.Lock()
 				allBuffers[b.Group] = currentBuf
+				mu.Unlock()
 			}
 			if !t.Equal(currentBuf.Time) {
 				// Flatten/Emit old buffer

--- a/node.go
+++ b/node.go
@@ -19,7 +19,9 @@ import (
 )
 
 const (
-	statAverageExecTime = "avg_exec_time_ns"
+	// TODO: Define stat somewhere else?
+	statsCardinalityGauge = "cardinality"
+	statAverageExecTime   = "avg_exec_time_ns"
 )
 
 // A node that can be  in an executor.

--- a/window.go
+++ b/window.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
+	kexpvar "github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 )
@@ -30,11 +32,21 @@ type window interface {
 }
 
 func (w *WindowNode) runWindow([]byte) error {
+	var mu sync.RWMutex
 	windows := make(map[models.GroupID]window)
+	cardinalityGauge := kexpvar.NewIntFuncGauge(func() int {
+		mu.RLock()
+		l := len(windows)
+		mu.RUnlock()
+		return l
+	})
+	w.statMap.Set(statsCardinalityGauge, cardinalityGauge)
 	// Loops through points windowing by group
 	for p, ok := w.ins[0].NextPoint(); ok; p, ok = w.ins[0].NextPoint() {
 		w.timer.Start()
+		mu.RLock()
 		wnd := windows[p.Group]
+		mu.RUnlock()
 		if wnd == nil {
 			tags := make(map[string]string, len(p.Dimensions.TagNames))
 			for _, dim := range p.Dimensions.TagNames {
@@ -70,7 +82,9 @@ func (w *WindowNode) runWindow([]byte) error {
 				// This should not be possible, but just in case.
 				return errors.New("invalid window, no period specified for either time or count")
 			}
+			mu.Lock()
 			windows[p.Group] = wnd
+			mu.Unlock()
 		}
 		batch, ok := wnd.Insert(p)
 		if ok {


### PR DESCRIPTION
This PR introduces a new stat `cardinality` that tracks the number of groups that exist for a given node for each relevant node type. 

- [x] Add new tests for cardinality tracking
- [x] Fill out k8s cardinality test

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated


