### PR TITLE
Example TICKScript improvements

### DIFF
--- a/examples/telegraf/cpu/cpu_alert_batch.tick
+++ b/examples/telegraf/cpu/cpu_alert_batch.tick
@@ -24,7 +24,7 @@ var every = 10s
 
 // Dataframe
 var data = batch
-  |query('''SELECT mean(usage_user) AS stat FROM "telegraf"."autogen"."cpu" WHERE cpu = 'cpu-total' ''')
+  |query('''SELECT 100 - mean(usage_idle) AS stat FROM "telegraf"."autogen"."cpu" WHERE cpu = 'cpu-total' ''')
     .period(period)
     .every(every)
     .groupBy('host')

--- a/examples/telegraf/cpu/cpu_alert_stream.tick
+++ b/examples/telegraf/cpu/cpu_alert_stream.tick
@@ -30,10 +30,12 @@ var data = stream
     .measurement('cpu')
     .groupBy('host')
     .where(lambda: "cpu" == 'cpu-total')
+  |eval(lambda: 100.0 - "usage_idle")
+    .as('used')
   |window()
     .period(period)
     .every(every)
-  |mean('usage_user')
+  |mean('used')
     .as('stat')
 
 // Thresholds

--- a/examples/telegraf/disk/disk_alert_batch.tick
+++ b/examples/telegraf/disk/disk_alert_batch.tick
@@ -26,12 +26,12 @@ var data = batch
     |query('''SELECT mean(used_percent) AS stat FROM "telegraf"."autogen"."disk" WHERE path = '/' ''')
         .period(period)
         .every(every)
-        .groupBy('host')
+        .groupBy('host', 'path')
 
 // Thresholds
 var alert = data
     |alert()
-        .id('{{ index .Tags "host"}}/disk_used')
+        .id('{{ index .Tags "host"}}/disk_used/{{ index .Tags "path" }}')
         .message('{{ .ID }}:{{ index .Fields "stat" }}')
         .info(lambda: "stat" > info)
         .warn(lambda: "stat" > warn)

--- a/examples/telegraf/disk/disk_alert_stream.tick
+++ b/examples/telegraf/disk/disk_alert_stream.tick
@@ -27,7 +27,7 @@ var data = stream
         .database('telegraf')
         .retentionPolicy('autogen')
         .measurement('disk')
-        .groupBy('host')
+        .groupBy('host', 'path')
     |window()
         .period(period)
         .every(every)
@@ -37,7 +37,7 @@ var data = stream
 // Thresholds
 var alert = data
     |alert()
-        .id('{{ index .Tags "host"}}/disk_used')
+        .id('{{ index .Tags "host"}}/disk_used/{{ index .Tags "path" }}')
         .message('{{ .ID }}:{{ index .Fields "stat" }}')
         .info(lambda: "stat" > info)
         .warn(lambda: "stat" > warn)


### PR DESCRIPTION
Hey Folks,

I've discovered some minor issues with your examples and wanted to share my experiences:

1. The cpu example is only alerting when `usage_user` exceeds the thresholds. Problems like high IOWait or System usage are not alerted. It should check the threshold against everything that is **not idle**.

2. The disk example checks the threshold agains the `mean` of **all disks available**. This means if one disk is full but another one almost empty, there is no alert. It should group by path and then alert with the path as well.

Cheers,
Christian