### PR TITLE
Add match conditions to alert handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@
 
 ### Release Notes
 
+With this release the technical preview alerting service has been refactored.
+Alert handlers now only ever have a single action and belong to a single topic.
+
+The handler defintion has been simplified as a result.
+Here are some example alert handlers using the new structure:
+
+```yaml
+id: my_handler
+kind: pagerDuty
+options:
+  serviceKey: XXX
+```
+
+```yaml
+id: aggregate_by_1m
+kind: aggregate
+options:
+  interval: 1m
+  topic: aggregated
+```
+
+```yaml
+id: publish_to_system
+kind: publish
+options:
+  topics: [ system ]
+```
+
+To define a handler now you must specify which topic the handler belongs to.
+For example to define the above aggregate handler on the system topic use this command:
+
+```sh
+kapacitor define-handler system aggregate_by_1m.yaml
+```
+
+
 ### Features
 
 - [#1159](https://github.com/influxdata/kapacitor/pulls/1159): Go version 1.7.4 -> 1.7.5
@@ -14,6 +50,11 @@
 - [#1162](https://github.com/influxdata/kapacitor/pulls/1162): Add Pushover integration.
 - [#1221](https://github.com/influxdata/kapacitor/pull/1221): Add `working_cardinality` stat to each node type that tracks the number of groups per node.
 - [#1211](https://github.com/influxdata/kapacitor/issues/1211): Add StateDuration node.
+- [#1209](https://github.com/influxdata/kapacitor/issues/1209): BREAKING: Refactor the Alerting service.
+    The change is completely breaking for the technical preview alerting service, a.k.a. the new alert topic handler features.
+    The change boils down to simplifying how you define and interact with topics.
+    Alert handlers now only ever have a single action and belong to a single topic.
+    See the updated API docs.
 
 ### Bugfixes
 

--- a/alert.go
+++ b/alert.go
@@ -464,7 +464,7 @@ func (a *AlertNode) runAlert([]byte) error {
 
 		// Register Handlers on topic
 		for _, h := range a.handlers {
-			a.et.tm.AlertService.RegisterAnonHandler([]string{a.anonTopic}, h)
+			a.et.tm.AlertService.RegisterAnonHandler(a.anonTopic, h)
 		}
 		// Restore anonTopic
 		a.et.tm.AlertService.RestoreTopic(a.anonTopic)
@@ -707,7 +707,7 @@ func (a *AlertNode) runAlert([]byte) error {
 	a.et.tm.AlertService.CloseTopic(a.anonTopic)
 	// Deregister Handlers on topic
 	for _, h := range a.handlers {
-		a.et.tm.AlertService.DeregisterAnonHandler([]string{a.anonTopic}, h)
+		a.et.tm.AlertService.DeregisterAnonHandler(a.anonTopic, h)
 	}
 	return nil
 }

--- a/alert.go
+++ b/alert.go
@@ -25,6 +25,7 @@ import (
 	"github.com/influxdata/kapacitor/services/snmptrap"
 	"github.com/influxdata/kapacitor/services/telegram"
 	"github.com/influxdata/kapacitor/services/victorops"
+	"github.com/influxdata/kapacitor/tick/ast"
 	"github.com/influxdata/kapacitor/tick/stateful"
 	"github.com/influxdata/kapacitor/vars"
 	"github.com/pkg/errors"
@@ -388,14 +389,14 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 		}
 
 		an.levels[alert.Info] = statefulExpression
-		an.scopePools[alert.Info] = stateful.NewScopePool(stateful.FindReferenceVariables(n.Info.Expression))
+		an.scopePools[alert.Info] = stateful.NewScopePool(ast.FindReferenceVariables(n.Info.Expression))
 		if n.InfoReset != nil {
 			lstatefulExpression, lexpressionCompileError := stateful.NewExpression(n.InfoReset.Expression)
 			if lexpressionCompileError != nil {
 				return nil, fmt.Errorf("Failed to compile stateful expression for infoReset: %s", lexpressionCompileError)
 			}
 			an.levelResets[alert.Info] = lstatefulExpression
-			an.lrScopePools[alert.Info] = stateful.NewScopePool(stateful.FindReferenceVariables(n.InfoReset.Expression))
+			an.lrScopePools[alert.Info] = stateful.NewScopePool(ast.FindReferenceVariables(n.InfoReset.Expression))
 		}
 	}
 
@@ -405,14 +406,14 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 			return nil, fmt.Errorf("Failed to compile stateful expression for warn: %s", expressionCompileError)
 		}
 		an.levels[alert.Warning] = statefulExpression
-		an.scopePools[alert.Warning] = stateful.NewScopePool(stateful.FindReferenceVariables(n.Warn.Expression))
+		an.scopePools[alert.Warning] = stateful.NewScopePool(ast.FindReferenceVariables(n.Warn.Expression))
 		if n.WarnReset != nil {
 			lstatefulExpression, lexpressionCompileError := stateful.NewExpression(n.WarnReset.Expression)
 			if lexpressionCompileError != nil {
 				return nil, fmt.Errorf("Failed to compile stateful expression for warnReset: %s", lexpressionCompileError)
 			}
 			an.levelResets[alert.Warning] = lstatefulExpression
-			an.lrScopePools[alert.Warning] = stateful.NewScopePool(stateful.FindReferenceVariables(n.WarnReset.Expression))
+			an.lrScopePools[alert.Warning] = stateful.NewScopePool(ast.FindReferenceVariables(n.WarnReset.Expression))
 		}
 	}
 
@@ -422,14 +423,14 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 			return nil, fmt.Errorf("Failed to compile stateful expression for crit: %s", expressionCompileError)
 		}
 		an.levels[alert.Critical] = statefulExpression
-		an.scopePools[alert.Critical] = stateful.NewScopePool(stateful.FindReferenceVariables(n.Crit.Expression))
+		an.scopePools[alert.Critical] = stateful.NewScopePool(ast.FindReferenceVariables(n.Crit.Expression))
 		if n.CritReset != nil {
 			lstatefulExpression, lexpressionCompileError := stateful.NewExpression(n.CritReset.Expression)
 			if lexpressionCompileError != nil {
 				return nil, fmt.Errorf("Failed to compile stateful expression for critReset: %s", lexpressionCompileError)
 			}
 			an.levelResets[alert.Critical] = lstatefulExpression
-			an.lrScopePools[alert.Critical] = stateful.NewScopePool(stateful.FindReferenceVariables(n.CritReset.Expression))
+			an.lrScopePools[alert.Critical] = stateful.NewScopePool(ast.FindReferenceVariables(n.CritReset.Expression))
 		}
 	}
 

--- a/alert/DESIGN.md
+++ b/alert/DESIGN.md
@@ -73,40 +73,57 @@ Then alert handlers can be configured to subscribe to the events.
 These alert handlers will be configured via the API.
 Use yaml/json to define the alert handlers.
 
+Here are a few examples:
+
 ```yaml
 id: my_handler
+kind: pagerDuty
+options:
+  serviceKey: XXX
+```
 
-topics:
-    - cpu
-    - mem
+```yaml
+id: aggregate_by_1m
+kind: aggregate
+options:
+  interval: 1m
+  topic: aggregated
+```
 
-actions:
-    - kind: aggregate
-      options:
-        groupBy: id
-        interval: 1m
-    - kind: throttle
-      options:
-        count: 10
-        every: 5m
-    - kind: publish
-      options:
-        topics: [ throttled_aggreated ]
-    - kind: pagerDuty
-      options:
-         serviceKey: XXX
+```yaml
+id: publish_to_system
+kind: publish
+options:
+  topics: [ system ]
 ```
 
 ```json
 {
     "id": "my_handler",
-    "topics": ["cpu", "mem"],
-    "actions": [
-        {"kind":"aggregate", "options": {"groupBy":"id","internal":"1m"}},
-        {"kind":"throttle", "options": {"count":10,"every":"5m"}},
-        {"kind":"publish", "options": {"topics":["throttled_aggreated"]}},
-        {"kind":"pagerDuty", "options": {"serviceKey":"XXX"}}
-    ]
+    "kind": "pagerDuty",
+    "options": {
+      "serviceKey": "XXX"
+    }
+}
+```
+
+```json
+{
+    "id": "aggregate_by_1m",
+    "kind": "aggregate",
+    "options": {
+      "interval": "1m"
+    }
+}
+```
+
+```json
+{
+    "id": "publish_to_system",
+    "kind": "publish",
+    "options": {
+      "topics": ["system"]
+    }
 }
 ```
 

--- a/alert/topics.go
+++ b/alert/topics.go
@@ -171,7 +171,7 @@ func (s *Topics) TopicStatus(pattern string, minLevel Level) map[string]TopicSta
 	s.mu.RLock()
 	res := make(map[string]TopicStatus, len(s.topics))
 	for _, topic := range s.topics {
-		if !match(pattern, topic.ID()) {
+		if !PatternMatch(pattern, topic.ID()) {
 			continue
 		}
 		level := topic.MaxLevel()
@@ -192,7 +192,7 @@ func (s *Topics) TopicStatusEvents(pattern string, minLevel Level) map[string]ma
 	s.mu.RLock()
 	topics := make([]*Topic, 0, len(s.topics))
 	for _, topic := range s.topics {
-		if topic.MaxLevel() >= minLevel && match(pattern, topic.id) {
+		if topic.MaxLevel() >= minLevel && PatternMatch(pattern, topic.id) {
 			topics = append(topics, topic)
 		}
 	}
@@ -207,7 +207,7 @@ func (s *Topics) TopicStatusEvents(pattern string, minLevel Level) map[string]ma
 	return res
 }
 
-func match(pattern, id string) bool {
+func PatternMatch(pattern, id string) bool {
 	if pattern == "" {
 		return true
 	}

--- a/alert/topics.go
+++ b/alert/topics.go
@@ -165,45 +165,24 @@ func (s *Topics) ReplaceHandler(oldTopics, newTopics []string, oldH, newH Handle
 	}
 }
 
-// TopicStatus returns the max alert level for each topic matching 'pattern', not returning
+// TopicState returns the max alert level for each topic matching 'pattern', not returning
 // any topics with max alert levels less severe than 'minLevel'
-func (s *Topics) TopicStatus(pattern string, minLevel Level) map[string]TopicStatus {
+func (s *Topics) TopicState(pattern string, minLevel Level) map[string]TopicState {
 	s.mu.RLock()
-	res := make(map[string]TopicStatus, len(s.topics))
+	res := make(map[string]TopicState, len(s.topics))
 	for _, topic := range s.topics {
 		if !PatternMatch(pattern, topic.ID()) {
 			continue
 		}
 		level := topic.MaxLevel()
 		if level >= minLevel {
-			res[topic.ID()] = TopicStatus{
+			res[topic.ID()] = TopicState{
 				Level:     level,
 				Collected: topic.Collected(),
 			}
 		}
 	}
 	s.mu.RUnlock()
-	return res
-}
-
-// TopicStatusDetails is similar to TopicStatus, but will additionally return
-// at least 'minLevel' severity
-func (s *Topics) TopicStatusEvents(pattern string, minLevel Level) map[string]map[string]EventState {
-	s.mu.RLock()
-	topics := make([]*Topic, 0, len(s.topics))
-	for _, topic := range s.topics {
-		if topic.MaxLevel() >= minLevel && PatternMatch(pattern, topic.id) {
-			topics = append(topics, topic)
-		}
-	}
-	s.mu.RUnlock()
-
-	res := make(map[string]map[string]EventState, len(topics))
-
-	for _, topic := range topics {
-		res[topic.ID()] = topic.EventStates(minLevel)
-	}
-
 	return res
 }
 
@@ -247,8 +226,8 @@ func (t *Topic) ID() string {
 	return t.id
 }
 
-func (t *Topic) Status() TopicStatus {
-	return TopicStatus{
+func (t *Topic) State() TopicState {
+	return TopicState{
 		Level:     t.MaxLevel(),
 		Collected: t.Collected(),
 	}

--- a/alert/types.go
+++ b/alert/types.go
@@ -150,7 +150,7 @@ func ParseLevel(s string) (l Level, err error) {
 	return
 }
 
-type TopicStatus struct {
+type TopicState struct {
 	Level     Level
 	Collected int64
 }

--- a/alert/types.go
+++ b/alert/types.go
@@ -13,6 +13,7 @@ type Event struct {
 	Topic         string
 	State         EventState
 	Data          EventData
+	NoExternal    bool
 	previousState EventState
 }
 

--- a/client/API.md
+++ b/client/API.md
@@ -1438,9 +1438,9 @@ GET /kapacitor/v1preview/alerts/topics?min-level=WARNING
 }
 ```
 
-### Topic Status
+### Topic State
 
-To query the status of a topic make a GET request to `/kapacitor/v1preview/alerts/topics/<topic id>`.
+To query the state of a topic make a GET request to `/kapacitor/v1preview/alerts/topics/<topic id>`.
 
 #### Example
 

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -1919,6 +1919,7 @@ type TopicHandler struct {
 	ID      string                 `json:"id"`
 	Kind    string                 `json:"kind"`
 	Options map[string]interface{} `json:"options"`
+	Match   string                 `json:"match"`
 }
 
 // TopicHandler retrieves an alert handler.
@@ -1945,6 +1946,7 @@ type TopicHandlerOptions struct {
 	ID      string                 `json:"id" yaml:"id"`
 	Kind    string                 `json:"kind" yaml:"kind"`
 	Options map[string]interface{} `json:"options" yaml:"options"`
+	Match   string                 `json:"match" yaml:"match"`
 }
 
 // CreateTopicHandler creates a new alert handler.

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -43,7 +43,6 @@ const (
 	configPath        = basePath + "/config"
 	serviceTestsPath  = basePath + "/service-tests"
 	alertsPath        = basePreviewPath + "/alerts"
-	handlersPath      = alertsPath + "/handlers"
 	topicsPath        = alertsPath + "/topics"
 	topicEventsPath   = "events"
 	topicHandlersPath = "handlers"
@@ -687,6 +686,10 @@ func (c *Client) ServiceTestLink(service string) Link {
 	return Link{Relation: Self, Href: path.Join(serviceTestsPath, service)}
 }
 
+func (c *Client) TopicLink(id string) Link {
+	return Link{Relation: Self, Href: path.Join(topicsPath, id)}
+}
+
 func (c *Client) TopicEventsLink(topic string) Link {
 	return Link{Relation: Self, Href: path.Join(topicsPath, topic, topicEventsPath)}
 }
@@ -697,12 +700,8 @@ func (c *Client) TopicEventLink(topic, event string) Link {
 func (c *Client) TopicHandlersLink(topic string) Link {
 	return Link{Relation: Self, Href: path.Join(topicsPath, topic, topicHandlersPath)}
 }
-
-func (c *Client) HandlerLink(id string) Link {
-	return Link{Relation: Self, Href: path.Join(handlersPath, id)}
-}
-func (c *Client) TopicLink(id string) Link {
-	return Link{Relation: Self, Href: path.Join(topicsPath, id)}
+func (c *Client) TopicHandlerLink(topic, id string) Link {
+	return Link{Relation: Self, Href: path.Join(topicsPath, topic, topicHandlersPath, id)}
 }
 
 type CreateTaskOptions struct {
@@ -1910,51 +1909,22 @@ func (c *Client) ListTopicEvents(link Link, opt *ListTopicEventsOptions) (TopicE
 }
 
 type TopicHandlers struct {
-	Link     Link      `json:"link"`
-	Topic    string    `json:"topic"`
-	Handlers []Handler `json:"handlers"`
+	Link     Link           `json:"link"`
+	Topic    string         `json:"topic"`
+	Handlers []TopicHandler `json:"handlers"`
 }
 
-// TopicHandlers returns the current state for events within a topic.
-func (c *Client) ListTopicHandlers(link Link) (TopicHandlers, error) {
-	t := TopicHandlers{}
-	if link.Href == "" {
-		return t, fmt.Errorf("invalid link %v", link)
-	}
-
-	u := *c.url
-	u.Path = link.Href
-
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return t, err
-	}
-
-	_, err = c.Do(req, &t, http.StatusOK)
-	return t, err
+type TopicHandler struct {
+	Link    Link                   `json:"link"`
+	ID      string                 `json:"id"`
+	Kind    string                 `json:"kind"`
+	Options map[string]interface{} `json:"options"`
 }
 
-type Handlers struct {
-	Link     Link      `json:"link"`
-	Handlers []Handler `json:"handlers"`
-}
-
-type Handler struct {
-	Link    Link            `json:"link"`
-	ID      string          `json:"id"`
-	Topics  []string        `json:"topics"`
-	Actions []HandlerAction `json:"actions"`
-}
-
-type HandlerAction struct {
-	Kind    string                 `json:"kind" yaml:"kind"`
-	Options map[string]interface{} `json:"options" yaml:"options"`
-}
-
-// Handler retrieves an alert handler.
+// TopicHandler retrieves an alert handler.
 // Errors if no handler exists.
-func (c *Client) Handler(link Link) (Handler, error) {
-	h := Handler{}
+func (c *Client) TopicHandler(link Link) (TopicHandler, error) {
+	h := TopicHandler{}
 	if link.Href == "" {
 		return h, fmt.Errorf("invalid link %v", link)
 	}
@@ -1971,39 +1941,39 @@ func (c *Client) Handler(link Link) (Handler, error) {
 	return h, err
 }
 
-type HandlerOptions struct {
-	ID      string          `json:"id" yaml:"id"`
-	Topics  []string        `json:"topics" yaml:"topics"`
-	Actions []HandlerAction `json:"actions" yaml:"actions"`
+type TopicHandlerOptions struct {
+	ID      string                 `json:"id" yaml:"id"`
+	Kind    string                 `json:"kind" yaml:"kind"`
+	Options map[string]interface{} `json:"options" yaml:"options"`
 }
 
-// CreateHandler creates a new alert handler.
+// CreateTopicHandler creates a new alert handler.
 // Errors if the handler already exists.
-func (c *Client) CreateHandler(opt HandlerOptions) (Handler, error) {
+func (c *Client) CreateTopicHandler(link Link, opt TopicHandlerOptions) (TopicHandler, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	err := enc.Encode(opt)
 	if err != nil {
-		return Handler{}, err
+		return TopicHandler{}, err
 	}
 
 	u := *c.url
-	u.Path = handlersPath
+	u.Path = link.Href
 
 	req, err := http.NewRequest("POST", u.String(), &buf)
 	if err != nil {
-		return Handler{}, err
+		return TopicHandler{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	h := Handler{}
+	h := TopicHandler{}
 	_, err = c.Do(req, &h, http.StatusOK)
 	return h, err
 }
 
-// PatchHandler applies a patch operation to an existing handler.
-func (c *Client) PatchHandler(link Link, patch JSONPatch) (Handler, error) {
-	h := Handler{}
+// PatchTopicHandler applies a patch operation to an existing handler.
+func (c *Client) PatchTopicHandler(link Link, patch JSONPatch) (TopicHandler, error) {
+	h := TopicHandler{}
 	if link.Href == "" {
 		return h, fmt.Errorf("invalid link %v", link)
 	}
@@ -2027,9 +1997,9 @@ func (c *Client) PatchHandler(link Link, patch JSONPatch) (Handler, error) {
 	return h, err
 }
 
-// ReplaceHandler replaces an existing handler, with the new definition.
-func (c *Client) ReplaceHandler(link Link, opt HandlerOptions) (Handler, error) {
-	h := Handler{}
+// ReplaceTopicHandler replaces an existing handler, with the new definition.
+func (c *Client) ReplaceTopicHandler(link Link, opt TopicHandlerOptions) (TopicHandler, error) {
+	h := TopicHandler{}
 	if link.Href == "" {
 		return h, fmt.Errorf("invalid link %v", link)
 	}
@@ -2053,8 +2023,8 @@ func (c *Client) ReplaceHandler(link Link, opt HandlerOptions) (Handler, error) 
 	return h, err
 }
 
-// DeleteHandler deletes a handler.
-func (c *Client) DeleteHandler(link Link) error {
+// DeleteTopicHandler deletes a handler.
+func (c *Client) DeleteTopicHandler(link Link) error {
 	if link.Href == "" {
 		return fmt.Errorf("invalid link %v", link)
 	}
@@ -2070,27 +2040,27 @@ func (c *Client) DeleteHandler(link Link) error {
 	return err
 }
 
-type ListHandlersOptions struct {
+type ListTopicHandlersOptions struct {
 	Pattern string
 }
 
-func (o *ListHandlersOptions) Default() {}
+func (o *ListTopicHandlersOptions) Default() {}
 
-func (o *ListHandlersOptions) Values() *url.Values {
+func (o *ListTopicHandlersOptions) Values() *url.Values {
 	v := &url.Values{}
 	v.Set("pattern", o.Pattern)
 	return v
 }
 
-func (c *Client) ListHandlers(opt *ListHandlersOptions) (Handlers, error) {
-	handlers := Handlers{}
+func (c *Client) ListTopicHandlers(link Link, opt *ListTopicHandlersOptions) (TopicHandlers, error) {
+	handlers := TopicHandlers{}
 	if opt == nil {
-		opt = new(ListHandlersOptions)
+		opt = new(ListTopicHandlersOptions)
 	}
 	opt.Default()
 
 	u := *c.url
-	u.Path = handlersPath
+	u.Path = link.Href
 	u.RawQuery = opt.Values().Encode()
 
 	req, err := http.NewRequest("GET", u.String(), nil)

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -1457,6 +1457,7 @@ func doShowHandler(args []string) error {
 	fmt.Println("ID:", h.ID)
 	fmt.Println("Topic:", topic)
 	fmt.Println("Kind:", h.Kind)
+	fmt.Println("Match:", h.Match)
 	fmt.Println("Options:", string(options))
 	return nil
 }

--- a/combine.go
+++ b/combine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
+	"github.com/influxdata/kapacitor/tick/ast"
 	"github.com/influxdata/kapacitor/tick/stateful"
 )
 
@@ -44,7 +45,7 @@ func newCombineNode(et *ExecutingTask, n *pipeline.CombineNode, l *log.Logger) (
 			return nil, fmt.Errorf("Failed to compile %v expression: %v", i, err)
 		}
 		cn.expressions[i] = statefulExpr
-		cn.scopePools[i] = stateful.NewScopePool(stateful.FindReferenceVariables(lambda.Expression))
+		cn.scopePools[i] = stateful.NewScopePool(ast.FindReferenceVariables(lambda.Expression))
 	}
 	cn.node.runF = cn.runCombine
 	return cn, nil

--- a/eval.go
+++ b/eval.go
@@ -50,11 +50,11 @@ func newEvalNode(et *ExecutingTask, n *pipeline.EvalNode, l *log.Logger) (*EvalN
 			return nil, fmt.Errorf("Failed to compile %v expression: %v", i, err)
 		}
 		en.expressions[i] = statefulExpr
-		refVars := stateful.FindReferenceVariables(lambda.Expression)
+		refVars := ast.FindReferenceVariables(lambda.Expression)
 		en.refVarList[i] = refVars
 	}
 	// Create a single pool for the combination of all expressions
-	en.scopePool = stateful.NewScopePool(stateful.FindReferenceVariables(expressions...))
+	en.scopePool = stateful.NewScopePool(ast.FindReferenceVariables(expressions...))
 
 	// Create map of tags
 	if l := len(n.TagsList); l > 0 {

--- a/k8s_autoscale.go
+++ b/k8s_autoscale.go
@@ -63,7 +63,7 @@ func newK8sAutoscaleNode(et *ExecutingTask, n *pipeline.K8sAutoscaleNode, l *log
 	// Initialize the replicas lambda expression scope pool
 	if n.Replicas != nil {
 		kn.replicasExprs = make(map[models.GroupID]stateful.Expression)
-		kn.replicasScopePool = stateful.NewScopePool(stateful.FindReferenceVariables(n.Replicas.Expression))
+		kn.replicasScopePool = stateful.NewScopePool(ast.FindReferenceVariables(n.Replicas.Expression))
 	}
 	return kn, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8107,7 +8107,7 @@ stream
 
 	if _, err := cli.ListTopicEvents(l, nil); err == nil {
 		t.Fatal("expected error listing anonymous topic for disabled task")
-	} else if got, exp := err.Error(), fmt.Sprintf("topic %q does not exist", topic); got != exp {
+	} else if got, exp := err.Error(), fmt.Sprintf("failed to get topic events: unknown topic %q", topic); got != exp {
 		t.Errorf("unexpected error message for nonexistent anonymous topic: got %q exp %q", got, exp)
 	}
 
@@ -8143,7 +8143,7 @@ stream
 
 	if _, err := cli.ListTopicEvents(l, nil); err == nil {
 		t.Fatal("expected error listing anonymous topic for deleted task")
-	} else if got, exp := err.Error(), fmt.Sprintf("topic %q does not exist", topic); got != exp {
+	} else if got, exp := err.Error(), fmt.Sprintf("failed to get topic events: unknown topic %q", topic); got != exp {
 		t.Errorf("unexpected error message for nonexistent anonymous topic: got %q exp %q", got, exp)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6936,184 +6936,69 @@ func TestServer_DoServiceTest(t *testing.T) {
 
 func TestServer_AlertHandlers_CRUD(t *testing.T) {
 	testCases := []struct {
-		create    client.HandlerOptions
-		expCreate client.Handler
+		topic     string
+		create    client.TopicHandlerOptions
+		expCreate client.TopicHandler
 		patch     client.JSONPatch
-		expPatch  client.Handler
-		put       client.HandlerOptions
-		expPut    client.Handler
+		expPatch  client.TopicHandler
+		put       client.TopicHandlerOptions
+		expPut    client.TopicHandler
 	}{
 		{
-			create: client.HandlerOptions{
-				ID:     "myhandler",
-				Topics: []string{"system", "test"},
-				Actions: []client.HandlerAction{{
-					Kind: "slack",
-					Options: map[string]interface{}{
-						"channel": "#test",
-					},
-				}},
+			topic: "system",
+			create: client.TopicHandlerOptions{
+				ID:   "myhandler",
+				Kind: "slack",
+				Options: map[string]interface{}{
+					"channel": "#test",
+				},
 			},
-			expCreate: client.Handler{
-				Link:   client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/myhandler"},
-				ID:     "myhandler",
-				Topics: []string{"system", "test"},
-				Actions: []client.HandlerAction{{
-					Kind: "slack",
-					Options: map[string]interface{}{
-						"channel": "#test",
-					},
-				}},
+			expCreate: client.TopicHandler{
+				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/system/handlers/myhandler"},
+				ID:   "myhandler",
+				Kind: "slack",
+				Options: map[string]interface{}{
+					"channel": "#test",
+				},
 			},
 			patch: client.JSONPatch{
 				{
-					Path:      "/topics/0",
+					Path:      "/kind",
+					Operation: "replace",
+					Value:     "log",
+				},
+				{
+					Path:      "/options/channel",
 					Operation: "remove",
 				},
 				{
-					Path:      "/actions/0/options/channel",
-					Operation: "replace",
-					Value:     "#kapacitor_test",
-				},
-			},
-			expPatch: client.Handler{
-				Link:   client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/myhandler"},
-				ID:     "myhandler",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{{
-					Kind: "slack",
-					Options: map[string]interface{}{
-						"channel": "#kapacitor_test",
-					},
-				}},
-			},
-			put: client.HandlerOptions{
-				ID:     "newid",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{{
-					Kind: "smtp",
-					Options: map[string]interface{}{
-						"to": []string{"oncall@example.com"},
-					},
-				}},
-			},
-			expPut: client.Handler{
-				Link:   client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/newid"},
-				ID:     "newid",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{{
-					Kind: "smtp",
-					Options: map[string]interface{}{
-						"to": []interface{}{"oncall@example.com"},
-					},
-				}},
-			},
-		},
-		{
-			create: client.HandlerOptions{
-				ID:     "anotherhandler",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{
-					{
-						Kind: "slack",
-						Options: map[string]interface{}{
-							"channel": "#test",
-						},
-					},
-					{
-						Kind: "log",
-						Options: map[string]interface{}{
-							"path": "/tmp/alert.log",
-						},
-					},
-				},
-			},
-			expCreate: client.Handler{
-				Link:   client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/anotherhandler"},
-				ID:     "anotherhandler",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{
-					{
-						Kind: "slack",
-						Options: map[string]interface{}{
-							"channel": "#test",
-						},
-					},
-					{
-						Kind: "log",
-						Options: map[string]interface{}{
-							"path": "/tmp/alert.log",
-						},
-					},
-				},
-			},
-			patch: client.JSONPatch{
-				{
-					Path:      "/topics/-",
+					Path:      "/options/path",
 					Operation: "add",
-					Value:     "system",
-				},
-				{
-					Path:      "/actions/0/options/channel",
-					Operation: "replace",
-					Value:     "#kapacitor_test",
-				},
-				{
-					Path:      "/actions/-",
-					Operation: "add",
-					Value: map[string]interface{}{
-						"kind": "smtp",
-						"options": map[string]interface{}{
-							"to": []string{"oncall@example.com"},
-						},
-					},
+					Value:     "/var/log/alert.log",
 				},
 			},
-			expPatch: client.Handler{
-				Link:   client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/anotherhandler"},
-				ID:     "anotherhandler",
-				Topics: []string{"test", "system"},
-				Actions: []client.HandlerAction{
-					{
-						Kind: "slack",
-						Options: map[string]interface{}{
-							"channel": "#kapacitor_test",
-						},
-					},
-					{
-						Kind: "log",
-						Options: map[string]interface{}{
-							"path": "/tmp/alert.log",
-						},
-					},
-					{
-						Kind: "smtp",
-						Options: map[string]interface{}{
-							"to": []interface{}{"oncall@example.com"},
-						},
-					},
+			expPatch: client.TopicHandler{
+				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/system/handlers/myhandler"},
+				ID:   "myhandler",
+				Kind: "log",
+				Options: map[string]interface{}{
+					"path": "/var/log/alert.log",
 				},
 			},
-			put: client.HandlerOptions{
-				ID:     "anotherhandler",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{{
-					Kind: "smtp",
-					Options: map[string]interface{}{
-						"to": []string{"oncall@example.com"},
-					},
-				}},
+			put: client.TopicHandlerOptions{
+				ID:   "newid",
+				Kind: "smtp",
+				Options: map[string]interface{}{
+					"to": []string{"oncall@example.com"},
+				},
 			},
-			expPut: client.Handler{
-				Link:   client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/anotherhandler"},
-				ID:     "anotherhandler",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{{
-					Kind: "smtp",
-					Options: map[string]interface{}{
-						"to": []interface{}{"oncall@example.com"},
-					},
-				}},
+			expPut: client.TopicHandler{
+				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/system/handlers/newid"},
+				ID:   "newid",
+				Kind: "smtp",
+				Options: map[string]interface{}{
+					"to": []interface{}{"oncall@example.com"},
+				},
 			},
 		},
 	}
@@ -7124,7 +7009,7 @@ func TestServer_AlertHandlers_CRUD(t *testing.T) {
 		cli := Client(s)
 		defer s.Close()
 
-		h, err := cli.CreateHandler(tc.create)
+		h, err := cli.CreateTopicHandler(cli.TopicHandlersLink(tc.topic), tc.create)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7133,7 +7018,7 @@ func TestServer_AlertHandlers_CRUD(t *testing.T) {
 			t.Errorf("unexpected handler created:\ngot\n%#v\nexp\n%#v\n", h, tc.expCreate)
 		}
 
-		h, err = cli.PatchHandler(h.Link, tc.patch)
+		h, err = cli.PatchTopicHandler(h.Link, tc.patch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7142,7 +7027,7 @@ func TestServer_AlertHandlers_CRUD(t *testing.T) {
 			t.Errorf("unexpected handler patched:\ngot\n%#v\nexp\n%#v\n", h, tc.expPatch)
 		}
 
-		h, err = cli.ReplaceHandler(h.Link, tc.put)
+		h, err = cli.ReplaceTopicHandler(h.Link, tc.put)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7154,7 +7039,7 @@ func TestServer_AlertHandlers_CRUD(t *testing.T) {
 		// Restart server
 		s.Restart()
 
-		rh, err := cli.Handler(h.Link)
+		rh, err := cli.TopicHandler(h.Link)
 		if err != nil {
 			t.Fatalf("could not find handler after restart: %v", err)
 		}
@@ -7162,12 +7047,12 @@ func TestServer_AlertHandlers_CRUD(t *testing.T) {
 			t.Errorf("unexpected handler after restart:\ngot\n%#v\nexp\n%#v\n", got, exp)
 		}
 
-		err = cli.DeleteHandler(h.Link)
+		err = cli.DeleteTopicHandler(h.Link)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		_, err = cli.Handler(h.Link)
+		_, err = cli.TopicHandler(h.Link)
 		if err == nil {
 			t.Errorf("expected handler to be deleted")
 		}
@@ -7202,12 +7087,12 @@ func TestServer_AlertHandlers(t *testing.T) {
 		t.Fatal(err)
 	}
 	testCases := []struct {
-		handlerAction client.HandlerAction
-		setup         func(*server.Config, *client.HandlerAction) (context.Context, error)
-		result        func(context.Context) error
+		handler client.TopicHandler
+		setup   func(*server.Config, *client.TopicHandler) (context.Context, error)
+		result  func(context.Context) error
 	}{
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "alerta",
 				Options: map[string]interface{}{
 					"token":        "testtoken1234567",
@@ -7217,7 +7102,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 					"environment":  "env",
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := alertatest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7249,14 +7134,14 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "exec",
 				Options: map[string]interface{}{
 					"prog": "/bin/alert-handler.sh",
 					"args": []string{"arg1", "arg2", "arg3"},
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				te := alerttest.NewExec()
 				ctxt := context.WithValue(nil, "exec", te)
 				c.Commander = te.Commander
@@ -7287,14 +7172,14 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "hipchat",
 				Options: map[string]interface{}{
 					"token": "testtoken1234567",
 					"room":  "1234567",
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := hipchattest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7322,13 +7207,13 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "log",
 				Options: map[string]interface{}{
 					"mode": 0604,
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				tdir := MustTempDir()
 				p := path.Join(tdir, "alert.log")
 
@@ -7365,14 +7250,14 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "opsgenie",
 				Options: map[string]interface{}{
 					"teams-list":      []string{"A team", "B team"},
 					"recipients-list": []string{"test_recipient1", "test_recipient2"},
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := opsgenietest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7410,11 +7295,11 @@ func TestServer_AlertHandlers(t *testing.T) {
 		},
 
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind:    "pushover",
 				Options: map[string]interface{}{},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := pushovertest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7444,13 +7329,13 @@ func TestServer_AlertHandlers(t *testing.T) {
 		},
 
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "pagerduty",
 				Options: map[string]interface{}{
 					"service-key": "service_key",
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := pagerdutytest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7481,10 +7366,10 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "post",
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := alerttest.NewPostServer()
 
 				ha.Options = map[string]interface{}{"url": ts.URL}
@@ -7504,10 +7389,10 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "sensu",
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts, err := sensutest.NewServer()
 				if err != nil {
 					return nil, err
@@ -7536,13 +7421,13 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "slack",
 				Options: map[string]interface{}{
 					"channel": "#test",
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := slacktest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7577,13 +7462,13 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "smtp",
 				Options: map[string]interface{}{
 					"to": []string{"oncall@example.com", "backup@example.com"},
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts, err := smtptest.NewServer()
 				if err != nil {
 					return nil, err
@@ -7630,7 +7515,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "snmptrap",
 				Options: map[string]interface{}{
 					"trap-oid": "1.1.2",
@@ -7648,7 +7533,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 					},
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts, err := snmptraptest.NewServer()
 				if err != nil {
 					return nil, err
@@ -7694,10 +7579,10 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "talk",
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := talktest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7725,10 +7610,10 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "tcp",
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts, err := alerttest.NewTCPServer()
 				if err != nil {
 					return nil, err
@@ -7751,14 +7636,14 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "telegram",
 				Options: map[string]interface{}{
 					"chat-id":                  "chat id",
 					"disable-web-page-preview": true,
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := telegramtest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7788,13 +7673,13 @@ func TestServer_AlertHandlers(t *testing.T) {
 			},
 		},
 		{
-			handlerAction: client.HandlerAction{
+			handler: client.TopicHandler{
 				Kind: "victorops",
 				Options: map[string]interface{}{
 					"routing-key": "key",
 				},
 			},
-			setup: func(c *server.Config, ha *client.HandlerAction) (context.Context, error) {
+			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				ts := victoropstest.NewServer()
 				ctxt := context.WithValue(nil, "server", ts)
 
@@ -7826,14 +7711,14 @@ func TestServer_AlertHandlers(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.handlerAction.Kind, func(t *testing.T) {
-			kind := tc.handlerAction.Kind
+		t.Run(tc.handler.Kind, func(t *testing.T) {
+			kind := tc.handler.Kind
 			// Create default config
 			c := NewConfig()
 			var ctxt context.Context
 			if tc.setup != nil {
 				var err error
-				ctxt, err = tc.setup(c, &tc.handlerAction)
+				ctxt, err = tc.setup(c, &tc.handler)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -7848,12 +7733,10 @@ func TestServer_AlertHandlers(t *testing.T) {
 			}()
 			ctxt = context.WithValue(ctxt, "kapacitorURL", s.URL())
 
-			if _, err := cli.CreateHandler(client.HandlerOptions{
-				ID:     "testAlertHandlers",
-				Topics: []string{"test"},
-				Actions: []client.HandlerAction{
-					tc.handlerAction,
-				},
+			if _, err := cli.CreateTopicHandler(cli.TopicHandlersLink("test"), client.TopicHandlerOptions{
+				ID:      "testAlertHandlers",
+				Kind:    tc.handler.Kind,
+				Options: tc.handler.Options,
 			}); err != nil {
 				t.Fatalf("%s: %v", kind, err)
 			}
@@ -8166,13 +8049,10 @@ func TestServer_AlertTopic_PersistedState(t *testing.T) {
 	cli := Client(s)
 	defer s.Close()
 
-	if _, err := cli.CreateHandler(client.HandlerOptions{
-		ID:     "testAlertHandler",
-		Topics: []string{"test"},
-		Actions: []client.HandlerAction{{
-			Kind:    "tcp",
-			Options: map[string]interface{}{"address": ts.Addr},
-		}},
+	if _, err := cli.CreateTopicHandler(cli.TopicHandlersLink("test"), client.TopicHandlerOptions{
+		ID:      "testAlertHandler",
+		Kind:    "tcp",
+		Options: map[string]interface{}{"address": ts.Addr},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -8284,50 +8164,47 @@ func TestServer_AlertListHandlers(t *testing.T) {
 	cli := Client(s)
 	defer s.Close()
 
-	topics := []string{"test"}
-	actions := []client.HandlerAction{{
-		Kind:    "tcp",
-		Options: map[string]interface{}{"address": ts.Addr},
-	}}
+	thl := cli.TopicHandlersLink("test")
 
 	// Number of handlers to create
 	n := 3
 	for i := 0; i < n; i++ {
 		id := fmt.Sprintf("handler%d", i)
-		if _, err := cli.CreateHandler(client.HandlerOptions{
+		if _, err := cli.CreateTopicHandler(thl, client.TopicHandlerOptions{
 			ID:      id,
-			Topics:  topics,
-			Actions: actions,
+			Kind:    "tcp",
+			Options: map[string]interface{}{"address": ts.Addr},
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	expHandlers := client.Handlers{
-		Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers?pattern="},
-		Handlers: []client.Handler{
+	expHandlers := client.TopicHandlers{
+		Link:  client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/test/handlers?pattern="},
+		Topic: "test",
+		Handlers: []client.TopicHandler{
 			{
-				Link:    client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/handler0"},
+				Link:    client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/test/handlers/handler0"},
 				ID:      "handler0",
-				Topics:  topics,
-				Actions: actions,
+				Kind:    "tcp",
+				Options: map[string]interface{}{"address": ts.Addr},
 			},
 			{
-				Link:    client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/handler1"},
+				Link:    client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/test/handlers/handler1"},
 				ID:      "handler1",
-				Topics:  topics,
-				Actions: actions,
+				Kind:    "tcp",
+				Options: map[string]interface{}{"address": ts.Addr},
 			},
 			{
-				Link:    client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/handlers/handler2"},
+				Link:    client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/test/handlers/handler2"},
 				ID:      "handler2",
-				Topics:  topics,
-				Actions: actions,
+				Kind:    "tcp",
+				Options: map[string]interface{}{"address": ts.Addr},
 			},
 		},
 	}
 
-	handlers, err := cli.ListHandlers(nil)
+	handlers, err := cli.ListTopicHandlers(thl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -8339,7 +8216,7 @@ func TestServer_AlertListHandlers(t *testing.T) {
 	s.Restart()
 
 	// Check again
-	handlers, err = cli.ListHandlers(nil)
+	handlers, err = cli.ListTopicHandlers(thl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -8347,60 +8224,49 @@ func TestServer_AlertListHandlers(t *testing.T) {
 		t.Errorf("unexpected handlers after restart:\ngot\n%+v\nexp\n%+v\n", handlers, expHandlers)
 	}
 
-	var exp client.Handlers
+	var exp client.TopicHandlers
 
 	// Pattern = *
-	handlers, err = cli.ListHandlers(&client.ListHandlersOptions{
+	handlers, err = cli.ListTopicHandlers(thl, &client.ListTopicHandlersOptions{
 		Pattern: "*",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	exp = expHandlers
-	exp.Link.Href = "/kapacitor/v1preview/alerts/handlers?pattern=%2A"
+	exp.Link.Href = "/kapacitor/v1preview/alerts/topics/test/handlers?pattern=%2A"
 	if !reflect.DeepEqual(handlers, exp) {
 		t.Errorf("unexpected handlers with pattern \"*\":\ngot\n%+v\nexp\n%+v\n", handlers, exp)
 	}
 
 	// Pattern = handler*
-	handlers, err = cli.ListHandlers(&client.ListHandlersOptions{
+	handlers, err = cli.ListTopicHandlers(thl, &client.ListTopicHandlersOptions{
 		Pattern: "handler*",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	exp = expHandlers
-	exp.Link.Href = "/kapacitor/v1preview/alerts/handlers?pattern=handler%2A"
+	exp.Link.Href = "/kapacitor/v1preview/alerts/topics/test/handlers?pattern=handler%2A"
 	if !reflect.DeepEqual(handlers, exp) {
-		t.Errorf("unexpected handlers with pattern \"test\":\ngot\n%+v\nexp\n%+v\n", handlers, exp)
+		t.Errorf("unexpected handlers with pattern \"handler*\":\ngot\n%+v\nexp\n%+v\n", handlers, exp)
 	}
 
 	// Pattern = handler0
-	handlers, err = cli.ListHandlers(&client.ListHandlersOptions{
+	handlers, err = cli.ListTopicHandlers(thl, &client.ListTopicHandlersOptions{
 		Pattern: "handler0",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	exp = expHandlers
-	exp.Link.Href = "/kapacitor/v1preview/alerts/handlers?pattern=handler0"
+	exp.Link.Href = "/kapacitor/v1preview/alerts/topics/test/handlers?pattern=handler0"
 	exp.Handlers = expHandlers.Handlers[0:1]
 	if !reflect.DeepEqual(handlers, exp) {
-		t.Errorf("unexpected handlers with pattern \"test\":\ngot\n%+v\nexp\n%+v\n", handlers, exp)
-	}
-
-	// List handlers of test topic
-	l := cli.TopicHandlersLink("test")
-	topicHandlers, err := cli.ListTopicHandlers(l)
-	expTopicHandlers := client.TopicHandlers{
-		Link:     client.Link{Relation: client.Self, Href: "/kapacitor/v1preview/alerts/topics/test/handlers"},
-		Topic:    "test",
-		Handlers: expHandlers.Handlers,
-	}
-	if !reflect.DeepEqual(topicHandlers, expTopicHandlers) {
-		t.Errorf("unexpected topic handlers:\ngot\n%+v\nexp\n%+v\n", topicHandlers, expTopicHandlers)
+		t.Errorf("unexpected handlers with pattern \"handler0\":\ngot\n%+v\nexp\n%+v\n", handlers, exp)
 	}
 }
+
 func TestServer_AlertTopic(t *testing.T) {
 	// Create default config
 	c := NewConfig()
@@ -8408,13 +8274,10 @@ func TestServer_AlertTopic(t *testing.T) {
 	cli := Client(s)
 	defer s.Close()
 
-	if _, err := cli.CreateHandler(client.HandlerOptions{
-		ID:     "testAlertHandler",
-		Topics: []string{"misc"},
-		Actions: []client.HandlerAction{{
-			Kind:    "tcp",
-			Options: map[string]interface{}{"address": "localhost:4657"},
-		}},
+	if _, err := cli.CreateTopicHandler(cli.TopicHandlersLink("misc"), client.TopicHandlerOptions{
+		ID:      "testAlertHandler",
+		Kind:    "tcp",
+		Options: map[string]interface{}{"address": "localhost:4657"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -8450,15 +8313,14 @@ func TestServer_AlertListTopics(t *testing.T) {
 	cli := Client(s)
 	defer s.Close()
 
-	if _, err := cli.CreateHandler(client.HandlerOptions{
-		ID:     "testAlertHandler",
-		Topics: []string{"test", "system", "misc"},
-		Actions: []client.HandlerAction{{
+	for _, topic := range []string{"system", "misc", "test"} {
+		if _, err := cli.CreateTopicHandler(cli.TopicHandlersLink(topic), client.TopicHandlerOptions{
+			ID:      "testAlertHandler",
 			Kind:    "tcp",
 			Options: map[string]interface{}{"address": ts.Addr},
-		}},
-	}); err != nil {
-		t.Fatal(err)
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	expTopics := client.Topics{
@@ -8584,7 +8446,7 @@ stream
 	}
 }
 
-func TestServer_AlertHandler_MultipleActions(t *testing.T) {
+func TestServer_AlertHandler_MultipleHandlers(t *testing.T) {
 	resultJSON := `{"series":[{"name":"alert","columns":["time","value"],"values":[["1970-01-01T00:00:00Z",1]]}]}`
 
 	// Create default config
@@ -8610,22 +8472,20 @@ func TestServer_AlertHandler_MultipleActions(t *testing.T) {
 		}
 	}()
 
-	if _, err := cli.CreateHandler(client.HandlerOptions{
-		ID:     "testAlertHandlers",
-		Topics: []string{"test"},
-		Actions: []client.HandlerAction{
-			{
-				Kind: "victorops",
-				Options: map[string]interface{}{
-					"routing-key": "key",
-				},
-			},
-			{
-				Kind: "slack",
-				Options: map[string]interface{}{
-					"channel": "#test",
-				},
-			},
+	if _, err := cli.CreateTopicHandler(cli.TopicHandlersLink("test"), client.TopicHandlerOptions{
+		ID:   "testAlertHandlers-VO",
+		Kind: "victorops",
+		Options: map[string]interface{}{
+			"routing-key": "key",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cli.CreateTopicHandler(cli.TopicHandlersLink("test"), client.TopicHandlerOptions{
+		ID:   "testAlertHandlers-Slack",
+		Kind: "slack",
+		Options: map[string]interface{}{
+			"channel": "#test",
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/services/alert/api.go
+++ b/services/alert/api.go
@@ -1,0 +1,483 @@
+package alert
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"sort"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/influxdata/kapacitor/alert"
+	client "github.com/influxdata/kapacitor/client/v1"
+	"github.com/influxdata/kapacitor/services/httpd"
+)
+
+const (
+	alertsPath         = "/alerts"
+	alertsPathAnchored = "/alerts/"
+
+	topicsPath             = alertsPath + "/topics"
+	topicsPathAnchored     = alertsPath + "/topics/"
+	topicsBasePath         = httpd.BasePreviewPath + topicsPath
+	topicsBasePathAnchored = httpd.BasePreviewPath + topicsPathAnchored
+
+	handlersPath             = alertsPath + "/handlers"
+	handlersPathAnchored     = alertsPath + "/handlers/"
+	handlersBasePath         = httpd.BasePreviewPath + handlersPath
+	handlersBasePathAnchored = httpd.BasePreviewPath + handlersPathAnchored
+
+	topicEventsPath   = "events"
+	topicHandlersPath = "handlers"
+
+	eventsPattern   = "*/" + topicEventsPath
+	eventPattern    = "*/" + topicEventsPath + "/*"
+	handlersPattern = "*/" + topicHandlersPath
+
+	eventsRelation   = "events"
+	handlersRelation = "handlers"
+)
+
+type apiServer struct {
+	Registrar    HandlerSpecRegistrar
+	Statuser     TopicStatuser
+	persister    TopicPersister
+	routes       []httpd.Route
+	HTTPDService interface {
+		AddPreviewRoutes([]httpd.Route) error
+		DelRoutes([]httpd.Route)
+	}
+}
+
+func (s *apiServer) Open() error {
+	// Define API routes
+	s.routes = []httpd.Route{
+		{
+			Method:      "GET",
+			Pattern:     topicsPath,
+			HandlerFunc: s.handleListTopics,
+		},
+		{
+			Method:      "GET",
+			Pattern:     topicsPathAnchored,
+			HandlerFunc: s.handleRouteTopic,
+		},
+		{
+			Method:      "DELETE",
+			Pattern:     topicsPathAnchored,
+			HandlerFunc: s.handleDeleteTopic,
+		},
+		{
+			Method:      "GET",
+			Pattern:     handlersPath,
+			HandlerFunc: s.handleListHandlers,
+		},
+		{
+			Method:      "POST",
+			Pattern:     handlersPath,
+			HandlerFunc: s.handleCreateHandler,
+		},
+		{
+			// Satisfy CORS checks.
+			Method:      "OPTIONS",
+			Pattern:     handlersPathAnchored,
+			HandlerFunc: httpd.ServeOptions,
+		},
+		{
+			Method:      "PATCH",
+			Pattern:     handlersPathAnchored,
+			HandlerFunc: s.handlePatchHandler,
+		},
+		{
+			Method:      "PUT",
+			Pattern:     handlersPathAnchored,
+			HandlerFunc: s.handlePutHandler,
+		},
+		{
+			Method:      "DELETE",
+			Pattern:     handlersPathAnchored,
+			HandlerFunc: s.handleDeleteHandler,
+		},
+		{
+			Method:      "GET",
+			Pattern:     handlersPathAnchored,
+			HandlerFunc: s.handleGetHandler,
+		},
+	}
+
+	return s.HTTPDService.AddPreviewRoutes(s.routes)
+}
+
+func (s *apiServer) Close() error {
+	s.HTTPDService.DelRoutes(s.routes)
+	return nil
+}
+
+type sortedTopics []client.Topic
+
+func (s sortedTopics) Len() int               { return len(s) }
+func (s sortedTopics) Less(i int, j int) bool { return s[i].ID < s[j].ID }
+func (s sortedTopics) Swap(i int, j int)      { s[i], s[j] = s[j], s[i] }
+
+func (s *apiServer) handleListTopics(w http.ResponseWriter, r *http.Request) {
+	pattern := r.URL.Query().Get("pattern")
+	if err := validatePattern(pattern); err != nil {
+		httpd.HttpError(w, fmt.Sprint("invalide pattern: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+	minLevelStr := r.URL.Query().Get("min-level")
+	minLevel, err := alert.ParseLevel(minLevelStr)
+	if err != nil {
+		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
+		return
+	}
+	statuses, err := s.Statuser.TopicStatus(pattern, minLevel)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to get topic statuses: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+	list := make([]client.Topic, 0, len(statuses))
+	for topic, status := range statuses {
+		list = append(list, s.createClientTopic(topic, status))
+	}
+	sort.Sort(sortedTopics(list))
+
+	topics := client.Topics{
+		Link:   client.Link{Relation: client.Self, Href: r.URL.String()},
+		Topics: list,
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(topics, true))
+}
+
+func (s *apiServer) topicIDFromPath(p string) (id string) {
+	d := p
+	for d != "." {
+		id = d
+		d = path.Dir(d)
+	}
+	return
+}
+
+func pathMatch(pattern, p string) (match bool) {
+	match, _ = path.Match(pattern, p)
+	return
+}
+
+func (s *apiServer) handleDeleteTopic(w http.ResponseWriter, r *http.Request) {
+	p := strings.TrimPrefix(r.URL.Path, topicsBasePathAnchored)
+	id := s.topicIDFromPath(p)
+	if err := s.persister.DeleteTopic(id); err != nil {
+		httpd.HttpError(w, fmt.Sprintf("failed to delete topic %q: %v", id, err), true, http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *apiServer) handleRouteTopic(w http.ResponseWriter, r *http.Request) {
+	p := strings.TrimPrefix(r.URL.Path, topicsBasePathAnchored)
+	id := s.topicIDFromPath(p)
+	t, ok := s.persister.topic(id)
+	if !ok {
+		httpd.HttpError(w, fmt.Sprintf("topic %q does not exist", id), true, http.StatusNotFound)
+		return
+	}
+
+	switch {
+	case pathMatch(eventsPattern, p):
+		s.handleListTopicEvents(t, w, r)
+	case pathMatch(eventPattern, p):
+		s.handleTopicEvent(t, w, r)
+	case pathMatch(handlersPattern, p):
+		s.handleListTopicHandlers(t, w, r)
+	default:
+		s.handleTopic(t, w, r)
+	}
+}
+
+func (s *apiServer) handlerLink(id string) client.Link {
+	return client.Link{Relation: client.Self, Href: path.Join(handlersBasePath, id)}
+}
+func (s *apiServer) topicLink(id string) client.Link {
+	return client.Link{Relation: client.Self, Href: path.Join(topicsBasePath, id)}
+}
+func (s *apiServer) topicEventsLink(id string, r client.Relation) client.Link {
+	return client.Link{Relation: r, Href: path.Join(topicsBasePath, id, topicEventsPath)}
+}
+func (s *apiServer) topicEventLink(topic, event string) client.Link {
+	return client.Link{Relation: client.Self, Href: path.Join(topicsBasePath, topic, topicEventsPath, event)}
+}
+func (s *apiServer) topicHandlersLink(id string, r client.Relation) client.Link {
+	return client.Link{Relation: r, Href: path.Join(topicsBasePath, id, topicHandlersPath)}
+}
+func (s *apiServer) topicHandlerLink(topic, handler string) client.Link {
+	return client.Link{Relation: client.Self, Href: path.Join(topicsBasePath, topic, topicHandlersPath, handler)}
+}
+
+func (s *apiServer) createClientTopic(topic string, status alert.TopicStatus) client.Topic {
+	return client.Topic{
+		ID:           topic,
+		Link:         s.topicLink(topic),
+		Level:        status.Level.String(),
+		Collected:    status.Collected,
+		EventsLink:   s.topicEventsLink(topic, eventsRelation),
+		HandlersLink: s.topicHandlersLink(topic, handlersRelation),
+	}
+}
+
+func (s *apiServer) handleTopic(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
+	topic := s.createClientTopic(t.ID(), t.Status())
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(topic, true))
+}
+
+func (s *apiServer) convertEventStateToClient(state alert.EventState) client.EventState {
+	return client.EventState{
+		Message:  state.Message,
+		Details:  state.Details,
+		Time:     state.Time,
+		Duration: client.Duration(state.Duration),
+		Level:    state.Level.String(),
+	}
+}
+
+func (s *apiServer) convertHandlerSpec(spec HandlerSpec) client.Handler {
+	actions := make([]client.HandlerAction, 0, len(spec.Actions))
+	for _, actionSpec := range spec.Actions {
+		action := client.HandlerAction{
+			Kind:    actionSpec.Kind,
+			Options: actionSpec.Options,
+		}
+		actions = append(actions, action)
+	}
+	return client.Handler{
+		Link:    s.handlerLink(spec.ID),
+		ID:      spec.ID,
+		Topics:  spec.Topics,
+		Actions: actions,
+	}
+}
+
+func (s *apiServer) handleListTopicEvents(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
+	minLevelStr := r.URL.Query().Get("min-level")
+	minLevel, err := alert.ParseLevel(minLevelStr)
+	if err != nil {
+		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
+		return
+	}
+	events := t.EventStates(minLevel)
+	res := client.TopicEvents{
+		Link:   s.topicEventsLink(t.ID(), client.Self),
+		Topic:  t.ID(),
+		Events: make([]client.TopicEvent, 0, len(events)),
+	}
+	for id, state := range events {
+		res.Events = append(res.Events, client.TopicEvent{
+			Link:  s.topicEventLink(t.ID(), id),
+			ID:    id,
+			State: s.convertEventStateToClient(state),
+		})
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(res, true))
+}
+
+func (s *apiServer) handleTopicEvent(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
+	id := path.Base(r.URL.Path)
+	state, ok := t.EventState(id)
+	if !ok {
+		httpd.HttpError(w, fmt.Sprintf("event %q does not exist for topic %q", id, t.ID()), true, http.StatusNotFound)
+		return
+	}
+	event := client.TopicEvent{
+		Link:  s.topicEventLink(t.ID(), id),
+		ID:    id,
+		State: s.convertEventStateToClient(state),
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(event, true))
+}
+
+func (s *apiServer) handleListTopicHandlers(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
+	var handlers []client.Handler
+	specs, err := s.Registrar.HandlerSpecs("")
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to get handler specs: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+
+	for _, spec := range specs {
+		if spec.HasTopic(t.ID()) {
+			handlers = append(handlers, s.convertHandlerSpec(spec))
+		}
+	}
+	sort.Sort(sortedHandlers(handlers))
+	th := client.TopicHandlers{
+		Link:     s.topicHandlersLink(t.ID(), client.Self),
+		Topic:    t.ID(),
+		Handlers: handlers,
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(th, true))
+}
+
+type sortedHandlers []client.Handler
+
+func (s sortedHandlers) Len() int               { return len(s) }
+func (s sortedHandlers) Less(i int, j int) bool { return s[i].ID < s[j].ID }
+func (s sortedHandlers) Swap(i int, j int)      { s[i], s[j] = s[j], s[i] }
+
+func (s *apiServer) handleListHandlers(w http.ResponseWriter, r *http.Request) {
+	pattern := r.URL.Query().Get("pattern")
+	if err := validatePattern(pattern); err != nil {
+		httpd.HttpError(w, fmt.Sprint("invalid pattern: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+
+	specs, err := s.Registrar.HandlerSpecs(pattern)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to get handler specs: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+	list := make([]client.Handler, len(specs))
+	for i := range specs {
+		list[i] = s.convertHandlerSpec(specs[i])
+	}
+	sort.Sort(sortedHandlers(list))
+
+	handlers := client.Handlers{
+		Link:     client.Link{Relation: client.Self, Href: r.URL.String()},
+		Handlers: list,
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(handlers, true))
+}
+
+func (s *apiServer) handleCreateHandler(w http.ResponseWriter, r *http.Request) {
+	handlerSpec := HandlerSpec{}
+	err := json.NewDecoder(r.Body).Decode(&handlerSpec)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("invalid handler json: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+	if err := handlerSpec.Validate(); err != nil {
+		httpd.HttpError(w, fmt.Sprint("invalid handler spec: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+
+	err = s.Registrar.RegisterHandlerSpec(handlerSpec)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to create handler: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+
+	h := s.convertHandlerSpec(handlerSpec)
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(h, true))
+}
+
+func (s *apiServer) handlePatchHandler(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
+	spec, err := s.Registrar.HandlerSpec(id)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprintf("unknown handler: %q", id), true, http.StatusNotFound)
+		return
+	}
+
+	patchBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to read request body: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+	patch, err := jsonpatch.DecodePatch(patchBytes)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("invalid patch json: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+	specBytes, err := json.Marshal(spec)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to marshal JSON: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+	newBytes, err := patch.Apply(specBytes)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to apply patch: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+	newSpec := HandlerSpec{}
+	if err := json.Unmarshal(newBytes, &newSpec); err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to unmarshal patched json: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+	if err := newSpec.Validate(); err != nil {
+		httpd.HttpError(w, fmt.Sprint("invalid handler spec: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+
+	if err := s.Registrar.UpdateHandlerSpec(spec, newSpec); err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to update handler: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+
+	ch := s.convertHandlerSpec(newSpec)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(ch, true))
+}
+
+func (s *apiServer) handlePutHandler(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
+	spec, err := s.Registrar.HandlerSpec(id)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprintf("unknown handler: %q", id), true, http.StatusNotFound)
+		return
+	}
+
+	newSpec := HandlerSpec{}
+	if err := json.NewDecoder(r.Body).Decode(&newSpec); err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to unmar JSON: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+	if err := newSpec.Validate(); err != nil {
+		httpd.HttpError(w, fmt.Sprint("invalid handler spec: ", err.Error()), true, http.StatusBadRequest)
+		return
+	}
+
+	if err := s.Registrar.UpdateHandlerSpec(spec, newSpec); err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to update handler: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+
+	ch := s.convertHandlerSpec(newSpec)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(ch, true))
+}
+
+func (s *apiServer) handleDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
+	if err := s.Registrar.DeregisterHandlerSpec(id); err != nil {
+		httpd.HttpError(w, fmt.Sprint("failed to delete handler: ", err.Error()), true, http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *apiServer) handleGetHandler(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
+	spec, err := s.Registrar.HandlerSpec(id)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprintf("unknown handler: %q", id), true, http.StatusNotFound)
+		return
+	}
+
+	h := s.convertHandlerSpec(spec)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(h, true))
+}

--- a/services/alert/api.go
+++ b/services/alert/api.go
@@ -277,6 +277,7 @@ func (s *apiServer) convertHandlerSpec(spec HandlerSpec) client.TopicHandler {
 		ID:      spec.ID,
 		Kind:    spec.Kind,
 		Options: spec.Options,
+		Match:   spec.Match,
 	}
 }
 

--- a/services/alert/dao.go
+++ b/services/alert/dao.go
@@ -61,6 +61,7 @@ type HandlerSpec struct {
 	Topic   string                 `json:"topic"`
 	Kind    string                 `json:"kind"`
 	Options map[string]interface{} `json:"options"`
+	Match   string                 `json:"match"`
 }
 
 var validHandlerID = regexp.MustCompile(`^[-\._\p{L}0-9]+$`)

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -1,19 +1,12 @@
 package alert
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"path"
-	"sort"
-	"strings"
 	"sync"
 
-	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/influxdata/kapacitor/alert"
-	client "github.com/influxdata/kapacitor/client/v1"
 	"github.com/influxdata/kapacitor/command"
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/hipchat"
@@ -29,31 +22,6 @@ import (
 	"github.com/influxdata/kapacitor/services/victorops"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-)
-
-const (
-	alertsPath         = "/alerts"
-	alertsPathAnchored = "/alerts/"
-
-	topicsPath             = alertsPath + "/topics"
-	topicsPathAnchored     = alertsPath + "/topics/"
-	topicsBasePath         = httpd.BasePreviewPath + topicsPath
-	topicsBasePathAnchored = httpd.BasePreviewPath + topicsPathAnchored
-
-	handlersPath             = alertsPath + "/handlers"
-	handlersPathAnchored     = alertsPath + "/handlers/"
-	handlersBasePath         = httpd.BasePreviewPath + handlersPath
-	handlersBasePathAnchored = httpd.BasePreviewPath + handlersPathAnchored
-
-	topicEventsPath   = "events"
-	topicHandlersPath = "handlers"
-
-	eventsPattern   = "*/" + topicEventsPath
-	eventPattern    = "*/" + topicEventsPath + "/*"
-	handlersPattern = "*/" + topicHandlersPath
-
-	eventsRelation   = "events"
-	handlersRelation = "handlers"
 )
 
 type handler struct {
@@ -73,17 +41,19 @@ type Service struct {
 	specsDAO  HandlerSpecDAO
 	topicsDAO TopicStateDAO
 
+	APIServer *apiServer
+
 	handlers map[string]handler
 
 	closedTopics map[string]bool
 
 	topics *alert.Topics
 
-	routes       []httpd.Route
 	HTTPDService interface {
 		AddPreviewRoutes([]httpd.Route) error
 		DelRoutes([]httpd.Route)
 	}
+
 	StorageService interface {
 		Store(namespace string) storage.Interface
 	}
@@ -138,6 +108,11 @@ func NewService(c Config, l *log.Logger) *Service {
 		topics:       alert.NewTopics(l),
 		logger:       l,
 	}
+	s.APIServer = &apiServer{
+		Registrar: s,
+		Statuser:  s,
+		persister: s,
+	}
 	return s
 }
 
@@ -171,62 +146,12 @@ func (s *Service) Open() error {
 		return err
 	}
 
-	// Define API routes
-	s.routes = []httpd.Route{
-		{
-			Method:      "GET",
-			Pattern:     topicsPath,
-			HandlerFunc: s.handleListTopics,
-		},
-		{
-			Method:      "GET",
-			Pattern:     topicsPathAnchored,
-			HandlerFunc: s.handleRouteTopic,
-		},
-		{
-			Method:      "DELETE",
-			Pattern:     topicsPathAnchored,
-			HandlerFunc: s.handleDeleteTopic,
-		},
-		{
-			Method:      "GET",
-			Pattern:     handlersPath,
-			HandlerFunc: s.handleListHandlers,
-		},
-		{
-			Method:      "POST",
-			Pattern:     handlersPath,
-			HandlerFunc: s.handleCreateHandler,
-		},
-		{
-			// Satisfy CORS checks.
-			Method:      "OPTIONS",
-			Pattern:     handlersPathAnchored,
-			HandlerFunc: httpd.ServeOptions,
-		},
-		{
-			Method:      "PATCH",
-			Pattern:     handlersPathAnchored,
-			HandlerFunc: s.handlePatchHandler,
-		},
-		{
-			Method:      "PUT",
-			Pattern:     handlersPathAnchored,
-			HandlerFunc: s.handlePutHandler,
-		},
-		{
-			Method:      "DELETE",
-			Pattern:     handlersPathAnchored,
-			HandlerFunc: s.handleDeleteHandler,
-		},
-		{
-			Method:      "GET",
-			Pattern:     handlersPathAnchored,
-			HandlerFunc: s.handleGetHandler,
-		},
+	s.APIServer.HTTPDService = s.HTTPDService
+	if err := s.APIServer.Open(); err != nil {
+		return err
 	}
 
-	return s.HTTPDService.AddPreviewRoutes(s.routes)
+	return nil
 }
 
 func (s *Service) loadSavedHandlerSpecs() error {
@@ -250,6 +175,42 @@ func (s *Service) loadSavedHandlerSpecs() error {
 		}
 	}
 	return nil
+}
+
+func (s *Service) convertEventStatesToAlert(states map[string]EventState) map[string]alert.EventState {
+	newStates := make(map[string]alert.EventState, len(states))
+	for id, state := range states {
+		newStates[id] = s.convertEventStateToAlert(id, state)
+	}
+	return newStates
+}
+func (s *Service) convertEventStateToAlert(id string, state EventState) alert.EventState {
+	return alert.EventState{
+		ID:       id,
+		Message:  state.Message,
+		Details:  state.Details,
+		Time:     state.Time,
+		Duration: state.Duration,
+		Level:    state.Level,
+	}
+}
+
+func (s *Service) convertEventStatesFromAlert(states map[string]alert.EventState) map[string]EventState {
+	newStates := make(map[string]EventState, len(states))
+	for id, state := range states {
+		newStates[id] = s.convertEventStateFromAlert(state)
+	}
+	return newStates
+}
+
+func (s *Service) convertEventStateFromAlert(state alert.EventState) EventState {
+	return EventState{
+		Message:  state.Message,
+		Details:  state.Details,
+		Time:     state.Time,
+		Duration: state.Duration,
+		Level:    state.Level,
+	}
 }
 
 func (s *Service) loadSavedTopicStates() error {
@@ -277,418 +238,12 @@ func (s *Service) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.topics.Close()
-	s.HTTPDService.DelRoutes(s.routes)
-	return nil
+	return s.APIServer.Close()
 }
 
 func validatePattern(pattern string) error {
 	_, err := path.Match(pattern, "")
 	return err
-}
-
-type sortedTopics []client.Topic
-
-func (s sortedTopics) Len() int               { return len(s) }
-func (s sortedTopics) Less(i int, j int) bool { return s[i].ID < s[j].ID }
-func (s sortedTopics) Swap(i int, j int)      { s[i], s[j] = s[j], s[i] }
-
-func (s *Service) handleListTopics(w http.ResponseWriter, r *http.Request) {
-	pattern := r.URL.Query().Get("pattern")
-	if err := validatePattern(pattern); err != nil {
-		httpd.HttpError(w, fmt.Sprint("invalide pattern: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-	minLevelStr := r.URL.Query().Get("min-level")
-	minLevel, err := alert.ParseLevel(minLevelStr)
-	if err != nil {
-		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
-		return
-	}
-	statuses, err := s.TopicStatus(pattern, minLevel)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to get topic statuses: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-	list := make([]client.Topic, 0, len(statuses))
-	for topic, status := range statuses {
-		list = append(list, s.createClientTopic(topic, status))
-	}
-	sort.Sort(sortedTopics(list))
-
-	topics := client.Topics{
-		Link:   client.Link{Relation: client.Self, Href: r.URL.String()},
-		Topics: list,
-	}
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(topics, true))
-}
-
-func (s *Service) topicIDFromPath(p string) (id string) {
-	d := p
-	for d != "." {
-		id = d
-		d = path.Dir(d)
-	}
-	return
-}
-
-func pathMatch(pattern, p string) (match bool) {
-	match, _ = path.Match(pattern, p)
-	return
-}
-
-func (s *Service) handleDeleteTopic(w http.ResponseWriter, r *http.Request) {
-	p := strings.TrimPrefix(r.URL.Path, topicsBasePathAnchored)
-	id := s.topicIDFromPath(p)
-	if err := s.DeleteTopic(id); err != nil {
-		httpd.HttpError(w, fmt.Sprintf("failed to delete topic %q: %v", id, err), true, http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
-func (s *Service) handleRouteTopic(w http.ResponseWriter, r *http.Request) {
-	p := strings.TrimPrefix(r.URL.Path, topicsBasePathAnchored)
-	id := s.topicIDFromPath(p)
-	t, ok := s.topics.Topic(id)
-	if !ok {
-		httpd.HttpError(w, fmt.Sprintf("topic %q does not exist", id), true, http.StatusNotFound)
-		return
-	}
-
-	switch {
-	case pathMatch(eventsPattern, p):
-		s.handleListTopicEvents(t, w, r)
-	case pathMatch(eventPattern, p):
-		s.handleTopicEvent(t, w, r)
-	case pathMatch(handlersPattern, p):
-		s.handleListTopicHandlers(t, w, r)
-	default:
-		s.handleTopic(t, w, r)
-	}
-}
-
-func (s *Service) handlerLink(id string) client.Link {
-	return client.Link{Relation: client.Self, Href: path.Join(handlersBasePath, id)}
-}
-func (s *Service) topicLink(id string) client.Link {
-	return client.Link{Relation: client.Self, Href: path.Join(topicsBasePath, id)}
-}
-func (s *Service) topicEventsLink(id string, r client.Relation) client.Link {
-	return client.Link{Relation: r, Href: path.Join(topicsBasePath, id, topicEventsPath)}
-}
-func (s *Service) topicEventLink(topic, event string) client.Link {
-	return client.Link{Relation: client.Self, Href: path.Join(topicsBasePath, topic, topicEventsPath, event)}
-}
-func (s *Service) topicHandlersLink(id string, r client.Relation) client.Link {
-	return client.Link{Relation: r, Href: path.Join(topicsBasePath, id, topicHandlersPath)}
-}
-func (s *Service) topicHandlerLink(topic, handler string) client.Link {
-	return client.Link{Relation: client.Self, Href: path.Join(topicsBasePath, topic, topicHandlersPath, handler)}
-}
-
-func (s *Service) createClientTopic(topic string, status alert.TopicStatus) client.Topic {
-	return client.Topic{
-		ID:           topic,
-		Link:         s.topicLink(topic),
-		Level:        status.Level.String(),
-		Collected:    status.Collected,
-		EventsLink:   s.topicEventsLink(topic, eventsRelation),
-		HandlersLink: s.topicHandlersLink(topic, handlersRelation),
-	}
-}
-
-func (s *Service) handleTopic(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
-	topic := s.createClientTopic(t.ID(), t.Status())
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(topic, true))
-}
-
-func (s *Service) convertEventStatesFromAlert(states map[string]alert.EventState) map[string]EventState {
-	newStates := make(map[string]EventState, len(states))
-	for id, state := range states {
-		newStates[id] = s.convertEventStateFromAlert(state)
-	}
-	return newStates
-}
-
-func (s *Service) convertEventStatesToAlert(states map[string]EventState) map[string]alert.EventState {
-	newStates := make(map[string]alert.EventState, len(states))
-	for id, state := range states {
-		newStates[id] = s.convertEventStateToAlert(id, state)
-	}
-	return newStates
-}
-
-func (s *Service) convertEventStateFromAlert(state alert.EventState) EventState {
-	return EventState{
-		Message:  state.Message,
-		Details:  state.Details,
-		Time:     state.Time,
-		Duration: state.Duration,
-		Level:    state.Level,
-	}
-}
-
-func (s *Service) convertEventStateToAlert(id string, state EventState) alert.EventState {
-	return alert.EventState{
-		ID:       id,
-		Message:  state.Message,
-		Details:  state.Details,
-		Time:     state.Time,
-		Duration: state.Duration,
-		Level:    state.Level,
-	}
-}
-
-func (s *Service) convertEventStateToClient(state alert.EventState) client.EventState {
-	return client.EventState{
-		Message:  state.Message,
-		Details:  state.Details,
-		Time:     state.Time,
-		Duration: client.Duration(state.Duration),
-		Level:    state.Level.String(),
-	}
-}
-
-func (s *Service) convertHandlerSpec(spec HandlerSpec) client.Handler {
-	actions := make([]client.HandlerAction, 0, len(spec.Actions))
-	for _, actionSpec := range spec.Actions {
-		action := client.HandlerAction{
-			Kind:    actionSpec.Kind,
-			Options: actionSpec.Options,
-		}
-		actions = append(actions, action)
-	}
-	return client.Handler{
-		Link:    s.handlerLink(spec.ID),
-		ID:      spec.ID,
-		Topics:  spec.Topics,
-		Actions: actions,
-	}
-}
-
-func (s *Service) handleListTopicEvents(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
-	minLevelStr := r.URL.Query().Get("min-level")
-	minLevel, err := alert.ParseLevel(minLevelStr)
-	if err != nil {
-		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
-		return
-	}
-	events := t.EventStates(minLevel)
-	res := client.TopicEvents{
-		Link:   s.topicEventsLink(t.ID(), client.Self),
-		Topic:  t.ID(),
-		Events: make([]client.TopicEvent, 0, len(events)),
-	}
-	for id, state := range events {
-		res.Events = append(res.Events, client.TopicEvent{
-			Link:  s.topicEventLink(t.ID(), id),
-			ID:    id,
-			State: s.convertEventStateToClient(state),
-		})
-	}
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(res, true))
-}
-
-func (s *Service) handleTopicEvent(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
-	id := path.Base(r.URL.Path)
-	state, ok := t.EventState(id)
-	if !ok {
-		httpd.HttpError(w, fmt.Sprintf("event %q does not exist for topic %q", id, t.ID()), true, http.StatusNotFound)
-		return
-	}
-	event := client.TopicEvent{
-		Link:  s.topicEventLink(t.ID(), id),
-		ID:    id,
-		State: s.convertEventStateToClient(state),
-	}
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(event, true))
-}
-
-func (s *Service) handleListTopicHandlers(t *alert.Topic, w http.ResponseWriter, r *http.Request) {
-	var handlers []client.Handler
-	for _, h := range s.handlers {
-		if h.Spec.HasTopic(t.ID()) {
-			handlers = append(handlers, s.convertHandlerSpec(h.Spec))
-		}
-	}
-	sort.Sort(sortedHandlers(handlers))
-	th := client.TopicHandlers{
-		Link:     s.topicHandlersLink(t.ID(), client.Self),
-		Topic:    t.ID(),
-		Handlers: handlers,
-	}
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(th, true))
-}
-
-type sortedHandlers []client.Handler
-
-func (s sortedHandlers) Len() int               { return len(s) }
-func (s sortedHandlers) Less(i int, j int) bool { return s[i].ID < s[j].ID }
-func (s sortedHandlers) Swap(i int, j int)      { s[i], s[j] = s[j], s[i] }
-
-func (s *Service) handleListHandlers(w http.ResponseWriter, r *http.Request) {
-	pattern := r.URL.Query().Get("pattern")
-	if err := validatePattern(pattern); err != nil {
-		httpd.HttpError(w, fmt.Sprint("invalid pattern: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-
-	specs, err := s.HandlerSpecs(pattern)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to get handler specs: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-	list := make([]client.Handler, len(specs))
-	for i := range specs {
-		list[i] = s.convertHandlerSpec(specs[i])
-	}
-	sort.Sort(sortedHandlers(list))
-
-	handlers := client.Handlers{
-		Link:     client.Link{Relation: client.Self, Href: r.URL.String()},
-		Handlers: list,
-	}
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(handlers, true))
-}
-
-func (s *Service) handleCreateHandler(w http.ResponseWriter, r *http.Request) {
-	handlerSpec := HandlerSpec{}
-	err := json.NewDecoder(r.Body).Decode(&handlerSpec)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("invalid handler json: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-	if err := handlerSpec.Validate(); err != nil {
-		httpd.HttpError(w, fmt.Sprint("invalid handler spec: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-
-	err = s.RegisterHandlerSpec(handlerSpec)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to create handler: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-
-	h := s.convertHandlerSpec(handlerSpec)
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(h, true))
-}
-
-func (s *Service) handlePatchHandler(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
-	s.mu.RLock()
-	h, ok := s.handlers[id]
-	s.mu.RUnlock()
-	if !ok {
-		httpd.HttpError(w, fmt.Sprintf("unknown handler: %q", id), true, http.StatusNotFound)
-		return
-	}
-
-	patchBytes, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to read request body: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-	patch, err := jsonpatch.DecodePatch(patchBytes)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("invalid patch json: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-	specBytes, err := json.Marshal(h.Spec)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to marshal JSON: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-	newBytes, err := patch.Apply(specBytes)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to apply patch: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-	newSpec := HandlerSpec{}
-	if err := json.Unmarshal(newBytes, &newSpec); err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to unmarshal patched json: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-	if err := newSpec.Validate(); err != nil {
-		httpd.HttpError(w, fmt.Sprint("invalid handler spec: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-
-	if err := s.UpdateHandlerSpec(h.Spec, newSpec); err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to update handler: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-
-	ch := s.convertHandlerSpec(newSpec)
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(ch, true))
-}
-
-func (s *Service) handlePutHandler(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
-	s.mu.RLock()
-	h, ok := s.handlers[id]
-	s.mu.RUnlock()
-	if !ok {
-		httpd.HttpError(w, fmt.Sprintf("unknown handler: %q", id), true, http.StatusNotFound)
-		return
-	}
-
-	newSpec := HandlerSpec{}
-	err := json.NewDecoder(r.Body).Decode(&newSpec)
-	if err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to unmar JSON: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-	if err := newSpec.Validate(); err != nil {
-		httpd.HttpError(w, fmt.Sprint("invalid handler spec: ", err.Error()), true, http.StatusBadRequest)
-		return
-	}
-
-	if err := s.UpdateHandlerSpec(h.Spec, newSpec); err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to update handler: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-
-	ch := s.convertHandlerSpec(newSpec)
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(ch, true))
-}
-
-func (s *Service) handleDeleteHandler(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
-	if err := s.DeregisterHandlerSpec(id); err != nil {
-		httpd.HttpError(w, fmt.Sprint("failed to delete handler: ", err.Error()), true, http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
-func (s *Service) handleGetHandler(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, handlersBasePathAnchored)
-	s.mu.RLock()
-	h, ok := s.handlers[id]
-	s.mu.RUnlock()
-	if !ok {
-		httpd.HttpError(w, fmt.Sprintf("unknown handler: %q", id), true, http.StatusNotFound)
-		return
-	}
-
-	ch := s.convertHandlerSpec(h.Spec)
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(httpd.MarshalJSON(ch, true))
 }
 
 func (s *Service) EventState(topic, event string) (alert.EventState, bool) {
@@ -765,6 +320,13 @@ func (s *Service) restoreTopic(topic string) error {
 		}
 	}
 	return nil
+}
+
+func (s *Service) topic(id string) (*alert.Topic, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.topics.Topic(id)
+	return t, ok
 }
 
 func (s *Service) RestoreTopic(topic string) error {
@@ -937,18 +499,11 @@ func (s *Service) HandlerSpecs(pattern string) ([]HandlerSpec, error) {
 
 	handlers := make([]HandlerSpec, 0, len(s.handlers))
 	for id, h := range s.handlers {
-		if match(pattern, id) {
+		if alert.PatternMatch(pattern, id) {
 			handlers = append(handlers, h.Spec)
 		}
 	}
 	return handlers, nil
-}
-func match(pattern, id string) bool {
-	if pattern == "" {
-		return true
-	}
-	matched, _ := path.Match(pattern, id)
-	return matched
 }
 
 func (s *Service) createHandlerFromSpec(spec HandlerSpec) (handler, error) {

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -656,11 +656,6 @@ func (s *Service) createHandlerFromSpec(spec HandlerSpec) (handler, error) {
 			return handler{}, err
 		}
 		h = newExternalHandler(h)
-	//case "stateChangesOnly":
-	//	c := StateChangesOnlyHandlerConfig{
-	//		topics: s.topics,
-	//	}
-	//	h = NewStateChangesOnlyHandler(c, s.logger)
 	case "talk":
 		h = s.TalkService.Handler(s.logger)
 		h = newExternalHandler(h)
@@ -691,23 +686,9 @@ func (s *Service) createHandlerFromSpec(spec HandlerSpec) (handler, error) {
 	default:
 		err = fmt.Errorf("unsupported action kind %q", spec.Kind)
 	}
+	if spec.Match != "" {
+		// Wrap handler in match handler
+		h, err = newMatchHandler(spec.Match, h, s.logger)
+	}
 	return handler{Spec: spec, Handler: h}, err
-}
-
-// ExternalHandler wraps an existing handler that calls out to external services.
-// The events are checked for the NoExternal flag before being passed to the external handler.
-type externalHandler struct {
-	h alert.Handler
-}
-
-func (h *externalHandler) Handle(event alert.Event) {
-	if !event.NoExternal {
-		h.h.Handle(event)
-	}
-}
-
-func newExternalHandler(h alert.Handler) *externalHandler {
-	return &externalHandler{
-		h: h,
-	}
 }

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -986,7 +986,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 		if err != nil {
 			return nil, err
 		}
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "exec":
 		c := ExecHandlerConfig{
 			Commander: s.Commander,
@@ -996,7 +996,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := NewExecHandler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "hipchat":
 		c := hipchat.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1004,7 +1004,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.HipChatService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "log":
 		c := DefaultLogHandlerConfig()
 		err = decodeOptions(spec.Options, &c)
@@ -1015,7 +1015,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 		if err != nil {
 			return nil, err
 		}
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "opsgenie":
 		c := opsgenie.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1023,7 +1023,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.OpsGenieService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "pagerduty":
 		c := pagerduty.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1031,7 +1031,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.PagerDutyService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "pushover":
 		c := pushover.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1039,7 +1039,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.PushoverService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "post":
 		c := PostHandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1047,7 +1047,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := NewPostHandler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "publish":
 		c := PublishHandlerConfig{
 			topics: s.topics,
@@ -1060,7 +1060,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 		ha = newPassThroughHandler(h)
 	case "sensu":
 		h := s.SensuService.Handler(s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "slack":
 		c := slack.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1068,7 +1068,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.SlackService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "smtp":
 		c := smtp.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1076,7 +1076,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.SMTPService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "snmptrap":
 		c := snmptrap.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1087,7 +1087,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 		if err != nil {
 			return nil, err
 		}
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "stateChangesOnly":
 		c := StateChangesOnlyHandlerConfig{
 			topics: s.topics,
@@ -1095,7 +1095,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 		ha = NewStateChangesOnlyHandler(c, s.logger)
 	case "talk":
 		h := s.TalkService.Handler(s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "tcp":
 		c := TCPHandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1103,7 +1103,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := NewTCPHandler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "telegram":
 		c := telegram.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1111,7 +1111,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.TelegramService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	case "victorops":
 		c := victorops.HandlerConfig{}
 		err = decodeOptions(spec.Options, &c)
@@ -1119,7 +1119,7 @@ func (s *Service) createHandlerActionFromSpec(spec HandlerActionSpec) (ha handle
 			return
 		}
 		h := s.VictorOpsService.Handler(c, s.logger)
-		ha = newPassThroughHandler(h)
+		ha = newPassThroughHandler(newExternalHandler(h))
 	default:
 		err = fmt.Errorf("unsupported action kind %q", spec.Kind)
 	}
@@ -1153,3 +1153,21 @@ func (h *passThroughHandler) Close() {
 type noopHandler struct{}
 
 func (h noopHandler) Handle(event alert.Event) {}
+
+// ExternalHandler wraps an existing handler that calls out to external services.
+// The events are checked for the NoExternal flag before being passed onto the external handler.
+type externalHandler struct {
+	h alert.Handler
+}
+
+func (h *externalHandler) Handle(event alert.Event) {
+	if !event.NoExternal {
+		h.h.Handle(event)
+	}
+}
+
+func newExternalHandler(h alert.Handler) *externalHandler {
+	return &externalHandler{
+		h: h,
+	}
+}

--- a/services/alert/types.go
+++ b/services/alert/types.go
@@ -52,4 +52,6 @@ type TopicPersister interface {
 	DeleteTopic(topic string) error
 	// RestoreTopic signals that a topic should be restored from persisted state.
 	RestoreTopic(topic string) error
+	// Topic returns an topic if it exists.
+	topic(id string) (*alert.Topic, bool)
 }

--- a/services/alert/types.go
+++ b/services/alert/types.go
@@ -1,0 +1,55 @@
+package alert
+
+import "github.com/influxdata/kapacitor/alert"
+
+// HandlerSpecRegistrar is responsible for registering and persisting handler spec definitions.
+type HandlerSpecRegistrar interface {
+	// RegisterHandlerSpec saves the handler spec and registers a handler defined by the spec
+	RegisterHandlerSpec(HandlerSpec) error
+	// DeregisterHandlerSpec deletes the handler spec and deregisters the defined handler.
+	DeregisterHandlerSpec(id string) error
+	// UpdateHandlerSpec updates the old spec with the new spec and takes care of registering new handlers based on the new spec.
+	UpdateHandlerSpec(oldSpec, newSpec HandlerSpec) error
+	// HandlerSpec returns a handler spec
+	HandlerSpec(id string) (HandlerSpec, error)
+	// Handlers returns a list of handler specs that match the pattern.
+	HandlerSpecs(pattern string) ([]HandlerSpec, error)
+}
+
+// TopicStatuser is responsible for querying  the status of topics and their events.
+type TopicStatuser interface {
+	// TopicStatus returns the status of all topics that match the pattern and have at least minLevel.
+	TopicStatus(pattern string, minLevel alert.Level) (map[string]alert.TopicStatus, error)
+	// TopicStatusEvents returns the specific events for each topic that matches the pattern.
+	// Only events greater or equal to minLevel will be returned
+	TopicStatusEvents(pattern string, minLevel alert.Level) (map[string]map[string]alert.EventState, error)
+}
+
+// HandlerRegistrar is responsible for directly registering hander instances.
+// This is to be used only when the origin of the handler is not defined by a handler spec.
+type HandlerRegistrar interface {
+	// RegisterHandler registers the handler instance for the listed topics.
+	RegisterHandler(topics []string, h alert.Handler)
+	// DeregisterHandler removes the handler from the listed topics.
+	DeregisterHandler(topics []string, h alert.Handler)
+}
+
+// Eventer is responsible for accepting events for processing and reporting on the state of events.
+type Eventer interface {
+	// Collect accepts a new event for processing.
+	Collect(event alert.Event) error
+	// UpdateEvent updates an existing event with a previously known state.
+	UpdateEvent(topic string, event alert.EventState) error
+	// EventState returns the current events state.
+	EventState(topic, event string) (alert.EventState, bool)
+}
+
+// TopicPersister is responsible for controlling the persistence of topic state.
+type TopicPersister interface {
+	// CloseTopic closes a topic but does not delete its state.
+	CloseTopic(topic string) error
+	// DeleteTopic closes a topic and deletes all state associated with the topic.
+	DeleteTopic(topic string) error
+	// RestoreTopic signals that a topic should be restored from persisted state.
+	RestoreTopic(topic string) error
+}

--- a/services/alert/types.go
+++ b/services/alert/types.go
@@ -39,10 +39,14 @@ type AnonHandlerRegistrar interface {
 	DeregisterAnonHandler(topic string, h alert.Handler)
 }
 
-// Events is responsible for accepting events for processing and reporting on the state of events.
-type Events interface {
+type EventCollector interface {
 	// Collect accepts a new event for processing.
 	Collect(event alert.Event) error
+}
+
+// Events is responsible for accepting events for processing and reporting on the state of events.
+type Events interface {
+	EventCollector
 	// UpdateEvent updates an existing event with a previously known state.
 	UpdateEvent(topic string, event alert.EventState) error
 	// EventState returns the current events state.
@@ -57,4 +61,9 @@ type TopicPersister interface {
 	DeleteTopic(topic string) error
 	// RestoreTopic signals that a topic should be restored from persisted state.
 	RestoreTopic(topic string) error
+}
+
+type handler struct {
+	Spec    HandlerSpec
+	Handler alert.Handler
 }

--- a/services/alert/types.go
+++ b/services/alert/types.go
@@ -16,32 +16,37 @@ type HandlerSpecRegistrar interface {
 	HandlerSpecs(pattern string) ([]HandlerSpec, error)
 }
 
-// TopicStatuser is responsible for querying  the status of topics and their events.
-type TopicStatuser interface {
-	// TopicStatus returns the status of all topics that match the pattern and have at least minLevel.
-	TopicStatus(pattern string, minLevel alert.Level) (map[string]alert.TopicStatus, error)
-	// TopicStatusEvents returns the specific events for each topic that matches the pattern.
+// Topics is responsible for querying the state of topics and their events.
+type Topics interface {
+	// TopicState returns the state of the specified topic,
+	TopicState(topic string) (alert.TopicState, bool, error)
+	// TopicStates returns the state of all topics that match the pattern and have at least minLevel.
+	TopicStates(pattern string, minLevel alert.Level) (map[string]alert.TopicState, error)
+
+	// EventState returns the current state of the event.
+	EventState(topic, event string) (alert.EventState, bool, error)
+	// EventStates returns the current state of events for the specified topic.
 	// Only events greater or equal to minLevel will be returned
-	TopicStatusEvents(pattern string, minLevel alert.Level) (map[string]map[string]alert.EventState, error)
+	EventStates(topic string, minLevel alert.Level) (map[string]alert.EventState, error)
 }
 
-// HandlerRegistrar is responsible for directly registering hander instances.
+// AnonHandlerRegistrar is responsible for directly registering handlers for anonymous topics.
 // This is to be used only when the origin of the handler is not defined by a handler spec.
-type HandlerRegistrar interface {
+type AnonHandlerRegistrar interface {
 	// RegisterHandler registers the handler instance for the listed topics.
-	RegisterHandler(topics []string, h alert.Handler)
+	RegisterAnonHandler(topics []string, h alert.Handler)
 	// DeregisterHandler removes the handler from the listed topics.
-	DeregisterHandler(topics []string, h alert.Handler)
+	DeregisterAnonHandler(topics []string, h alert.Handler)
 }
 
-// Eventer is responsible for accepting events for processing and reporting on the state of events.
-type Eventer interface {
+// Events is responsible for accepting events for processing and reporting on the state of events.
+type Events interface {
 	// Collect accepts a new event for processing.
 	Collect(event alert.Event) error
 	// UpdateEvent updates an existing event with a previously known state.
 	UpdateEvent(topic string, event alert.EventState) error
 	// EventState returns the current events state.
-	EventState(topic, event string) (alert.EventState, bool)
+	EventState(topic, event string) (alert.EventState, bool, error)
 }
 
 // TopicPersister is responsible for controlling the persistence of topic state.
@@ -52,6 +57,4 @@ type TopicPersister interface {
 	DeleteTopic(topic string) error
 	// RestoreTopic signals that a topic should be restored from persisted state.
 	RestoreTopic(topic string) error
-	// Topic returns an topic if it exists.
-	topic(id string) (*alert.Topic, bool)
 }

--- a/services/alert/types.go
+++ b/services/alert/types.go
@@ -5,15 +5,15 @@ import "github.com/influxdata/kapacitor/alert"
 // HandlerSpecRegistrar is responsible for registering and persisting handler spec definitions.
 type HandlerSpecRegistrar interface {
 	// RegisterHandlerSpec saves the handler spec and registers a handler defined by the spec
-	RegisterHandlerSpec(HandlerSpec) error
+	RegisterHandlerSpec(spec HandlerSpec) error
 	// DeregisterHandlerSpec deletes the handler spec and deregisters the defined handler.
-	DeregisterHandlerSpec(id string) error
+	DeregisterHandlerSpec(topic, id string) error
 	// UpdateHandlerSpec updates the old spec with the new spec and takes care of registering new handlers based on the new spec.
 	UpdateHandlerSpec(oldSpec, newSpec HandlerSpec) error
 	// HandlerSpec returns a handler spec
-	HandlerSpec(id string) (HandlerSpec, error)
+	HandlerSpec(topic, id string) (HandlerSpec, bool, error)
 	// Handlers returns a list of handler specs that match the pattern.
-	HandlerSpecs(pattern string) ([]HandlerSpec, error)
+	HandlerSpecs(topic, pattern string) ([]HandlerSpec, error)
 }
 
 // Topics is responsible for querying the state of topics and their events.
@@ -34,9 +34,9 @@ type Topics interface {
 // This is to be used only when the origin of the handler is not defined by a handler spec.
 type AnonHandlerRegistrar interface {
 	// RegisterHandler registers the handler instance for the listed topics.
-	RegisterAnonHandler(topics []string, h alert.Handler)
+	RegisterAnonHandler(topic string, h alert.Handler)
 	// DeregisterHandler removes the handler from the listed topics.
-	DeregisterAnonHandler(topics []string, h alert.Handler)
+	DeregisterAnonHandler(topic string, h alert.Handler)
 }
 
 // Events is responsible for accepting events for processing and reporting on the state of events.

--- a/services/logging/loggingtest/logging.go
+++ b/services/logging/loggingtest/logging.go
@@ -9,6 +9,10 @@ import (
 	"github.com/influxdata/wlog"
 )
 
+func init() {
+	wlog.SetLevel(wlog.DEBUG)
+}
+
 type TestLogService struct {
 	prefix string
 }

--- a/state_tracking.go
+++ b/state_tracking.go
@@ -42,7 +42,7 @@ func (stn *StateTrackingNode) group(g models.GroupID) (*stateTrackingGroup, erro
 			return nil, fmt.Errorf("Failed to compile expression: %v", err)
 		}
 
-		stg.ScopePool = stateful.NewScopePool(stateful.FindReferenceVariables(stn.lambda.Expression))
+		stg.ScopePool = stateful.NewScopePool(ast.FindReferenceVariables(stn.lambda.Expression))
 
 		stg.tracker = stn.newTracker()
 

--- a/stream.go
+++ b/stream.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
+	"github.com/influxdata/kapacitor/tick/ast"
 	"github.com/influxdata/kapacitor/tick/stateful"
 )
 
@@ -67,7 +68,7 @@ func newFromNode(et *ExecutingTask, n *pipeline.FromNode, l *log.Logger) (*FromN
 		}
 
 		sn.expression = expr
-		sn.scopePool = stateful.NewScopePool(stateful.FindReferenceVariables(n.Lambda.Expression))
+		sn.scopePool = stateful.NewScopePool(ast.FindReferenceVariables(n.Lambda.Expression))
 	}
 
 	return sn, nil

--- a/task_master.go
+++ b/task_master.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/kapacitor/influxdb"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
+	alertservice "github.com/influxdata/kapacitor/services/alert"
 	"github.com/influxdata/kapacitor/services/alerta"
 	"github.com/influxdata/kapacitor/services/hipchat"
 	"github.com/influxdata/kapacitor/services/httpd"
@@ -73,14 +74,9 @@ type TaskMaster struct {
 	UDFService UDFService
 
 	AlertService interface {
-		EventState(topic, event string) (alert.EventState, bool)
-		UpdateEvent(topic string, event alert.EventState) error
-		Collect(event alert.Event) error
-		RegisterHandler(topics []string, h alert.Handler)
-		DeregisterHandler(topics []string, h alert.Handler)
-		RestoreTopic(topic string) error
-		CloseTopic(topic string) error
-		DeleteTopic(topic string) error
+		alertservice.HandlerRegistrar
+		alertservice.Eventer
+		alertservice.TopicPersister
 	}
 	InfluxDBService interface {
 		NewNamedClient(name string) (influxdb.Client, error)

--- a/task_master.go
+++ b/task_master.go
@@ -74,8 +74,8 @@ type TaskMaster struct {
 	UDFService UDFService
 
 	AlertService interface {
-		alertservice.HandlerRegistrar
-		alertservice.Eventer
+		alertservice.AnonHandlerRegistrar
+		alertservice.Events
 		alertservice.TopicPersister
 	}
 	InfluxDBService interface {

--- a/tick/ast/find.go
+++ b/tick/ast/find.go
@@ -1,0 +1,45 @@
+package ast
+
+// FindReferenceVariables walks all nodes and returns a list of name from reference variables.
+func FindReferenceVariables(nodes ...Node) []string {
+	variablesSet := make(map[string]bool)
+
+	for _, node := range nodes {
+		Walk(node, func(n Node) (Node, error) {
+			if ref, ok := n.(*ReferenceNode); ok {
+				variablesSet[ref.Reference] = true
+			}
+			return n, nil
+		})
+	}
+
+	variables := make([]string, 0, len(variablesSet))
+
+	for variable := range variablesSet {
+		variables = append(variables, variable)
+	}
+
+	return variables
+}
+
+// FindFunctionCalls walks all nodes and returns a list of name of function calls.
+func FindFunctionCalls(nodes ...Node) []string {
+	funcCallsSet := make(map[string]bool)
+
+	for _, node := range nodes {
+		Walk(node, func(n Node) (Node, error) {
+			if fnc, ok := n.(*FunctionNode); ok {
+				funcCallsSet[fnc.Func] = true
+			}
+			return n, nil
+		})
+	}
+
+	funcCalls := make([]string, 0, len(funcCallsSet))
+
+	for variable := range funcCallsSet {
+		funcCalls = append(funcCalls, variable)
+	}
+
+	return funcCalls
+}

--- a/tick/ast/node.go
+++ b/tick/ast/node.go
@@ -29,6 +29,12 @@ type Node interface {
 	Equal(interface{}) bool
 }
 
+func Format(n Node) string {
+	var buf bytes.Buffer
+	n.Format(&buf, "", false)
+	return buf.String()
+}
+
 // Represents a node that can have a comment associated with it.
 type commentedNode interface {
 	SetComment(c *CommentNode)

--- a/tick/ast/walk.go
+++ b/tick/ast/walk.go
@@ -1,0 +1,70 @@
+package ast
+
+import "errors"
+
+// Walk calls f on all nodes reachable from the root node.
+// The node returned will replace the node provided within the AST.
+// Returning an error from f will stop the walking process and f will not be called on any other nodes.
+func Walk(root Node, f func(n Node) (Node, error)) (Node, error) {
+	replacement, err := f(root)
+	if err != nil {
+		return nil, err
+	}
+	switch node := replacement.(type) {
+	case *LambdaNode:
+		r, err := Walk(node.Expression, f)
+		if err != nil {
+			return nil, err
+		}
+		node.Expression = r
+	case *UnaryNode:
+		r, err := Walk(node.Node, f)
+		if err != nil {
+			return nil, err
+		}
+		node.Node = r
+	case *BinaryNode:
+		r, err := Walk(node.Left, f)
+		if err != nil {
+			return nil, err
+		}
+		node.Left = r
+		r, err = Walk(node.Right, f)
+		if err != nil {
+			return nil, err
+		}
+		node.Right = r
+	case *DeclarationNode:
+		r, err := Walk(node.Left, f)
+		if err != nil {
+			return nil, err
+		}
+		ident, ok := r.(*IdentifierNode)
+		if !ok {
+			return nil, errors.New("declaration node must always have an IdentifierNode")
+		}
+		node.Left = ident
+		r, err = Walk(node.Right, f)
+		if err != nil {
+			return nil, err
+		}
+		node.Right = r
+	case *FunctionNode:
+		for i := range node.Args {
+			r, err := Walk(node.Args[i], f)
+			if err != nil {
+				return nil, err
+			}
+			node.Args[i] = r
+		}
+	case *ProgramNode:
+		for i := range node.Nodes {
+			r, err := Walk(node.Nodes[i], f)
+			if err != nil {
+				return nil, err
+			}
+			node.Nodes[i] = r
+		}
+	}
+	return replacement, nil
+}

--- a/tick/ast/walk_test.go
+++ b/tick/ast/walk_test.go
@@ -1,0 +1,137 @@
+package ast_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/kapacitor/tick/ast"
+)
+
+func TestWalk(t *testing.T) {
+	// AST for `var x = lambda: "value" < 10`
+	root := &ast.ProgramNode{
+		Nodes: []ast.Node{
+			&ast.DeclarationNode{
+				Left: &ast.IdentifierNode{
+					Ident: "x",
+				},
+				Right: &ast.LambdaNode{
+					Expression: &ast.BinaryNode{
+						Operator: ast.TokenLess,
+						Left: &ast.ReferenceNode{
+							Reference: "value",
+						},
+						Right: &ast.NumberNode{
+							IsInt: true,
+							Base:  10,
+							Int64: 10,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expList := []string{
+		"*ast.ProgramNode",
+		"*ast.DeclarationNode",
+		"*ast.IdentifierNode",
+		"*ast.LambdaNode",
+		"*ast.BinaryNode",
+		"*ast.ReferenceNode",
+		"*ast.NumberNode",
+	}
+
+	list := make([]string, 0, len(expList))
+	f := func(n ast.Node) (ast.Node, error) {
+		list = append(list, reflect.TypeOf(n).String())
+		return n, nil
+	}
+
+	if _, err := ast.Walk(root, f); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expList, list) {
+		t.Errorf("unexpected walk list:\ngot\n%v\nexp\n%v\n", list, expList)
+	}
+}
+
+func TestWalk_Mutate(t *testing.T) {
+	// AST for `lambda: "value" < VAR_A AND "value" > VAR_B`
+	root := &ast.LambdaNode{
+		Expression: &ast.BinaryNode{
+			Operator: ast.TokenAnd,
+			Left: &ast.BinaryNode{
+				Operator: ast.TokenLess,
+				Left: &ast.ReferenceNode{
+					Reference: "value",
+				},
+				Right: &ast.IdentifierNode{
+					Ident: "VAR_A",
+				},
+			},
+			Right: &ast.BinaryNode{
+				Operator: ast.TokenGreater,
+				Left: &ast.ReferenceNode{
+					Reference: "value",
+				},
+				Right: &ast.IdentifierNode{
+					Ident: "VAR_B",
+				},
+			},
+		},
+	}
+
+	// Replace the IdentifierNodes with a NumberNode
+	numbers := map[string]int64{
+		"VAR_A": 42,
+		"VAR_B": 3,
+	}
+	replace := func(n ast.Node) (ast.Node, error) {
+		if ident, ok := n.(*ast.IdentifierNode); ok {
+			return &ast.NumberNode{
+				IsInt: true,
+				Int64: numbers[ident.Ident],
+				Base:  10,
+			}, nil
+		}
+		return n, nil
+	}
+
+	if _, err := ast.Walk(root, replace); err != nil {
+		t.Fatal(err)
+	}
+
+	expList := []string{
+		"*ast.LambdaNode",
+		"*ast.BinaryNode",
+		"*ast.BinaryNode",
+		"*ast.ReferenceNode",
+		"*ast.NumberNode",
+		"*ast.BinaryNode",
+		"*ast.ReferenceNode",
+		"*ast.NumberNode",
+	}
+
+	list := make([]string, 0, len(expList))
+	f := func(n ast.Node) (ast.Node, error) {
+		list = append(list, reflect.TypeOf(n).String())
+		return n, nil
+	}
+
+	if _, err := ast.Walk(root, f); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expList, list) {
+		t.Errorf("unexpected walk list:\ngot\n%v\nexp\n%v\n", list, expList)
+	}
+
+	// Check the lambda formatted lambda expression
+	expStr := `lambda: "value" < 42 AND "value" > 3`
+	str := ast.Format(root)
+	if expStr != str {
+		t.Errorf("unexpected lambda str: got %s exp %s", str, expStr)
+	}
+}

--- a/tick/fmt.go
+++ b/tick/fmt.go
@@ -1,10 +1,6 @@
 package tick
 
-import (
-	"bytes"
-
-	"github.com/influxdata/kapacitor/tick/ast"
-)
+import "github.com/influxdata/kapacitor/tick/ast"
 
 // Formats a TICKscript according to the standard.
 func Format(script string) (string, error) {
@@ -12,8 +8,5 @@ func Format(script string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var buf bytes.Buffer
-	buf.Grow(len(script))
-	root.Format(&buf, "", false)
-	return buf.String(), nil
+	return ast.Format(root), nil
 }

--- a/tick/stateful/eval_function_node.go
+++ b/tick/stateful/eval_function_node.go
@@ -61,6 +61,13 @@ func (n *EvalFunctionNode) callFunction(scope *Scope, executionState ExecutionSt
 
 	f := executionState.Funcs[n.funcName]
 
+	// Look for function on scope
+	if f == nil {
+		if dm := scope.DynamicMethod(n.funcName); dm != nil {
+			f = dynamicMethodFunc{dm: dm}
+		}
+	}
+
 	if f == nil {
 		return nil, fmt.Errorf("undefined function: %q", n.funcName)
 	}
@@ -191,4 +198,14 @@ func eval(n NodeEvaluator, scope *Scope, executionState ExecutionState) (interfa
 		return nil, fmt.Errorf("function arg expression returned unexpected type %s", retType)
 	}
 
+}
+
+type dynamicMethodFunc struct {
+	dm DynamicMethod
+}
+
+func (dmf dynamicMethodFunc) Call(args ...interface{}) (interface{}, error) {
+	return dmf.dm(nil, args...)
+}
+func (dmf dynamicMethodFunc) Reset() {
 }

--- a/tick/stateful/expr.go
+++ b/tick/stateful/expr.go
@@ -119,37 +119,3 @@ func (se *expression) Eval(scope *Scope) (interface{}, error) {
 		return nil, fmt.Errorf("expression returned unexpected type %s", typ)
 	}
 }
-
-func FindReferenceVariables(nodes ...ast.Node) []string {
-	variablesSet := make(map[string]bool, 0)
-
-	for _, node := range nodes {
-		buildReferenceVariablesSet(node, variablesSet)
-	}
-
-	variables := make([]string, 0, len(variablesSet))
-
-	for variable := range variablesSet {
-		variables = append(variables, variable)
-	}
-
-	return variables
-}
-
-// util method for findReferenceVariables, we are passing the itemsSet and not returning it
-// so we will won't to merge the maps
-func buildReferenceVariablesSet(n ast.Node, itemsSet map[string]bool) {
-	switch node := n.(type) {
-	case *ast.ReferenceNode:
-		itemsSet[node.Reference] = true
-	case *ast.UnaryNode:
-		buildReferenceVariablesSet(node.Node, itemsSet)
-	case *ast.BinaryNode:
-		buildReferenceVariablesSet(node.Left, itemsSet)
-		buildReferenceVariablesSet(node.Right, itemsSet)
-	case *ast.FunctionNode:
-		for _, arg := range node.Args {
-			buildReferenceVariablesSet(arg, itemsSet)
-		}
-	}
-}

--- a/tick/stateful/scope_pool_test.go
+++ b/tick/stateful/scope_pool_test.go
@@ -58,7 +58,7 @@ func TestExpression_RefernceVariables(t *testing.T) {
 	}
 
 	for i, expect := range expectations {
-		refVariables := stateful.FindReferenceVariables(expect.node)
+		refVariables := ast.FindReferenceVariables(expect.node)
 		if !reflect.DeepEqual(refVariables, expect.refVariables) {
 			t.Errorf("[Iteration: %v, Node: %T] Got unexpected result:\ngot: %v\nexpected: %v", i+1, expect.node, refVariables, expect.refVariables)
 		}

--- a/usr/share/bash-completion/completions/kapacitor
+++ b/usr/share/bash-completion/completions/kapacitor
@@ -84,7 +84,12 @@ _kapacitor()
             fi
             ;;
         define-handler)
-            _kapacitor_json_yaml_files "${cur}"
+            if [[ -z "${COMP_WORDS[2]}" || ("$cur" = "${COMP_WORDS[2]}" && -z "${COMP_WORDS[3]}") ]]
+            then
+                words=$(_kapacitor_list topics "$cur")
+            else
+                _kapacitor_json_yaml_files "${cur}"
+            fi
             ;;
         replay)
             case "$prev" in
@@ -151,8 +156,23 @@ _kapacitor()
             ;;
         delete|list)
             case "${COMP_WORDS[2]}" in
-                tasks|templates|recordings|replays|handlers|topics|service-tests)
+                tasks|templates|recordings|replays|topics|service-tests)
                     words=$(_kapacitor_list "${COMP_WORDS[2]}" "$cur")
+                    ;;
+                handlers)
+                    case "${COMP_WORDS[1]}" in
+                        list)
+                            words=$(_kapacitor_list handlers "$cur")
+                            ;;
+                        delete)
+                            if [[ -z "${COMP_WORDS[3]}" || ("$cur" = "${COMP_WORDS[3]}" && -z "${COMP_WORDS[4]}") ]]
+                            then
+                                words=$(_kapacitor_list topics "$cur")
+                            else
+                                words=$(_kapacitor_list handlers "$cur")
+                            fi
+                            ;;
+                    esac
                     ;;
                 *)
                     words='tasks templates recordings replays handlers topics service-tests'
@@ -163,7 +183,12 @@ _kapacitor()
             words=$(_kapacitor_list templates "$cur")
             ;;
         show-handler)
-            words=$(_kapacitor_list handlers "$cur")
+            if [[ -z "${COMP_WORDS[2]}" || ("$cur" = "${COMP_WORDS[2]}" && -z "${COMP_WORDS[3]}") ]]
+            then
+                words=$(_kapacitor_list topics "$cur")
+            else
+                words=$(_kapacitor_list handlers "$cur")
+            fi
             ;;
         show-topic)
             words=$(_kapacitor_list topics "$cur")

--- a/where.go
+++ b/where.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
+	"github.com/influxdata/kapacitor/tick/ast"
 	"github.com/influxdata/kapacitor/tick/stateful"
 )
 
@@ -66,7 +67,7 @@ func (w *WhereNode) runWhere(snapshot []byte) error {
 				w.expressions[p.Group] = expr
 				mu.Unlock()
 
-				scopePool = stateful.NewScopePool(stateful.FindReferenceVariables(w.w.Lambda.Expression))
+				scopePool = stateful.NewScopePool(ast.FindReferenceVariables(w.w.Lambda.Expression))
 				w.scopePools[p.Group] = scopePool
 			}
 			if pass, err := EvalPredicate(expr, scopePool, p.Time, p.Fields, p.Tags); pass {
@@ -103,7 +104,7 @@ func (w *WhereNode) runWhere(snapshot []byte) error {
 				w.expressions[b.Group] = expr
 				mu.Unlock()
 
-				scopePool = stateful.NewScopePool(stateful.FindReferenceVariables(w.w.Lambda.Expression))
+				scopePool = stateful.NewScopePool(ast.FindReferenceVariables(w.w.Lambda.Expression))
 				w.scopePools[b.Group] = scopePool
 			}
 			points := b.Points


### PR DESCRIPTION
This PR depends on #1209 to be merged first.

Match conditions can now be specified on any handler and it will filter down the events that the handler handles.


- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Document how to write match conditions