### PR TITLE
WIP: Add httppost service (add headers to POST alerts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased [unreleased]
 
+### Features
+
+- [#117](https://github.com/influxdata/kapacitor/issues/117): Add headers to alert POST requests.
+
 ### Bugfixes
 
 - [#1294](https://github.com/influxdata/kapacitor/issues/1294): Fix bug where batch queries would be missing all fields after the first nil field.

--- a/alert.go
+++ b/alert.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/kapacitor/pipeline"
 	alertservice "github.com/influxdata/kapacitor/services/alert"
 	"github.com/influxdata/kapacitor/services/hipchat"
+	"github.com/influxdata/kapacitor/services/httppost"
 	"github.com/influxdata/kapacitor/services/opsgenie"
 	"github.com/influxdata/kapacitor/services/pagerduty"
 	"github.com/influxdata/kapacitor/services/pushover"
@@ -128,15 +129,6 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 	}).Parse(n.Details)
 	if err != nil {
 		return nil, err
-	}
-
-	// Construct alert handlers
-	for _, post := range n.PostHandlers {
-		c := alertservice.PostHandlerConfig{
-			URL: post.URL,
-		}
-		h := alertservice.NewPostHandler(c, l)
-		an.handlers = append(an.handlers, h)
 	}
 
 	for _, tcp := range n.TcpHandlers {
@@ -360,6 +352,16 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 			c.Sound = p.Sound
 		}
 		h := et.tm.PushoverService.Handler(c, l)
+		an.handlers = append(an.handlers, h)
+	}
+
+	for _, p := range n.HTTPPostHandlers {
+		c := httppost.HandlerConfig{
+			URL:      p.URL,
+			Endpoint: p.Endpoint,
+			Headers:  p.Headers,
+		}
+		h := et.tm.HTTPPostService.Handler(c, l)
 		an.handlers = append(an.handlers, h)
 	}
 

--- a/alert/types.go
+++ b/alert/types.go
@@ -17,6 +17,18 @@ type Event struct {
 	previousState EventState
 }
 
+func (e Event) AlertData() Data {
+	return Data{
+		ID:       e.State.ID,
+		Message:  e.State.Message,
+		Details:  e.State.Details,
+		Time:     e.State.Time,
+		Duration: e.State.Duration,
+		Level:    e.State.Level,
+		Data:     e.Data.Result,
+	}
+}
+
 func (e Event) PreviousState() EventState {
 	return e.previousState
 }
@@ -153,4 +165,16 @@ func ParseLevel(s string) (l Level, err error) {
 type TopicState struct {
 	Level     Level
 	Collected int64
+}
+
+// Data is a structure that contains relevant data about an alert event.
+// The structure is intended to be JSON encoded, providing a consistent data format.
+type Data struct {
+	ID       string        `json:"id"`
+	Message  string        `json:"message"`
+	Details  string        `json:"details"`
+	Time     time.Time     `json:"time"`
+	Duration time.Duration `json:"duration"`
+	Level    Level         `json:"level"`
+	Data     models.Result `json:"data"`
 }

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -275,6 +275,20 @@ default-retention-policy = ""
   # The URL for the Pushover API.
   url = "https://api.pushover.net/1/messages.json"
 
+##########################################
+# Configure Alert POST request Endpoints
+
+# As ENV variables:
+# KAPACITOR_HTTPPOST_0_ENDPOINT = "example"
+# KAPACITOR_HTTPPOST_0_URL = "http://example.com"
+# KAPACITOR_HTTPPOST_0_HEADERS_Example = "header"
+
+# [[httppost]]
+#   endpoint = "example"
+#   url = "http://example.com"
+#   headers = { Example = "your-key" }
+#   basic-auth = { username = "my-user", password = "my-pass" }
+
 [slack]
   # Configure Slack.
   enabled = false

--- a/integrations/helpers_test.go
+++ b/integrations/helpers_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/influxdata/kapacitor"
+	"github.com/influxdata/kapacitor/alert"
 	"github.com/influxdata/kapacitor/influxdb"
 	"github.com/influxdata/kapacitor/models"
-	alertservice "github.com/influxdata/kapacitor/services/alert"
 	"github.com/influxdata/kapacitor/services/httpd"
 	k8s "github.com/influxdata/kapacitor/services/k8s/client"
 	"github.com/influxdata/kapacitor/udf"
@@ -117,7 +117,7 @@ func compareResultsIgnoreSeriesOrder(exp, got models.Result) (bool, string) {
 	return true, ""
 }
 
-func compareAlertData(exp, got alertservice.AlertData) (bool, string) {
+func compareAlertData(exp, got alert.Data) (bool, string) {
 	// Pull out Result for comparison
 	expData := exp.Data
 	exp.Data = models.Result{}

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -327,8 +327,10 @@ func (n *chainnode) HttpOut(endpoint string) *HTTPOutNode {
 }
 
 // Creates an HTTP Post node that POSTS received data to the provided HTTP endpoint.
-func (n *chainnode) HttpPost(url string) *HTTPPostNode {
-	h := newHTTPPostNode(n.provides, url)
+// HttpPost expects 0 or 1 arguments. If 0 arguments are provided, you must specify an
+// endpoint property method.
+func (n *chainnode) HttpPost(url ...string) *HTTPPostNode {
+	h := newHTTPPostNode(n.provides, url...)
 	n.linkChild(h)
 	return h
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -43,6 +43,9 @@ dir = "/tmp/replay"
 
 [storage]
 boltdb = "/tmp/kapacitor.db"
+
+[[httppost]]
+headers = { Authorization = "your-key" }
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -59,6 +62,10 @@ boltdb = "/tmp/kapacitor.db"
 		t.Fatalf("failed to set env var: %v", err)
 	}
 
+	if err := os.Setenv("KAPACITOR_HTTPPOST_0_HEADERS_Authorization", "my-key"); err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+
 	if err := c.ApplyEnvOverrides(); err != nil {
 		t.Fatalf("failed to apply env overrides: %v", err)
 	}
@@ -70,5 +77,7 @@ boltdb = "/tmp/kapacitor.db"
 		t.Fatalf("unexpected storage boltdb-path: %s", c.Storage.BoltDBPath)
 	} else if c.InfluxDB[0].URLs[0] != "http://localhost:18086" {
 		t.Fatalf("unexpected url 0: %s", c.InfluxDB[0].URLs[0])
+	} else if c.HTTPPost[0].Headers["Authorization"] != "my-key" {
+		t.Fatalf("unexpected header Authorization: %s", c.InfluxDB[0].URLs[0])
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/influxdata/kapacitor/services/gce"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
+	"github.com/influxdata/kapacitor/services/httppost"
 	"github.com/influxdata/kapacitor/services/influxdb"
 	"github.com/influxdata/kapacitor/services/k8s"
 	"github.com/influxdata/kapacitor/services/logging"
@@ -213,6 +214,7 @@ func New(c *Config, buildInfo BuildInfo, logService logging.Interface) (*Server,
 	s.appendOpsGenieService()
 	s.appendPagerDutyService()
 	s.appendPushoverService()
+	s.appendHTTPPostService()
 	s.appendSMTPService()
 	s.appendTelegramService()
 	if err := s.appendSlackService(); err != nil {
@@ -499,6 +501,18 @@ func (s *Server) appendPushoverService() {
 
 	s.SetDynamicService("pushover", srv)
 	s.AppendService("pushover", srv)
+}
+
+func (s *Server) appendHTTPPostService() {
+	c := s.config.HTTPPost
+	l := s.LogService.NewLogger("[httppost] ", log.LstdFlags)
+	srv := httppost.NewService(c, l)
+
+	s.TaskMaster.HTTPPostService = srv
+	s.AlertService.HTTPPostService = srv
+
+	s.SetDynamicService("httppost", srv)
+	s.AppendService("httppost", srv)
 }
 
 func (s *Server) appendSensuService() {

--- a/services/alert/alerttest/alerttest.go
+++ b/services/alert/alerttest/alerttest.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"sync"
 
+	"github.com/influxdata/kapacitor/alert"
 	"github.com/influxdata/kapacitor/command"
 	"github.com/influxdata/kapacitor/command/commandtest"
-	alertservice "github.com/influxdata/kapacitor/services/alert"
 )
 
 type Log struct {
@@ -23,16 +23,16 @@ func NewLog(p string) *Log {
 	}
 }
 
-func (l *Log) Data() ([]alertservice.AlertData, error) {
+func (l *Log) Data() ([]alert.Data, error) {
 	f, err := os.Open(l.path)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 	dec := json.NewDecoder(f)
-	var data []alertservice.AlertData
+	var data []alert.Data
 	for dec.More() {
-		ad := alertservice.AlertData{}
+		ad := alert.Data{}
 		err := dec.Decode(&ad)
 		if err != nil {
 			return nil, err
@@ -72,7 +72,7 @@ type TCPServer struct {
 
 	l *net.TCPListener
 
-	data []alertservice.AlertData
+	data []alert.Data
 
 	wg     sync.WaitGroup
 	closed bool
@@ -99,7 +99,7 @@ func NewTCPServer() (*TCPServer, error) {
 	return s, nil
 }
 
-func (s *TCPServer) Data() []alertservice.AlertData {
+func (s *TCPServer) Data() []alert.Data {
 	return s.data
 }
 
@@ -120,7 +120,7 @@ func (s *TCPServer) run() {
 		}
 		func() {
 			defer conn.Close()
-			ad := alertservice.AlertData{}
+			ad := alert.Data{}
 			json.NewDecoder(conn).Decode(&ad)
 			s.data = append(s.data, ad)
 		}()
@@ -130,14 +130,14 @@ func (s *TCPServer) run() {
 type PostServer struct {
 	ts     *httptest.Server
 	URL    string
-	data   []alertservice.AlertData
+	data   []alert.Data
 	closed bool
 }
 
 func NewPostServer() *PostServer {
 	s := new(PostServer)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ad := alertservice.AlertData{}
+		ad := alert.Data{}
 		dec := json.NewDecoder(r.Body)
 		dec.Decode(&ad)
 		s.data = append(s.data, ad)
@@ -147,7 +147,7 @@ func NewPostServer() *PostServer {
 	return s
 }
 
-func (s *PostServer) Data() []alertservice.AlertData {
+func (s *PostServer) Data() []alert.Data {
 	return s.data
 }
 

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
+	"github.com/influxdata/kapacitor/services/httppost"
 	"github.com/influxdata/kapacitor/services/opsgenie"
 	"github.com/influxdata/kapacitor/services/pagerduty"
 	"github.com/influxdata/kapacitor/services/pushover"
@@ -72,6 +73,9 @@ type Service struct {
 	}
 	PushoverService interface {
 		Handler(pushover.HandlerConfig, *log.Logger) alert.Handler
+	}
+	HTTPPostService interface {
+		Handler(httppost.HandlerConfig, *log.Logger) alert.Handler
 	}
 	SensuService interface {
 		Handler(sensu.HandlerConfig, *log.Logger) (alert.Handler, error)

--- a/services/config/override/doc.go
+++ b/services/config/override/doc.go
@@ -5,10 +5,13 @@ These fields may either be a struct or a slice of structs.
 As such a section consists of a list of elements.
 In the case where the field is a struct and not a slice, the section list always contains one element.
 Further nested levels may exist but Overrider will not interact with them directly.
+If a nested field is a struct, then github.com/mitchellh/mapstructure will be used to decode the map into the struct.
 
 In order for a section to be overridden an `override` struct tag must be present.
 The `override` tag defines a name for the section and option.
 Struct tags can be used to mark options as redacted by adding a `<name>,redact` to the end of the `override` tag value.
+
+
 
 Example:
    type SectionAConfig struct {

--- a/services/config/override/override_internal_test.go
+++ b/services/config/override/override_internal_test.go
@@ -47,3 +47,49 @@ func TestGetSectionName(t *testing.T) {
 		}
 	}
 }
+
+func Test_isZero(t *testing.T) {
+	tt := []struct {
+		exp   bool
+		value struct {
+			X string
+			Y int
+		}
+	}{
+		{
+			exp: true,
+			value: struct {
+				X string
+				Y int
+			}{},
+		},
+		{
+			exp: false,
+			value: struct {
+				X string
+				Y int
+			}{X: "hello"},
+		},
+		{
+			exp: false,
+			value: struct {
+				X string
+				Y int
+			}{Y: 10},
+		},
+		{
+			exp: false,
+			value: struct {
+				X string
+				Y int
+			}{X: "hello", Y: 10},
+		},
+	}
+
+	for _, tst := range tt {
+		if got, exp := isZero(reflect.ValueOf(tst.value)), tst.exp; got != exp {
+			t.Errorf("unexpected result for isZero of %v got %t exp %t", tst.value, got, exp)
+		}
+	}
+
+}

--- a/services/httppost/config.go
+++ b/services/httppost/config.go
@@ -1,0 +1,77 @@
+package httppost
+
+import (
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type BasicAuth struct {
+	Username string `toml:"username" json:"username"`
+	Password string `toml:"password" json:"password"`
+}
+
+func (b BasicAuth) valid() bool {
+	return b.Username != "" && b.Password != ""
+}
+
+func (b BasicAuth) validate() error {
+	if !b.valid() {
+		return errors.New("basic-auth must set both \"username\" and \"password\" parameters")
+	}
+
+	return nil
+}
+
+// Config is the configuration for a single [[httppost]] section of the kapacitor
+// configuration file.
+type Config struct {
+	Endpoint  string            `toml:"endpoint" override:"endpoint"`
+	URL       string            `toml:"url" override:"url"`
+	Headers   map[string]string `toml:"headers" override:"headers"`
+	BasicAuth BasicAuth         `toml:"basic-auth" override:"basic-auth,redact"`
+}
+
+// Validate ensures that all configurations options are valid. The Endpoint,
+// and URL parameters must be set to be considered valid.
+func (c Config) Validate() error {
+	if c.Endpoint == "" {
+		return errors.New("must specify endpoint name")
+	}
+
+	if c.URL == "" {
+		return errors.New("must specify url")
+	}
+
+	if _, err := url.Parse(c.URL); err != nil {
+		return errors.Wrapf(err, "invalid URL %q", c.URL)
+	}
+
+	return nil
+}
+
+// Configs is the configuration for all [[alertpost]] sections of the kapacitor
+// configuration file.
+type Configs []Config
+
+// Validate calls config.Validate for each element in Configs
+func (cs Configs) Validate() error {
+	for _, c := range cs {
+		err := c.Validate()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// index generates a map from config.Endpoint to config
+func (cs Configs) index() map[string]*Endpoint {
+	m := map[string]*Endpoint{}
+
+	for _, c := range cs {
+		m[c.Endpoint] = NewEndpoint(c.URL, c.Headers, c.BasicAuth)
+	}
+
+	return m
+}

--- a/services/httppost/httpposttest/server.go
+++ b/services/httppost/httpposttest/server.go
@@ -1,0 +1,53 @@
+package httpposttest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/influxdata/kapacitor/alert"
+)
+
+type AlertServer struct {
+	ts     *httptest.Server
+	URL    string
+	data   []AlertRequest
+	closed bool
+}
+
+func NewAlertServer(headers map[string]string) *AlertServer {
+	s := new(AlertServer)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := AlertRequest{MatchingHeaders: true}
+		for k, v := range headers {
+			nv := r.Header.Get(k)
+			if nv != v {
+				req.MatchingHeaders = false
+			}
+		}
+		req.Data = alert.Data{}
+		dec := json.NewDecoder(r.Body)
+		dec.Decode(&req.Data)
+		s.data = append(s.data, req)
+	}))
+	s.ts = ts
+	s.URL = ts.URL
+	return s
+}
+
+type AlertRequest struct {
+	MatchingHeaders bool
+	Data            alert.Data
+}
+
+func (s *AlertServer) Data() []AlertRequest {
+	return s.data
+}
+
+func (s *AlertServer) Close() {
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.ts.Close()
+}

--- a/services/httppost/service.go
+++ b/services/httppost/service.go
@@ -1,0 +1,254 @@
+package httppost
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/influxdata/kapacitor/alert"
+	"github.com/influxdata/kapacitor/bufpool"
+)
+
+// Only one of name and url should be non-empty
+type Endpoint struct {
+	mu      sync.RWMutex
+	url     string
+	headers map[string]string
+	auth    BasicAuth
+	closed  bool
+}
+
+func NewEndpoint(url string, headers map[string]string, auth BasicAuth) *Endpoint {
+	return &Endpoint{
+		url:     url,
+		headers: headers,
+		auth:    auth,
+	}
+}
+func (e *Endpoint) Close() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.closed = true
+	return
+}
+
+func (e *Endpoint) Update(c Config) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.url = c.URL
+	e.headers = c.Headers
+	e.auth = c.BasicAuth
+}
+
+func (e *Endpoint) NewHTTPRequest(body io.Reader) (req *http.Request, err error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closed {
+		return nil, errors.New("endpoint was closed")
+	}
+
+	req, err = http.NewRequest("POST", e.url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create POST request: %v", err)
+	}
+
+	if e.auth.valid() {
+		req.SetBasicAuth(e.auth.Username, e.auth.Password)
+	}
+
+	for k, v := range e.headers {
+		req.Header.Add(k, v)
+	}
+
+	return req, nil
+}
+
+type Service struct {
+	mu        sync.RWMutex
+	endpoints map[string]*Endpoint
+	logger    *log.Logger
+}
+
+func NewService(c Configs, l *log.Logger) *Service {
+	s := &Service{
+		logger:    l,
+		endpoints: c.index(),
+	}
+	return s
+}
+
+func (s *Service) Endpoint(name string) (*Endpoint, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	e, ok := s.endpoints[name]
+	return e, ok
+}
+
+func (s *Service) Update(newConfigs []interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	endpointSet := map[string]bool{}
+
+	for _, nc := range newConfigs {
+		if c, ok := nc.(Config); ok {
+			if err := c.Validate(); err != nil {
+				return err
+			}
+			e, ok := s.endpoints[c.Endpoint]
+			if !ok {
+				s.endpoints[c.Endpoint] = NewEndpoint(c.URL, c.Headers, c.BasicAuth)
+				continue
+			}
+			e.Update(c)
+
+			endpointSet[c.Endpoint] = true
+		} else {
+			return fmt.Errorf("unexpected config object type, got %T exp %T", nc, c)
+		}
+	}
+
+	// Find any deleted endpoints
+	for name, endpoint := range s.endpoints {
+		if !endpointSet[name] {
+			endpoint.Close()
+			delete(s.endpoints, name)
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+
+func (s *Service) Close() error {
+	return nil
+}
+
+type testOptions struct {
+	Endpoint string            `json:"endpoint"`
+	URL      string            `json:"url"`
+	Headers  map[string]string `json:"headers"`
+}
+
+func (s *Service) TestOptions() interface{} {
+	return &testOptions{
+		Endpoint: "example",
+		URL:      "http://localhost:3000/",
+		Headers:  map[string]string{"Auth": "secret"},
+	}
+}
+
+func (s *Service) Test(options interface{}) error {
+	var err error
+	o, ok := options.(*testOptions)
+	if !ok {
+		return fmt.Errorf("unexpected options type %t", options)
+	}
+
+	event := alert.Event{}
+	body := bytes.NewBuffer(nil)
+	ad := event.AlertData()
+
+	err = json.NewEncoder(body).Encode(ad)
+	if err != nil {
+		return fmt.Errorf("failed to marshal alert data json: %v", err)
+	}
+
+	// Create the HTTP request
+	var req *http.Request
+	e := &Endpoint{
+		url:     o.URL,
+		headers: o.Headers,
+	}
+	req, err = e.NewHTTPRequest(body)
+
+	// Execute the request
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to POST alert data: %v", err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+type HandlerConfig struct {
+	URL      string            `mapstructure:"url"`
+	Endpoint string            `mapstructure:"endpoint"`
+	Headers  map[string]string `mapstructure:"headers"`
+}
+
+type handler struct {
+	s        *Service
+	bp       *bufpool.Pool
+	endpoint *Endpoint
+	logger   *log.Logger
+	headers  map[string]string
+}
+
+func (s *Service) Handler(c HandlerConfig, l *log.Logger) alert.Handler {
+	e, ok := s.Endpoint(c.Endpoint)
+	if !ok {
+		e = NewEndpoint(c.URL, nil, BasicAuth{})
+	}
+
+	return &handler{
+		s:        s,
+		bp:       bufpool.New(),
+		endpoint: e,
+		logger:   l,
+		headers:  c.Headers,
+	}
+}
+
+func (h *handler) NewHTTPRequest(body io.Reader) (req *http.Request, err error) {
+	req, err = h.endpoint.NewHTTPRequest(body)
+	if err != nil {
+		return
+	}
+
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
+	}
+
+	return
+}
+
+func (h *handler) Handle(event alert.Event) {
+	var err error
+
+	// Construct the body of the HTTP request
+	body := h.bp.Get()
+	defer h.bp.Put(body)
+	ad := event.AlertData()
+
+	err = json.NewEncoder(body).Encode(ad)
+	if err != nil {
+		h.logger.Printf("E! failed to marshal alert data json: %v", err)
+		return
+	}
+
+	req, err := h.NewHTTPRequest(body)
+	if err != nil {
+		h.logger.Printf("E! fail to create HTTP request: %v", err)
+		return
+	}
+
+	// Execute the request
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.logger.Printf("E! failed to POST alert data: %v", err)
+		return
+	}
+	resp.Body.Close()
+}

--- a/task_master.go
+++ b/task_master.go
@@ -18,6 +18,7 @@ import (
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
+	"github.com/influxdata/kapacitor/services/httppost"
 	k8s "github.com/influxdata/kapacitor/services/k8s/client"
 	"github.com/influxdata/kapacitor/services/opsgenie"
 	"github.com/influxdata/kapacitor/services/pagerduty"
@@ -101,6 +102,10 @@ type TaskMaster struct {
 	}
 	PushoverService interface {
 		Handler(pushover.HandlerConfig, *log.Logger) alert.Handler
+	}
+	HTTPPostService interface {
+		Handler(httppost.HandlerConfig, *log.Logger) alert.Handler
+		Endpoint(string) (*httppost.Endpoint, bool)
 	}
 	SlackService interface {
 		Global() bool


### PR DESCRIPTION
This PR allows users to create POST request `endpoints` for an alert node where arbitrary HTTP headers may be set. It works as a fix for https://github.com/influxdata/kapacitor/issues/117.

Todo:
- [x] Add comments
- [x] Cleanup 
- [x] Test how ENV variables work with toml maps

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)