### PR TITLE
Add repair logic for broken indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ kapacitor define-handler system aggregate_by_1m.yaml
     Also empty string on a tag value is now a sufficient condition for the default conditions to be applied.
     See [#1233](https://github.com/influxdata/kapacitor/pull/1233) for more information.
 - [#1068](https://github.com/influxdata/kapacitor/issues/1068): Fix dot view syntax to use xlabels and not create invalid quotes.
+- [#1295](https://github.com/influxdata/kapacitor/issues/1295): Fix curruption of recordings list after deleting all recordings.
 
 ## v1.2.0 [2017-01-23]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ kapacitor define-handler system aggregate_by_1m.yaml
     An automatic migration from old to new handler definitions will be performed during startup.
     See the updated API docs.
 - [#1286](https://github.com/influxdata/kapacitor/issues/1286): Default HipChat URL should be blank
+- [#507](https://github.com/influxdata/kapacitor/issues/507): Add API endpoint for performing Kapacitor database backups.
 
 ### Bugfixes
 

--- a/client/API.md
+++ b/client/API.md
@@ -8,6 +8,7 @@
 * [Replays](#replays)
 * [Alerts](#alerts)
 * [Configuration](#configuration)
+* [Storage](#storage)
 * [Testing Services](#testing-services)
 * [Miscellaneous](#miscellaneous)
 
@@ -2115,6 +2116,62 @@ POST /kapacitor/v1/config/influxdb/remote
 | 200  | Success                                                   |
 | 403  | Config override service not enabled                       |
 | 404  | The specified configuration section/option does not exist |
+
+## Storage
+
+Kapacitor exposes some operations that can be performed on the underlying storage.
+
+>WARNING: Everything storage operation is directly manipulating the underlying storage database.
+Always make a backup of the database before performing any of these operations.
+
+### Backing up the Storage
+
+Making a GET request to `/kapacitor/v1/storage/backup` will return a dump of the Kapacitor database.
+To restore from a backup replace the `kapacitor.db` file with the contents of the backup request.
+
+```
+# Create a backup.
+curl http://localhost:9092/kapacitor/v1/storage/backup > kapacitor.db
+```
+
+```
+# Restore a backup.
+# The destination path is dependent on your configuration.
+cp kapacitor.db ~/.kapacitor/kapacitor.db
+```
+
+### Stores
+
+Kapacitor's underlying storage system is organized into different stores.
+Various actions can be performed on each individual store.
+
+>WARNING: Everything storage operation is directly manipulating the underlying storage database.
+Always make a backup of the database before performing any of these operations.
+
+Available actions:
+
+| Action  | Description                                                           |
+| ------  | -----------                                                           |
+| rebuild | Rebuild all indexes in a store, this operation can be very expensive. |
+
+To perform an action make a POST request to the `/kapacitor/v1/storage/stores/<name of store>`
+
+#### Example
+
+```
+POST /kapacitor/v1/storage/stores/tasks
+{
+    "action" : "rebuild"
+}
+```
+
+#### Response
+
+| Code | Meaning                            |
+| ---- | -------                            |
+| 204  | Success                            |
+| 400  | Unknown action                     |
+| 404  | The specified store does not exist |
 
 ## Testing Services
 

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -2185,13 +2184,12 @@ func (c *Client) DoStorageAction(l Link, opt StorageActionOptions) error {
 	return nil
 }
 
-// StorageBackup requests a backup of all storage from Kapacitor.
+// Backup requests a backup of all storage from Kapacitor.
 // A short read is possible, to verify that the backup was successful
 // check that the number of bytes read matches the returned size.
-func (c *Client) StorageBackup() (int64, io.ReadCloser, error) {
+func (c *Client) Backup() (int64, io.ReadCloser, error) {
 	u := *c.url
 	u.Path = backupPath
-	log.Println("D! PATH", backupPath)
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -254,6 +254,8 @@ func (s *Server) appendStorageService() {
 	l := s.LogService.NewLogger("[storage] ", log.LstdFlags)
 	srv := storage.NewService(s.config.Storage, l)
 
+	srv.HTTPDService = s.HTTPDService
+
 	s.StorageService = srv
 	s.AppendService("storage", srv)
 }

--- a/server/server_helper_test.go
+++ b/server/server_helper_test.go
@@ -54,8 +54,11 @@ func NewServer(c *server.Config) *Server {
 	return &s
 }
 
-func (s *Server) Restart() {
+func (s *Server) Stop() {
 	s.Server.Close()
+}
+
+func (s *Server) Start() {
 	srv, err := server.New(s.Config, s.buildInfo, s.ls)
 	if err != nil {
 		panic(err.Error())
@@ -64,6 +67,11 @@ func (s *Server) Restart() {
 		panic(err.Error())
 	}
 	s.Server = srv
+}
+
+func (s *Server) Restart() {
+	s.Stop()
+	s.Start()
 }
 
 // OpenServer opens a test server.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9021,7 +9021,7 @@ func TestStorage_Backup(t *testing.T) {
 	}
 
 	// Perform backup
-	size, r, err := cli.StorageBackup()
+	size, r, err := cli.Backup()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8967,3 +8967,110 @@ stream
 		}
 	}
 }
+
+func TestStorage_Rebuild(t *testing.T) {
+	s, cli := OpenDefaultServer()
+	defer s.Close()
+
+	storages, err := cli.ListStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, storage := range storages.Storage {
+		t.Log(storage.Link)
+		err := cli.DoStorageAction(storage.Link, client.StorageActionOptions{
+			Action: client.StorageRebuild,
+		})
+		if err != nil {
+			t.Errorf("error rebuilding storage %q: %v", storage.Name, err)
+		}
+	}
+}
+
+func TestStorage_Backup(t *testing.T) {
+	s, cli := OpenDefaultServer()
+	defer s.Close()
+
+	// Create a task
+	id := "testTaskID"
+	ttype := client.StreamTask
+	dbrps := []client.DBRP{
+		{
+			Database:        "mydb",
+			RetentionPolicy: "myrp",
+		},
+		{
+			Database:        "otherdb",
+			RetentionPolicy: "default",
+		},
+	}
+	tick := `stream
+    |from()
+        .measurement('test')
+`
+	task, err := cli.CreateTask(client.CreateTaskOptions{
+		ID:         id,
+		Type:       ttype,
+		DBRPs:      dbrps,
+		TICKscript: tick,
+		Status:     client.Disabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Perform backup
+	size, r, err := cli.StorageBackup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	backup, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := int64(len(backup)), size; got != exp {
+		t.Fatalf("unexpected backup size got %d exp %d", got, exp)
+	}
+
+	// Stop the server
+	s.Stop()
+
+	// Restore from backup
+	if err := ioutil.WriteFile(s.Config.Storage.BoltDBPath, backup, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the server again
+	s.Start()
+
+	// Check that the task was restored
+	ti, err := cli.Task(task.Link, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ti.Error != "" {
+		t.Fatal(ti.Error)
+	}
+	if ti.ID != id {
+		t.Fatalf("unexpected id got %s exp %s", ti.ID, id)
+	}
+	if ti.Type != client.StreamTask {
+		t.Fatalf("unexpected type got %v exp %v", ti.Type, client.StreamTask)
+	}
+	if ti.Status != client.Disabled {
+		t.Fatalf("unexpected status got %v exp %v", ti.Status, client.Disabled)
+	}
+	if !reflect.DeepEqual(ti.DBRPs, dbrps) {
+		t.Fatalf("unexpected dbrps got %s exp %s", ti.DBRPs, dbrps)
+	}
+	if ti.TICKscript != tick {
+		t.Fatalf("unexpected TICKscript got %s exp %s", ti.TICKscript, tick)
+	}
+	dot := "digraph testTaskID {\nstream0 -> from1;\n}"
+	if ti.Dot != dot {
+		t.Fatalf("unexpected dot\ngot\n%s\nexp\n%s\n", ti.Dot, dot)
+	}
+}

--- a/services/alert/dao.go
+++ b/services/alert/dao.go
@@ -44,6 +44,8 @@ type HandlerSpecDAO interface {
 	// More results may exist while the number of returned items is equal to limit.
 	List(topic, pattern string, offset, limit int) ([]HandlerSpec, error)
 	ListTx(tx storage.ReadOnlyTx, topic, pattern string, offset, limit int) ([]HandlerSpec, error)
+
+	Rebuild() error
 }
 
 //--------------------------------------------------------------------
@@ -210,6 +212,10 @@ func (kv *handlerSpecKV) listHelper(objects []storage.BinaryObject, err error) (
 	return specs, nil
 }
 
+func (kv *handlerSpecKV) Rebuild() error {
+	return kv.store.Rebuild()
+}
+
 var (
 	ErrNoTopicStateExists = errors.New("no topic state exists")
 )
@@ -231,6 +237,8 @@ type TopicStateDAO interface {
 	// Offset and limit are pagination bounds. Offset is inclusive starting at index 0.
 	// More results may exist while the number of returned items is equal to limit.
 	List(pattern string, offset, limit int) ([]TopicState, error)
+
+	Rebuild() error
 }
 
 const topicStateVersion = 1
@@ -325,4 +333,8 @@ func (kv *topicStateKV) List(pattern string, offset, limit int) ([]TopicState, e
 		specs[i] = *t
 	}
 	return specs, nil
+}
+
+func (kv *topicStateKV) Rebuild() error {
+	return kv.store.Rebuild()
 }

--- a/services/config/dao.go
+++ b/services/config/dao.go
@@ -27,6 +27,8 @@ type OverrideDAO interface {
 
 	// List all overrides whose ID starts with the given prefix
 	List(prefix string) ([]Override, error)
+
+	Rebuild() error
 }
 
 //--------------------------------------------------------------------
@@ -125,4 +127,8 @@ func (kv *overrideKV) List(prefix string) ([]Override, error) {
 		overrides[i] = *o
 	}
 	return overrides, nil
+}
+
+func (kv *overrideKV) Rebuild() error {
+	return kv.store.Rebuild()
 }

--- a/services/config/service.go
+++ b/services/config/service.go
@@ -46,6 +46,7 @@ type Service struct {
 
 	StorageService interface {
 		Store(namespace string) storage.Interface
+		Register(name string, store storage.StoreActioner)
 	}
 	HTTPDService interface {
 		AddRoutes([]httpd.Route) error
@@ -62,8 +63,12 @@ func NewService(c Config, config interface{}, l *log.Logger, updates chan<- Conf
 	}
 }
 
-// The storage namespace for all configuration override data.
-const configNamespace = "config_overrides"
+const (
+	// Public name of overrides store
+	overridesAPIName = "overrides"
+	// The storage namespace for all configuration override data.
+	configNamespace = "config_overrides"
+)
 
 func (s *Service) Open() error {
 	store := s.StorageService.Store(configNamespace)
@@ -72,6 +77,7 @@ func (s *Service) Open() error {
 		return err
 	}
 	s.overrides = overrides
+	s.StorageService.Register(overridesAPIName, s.overrides)
 
 	// Cache element keys
 	if elementKeys, err := override.ElementKeys(s.config); err != nil {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -61,7 +61,8 @@ type Route struct {
 	Method      string
 	Pattern     string
 	HandlerFunc interface{}
-	noJSON      bool
+	NoGzip      bool
+	NoJSON      bool
 }
 
 // Handler represents an HTTP handler for the Kapacitor API server.
@@ -201,31 +202,31 @@ func NewHandler(
 			Method:      "GET",
 			Pattern:     BasePath + "/debug/pprof/",
 			HandlerFunc: servePprof,
-			noJSON:      true,
+			NoJSON:      true,
 		},
 		{
 			Method:      "GET",
 			Pattern:     BasePath + "/debug/pprof/cmdline",
 			HandlerFunc: pprof.Cmdline,
-			noJSON:      true,
+			NoJSON:      true,
 		},
 		{
 			Method:      "GET",
 			Pattern:     BasePath + "/debug/pprof/profile",
 			HandlerFunc: pprof.Profile,
-			noJSON:      true,
+			NoJSON:      true,
 		},
 		{
 			Method:      "GET",
 			Pattern:     BasePath + "/debug/pprof/symbol",
 			HandlerFunc: pprof.Symbol,
-			noJSON:      true,
+			NoJSON:      true,
 		},
 		{
 			Method:      "GET",
 			Pattern:     BasePath + "/debug/pprof/trace",
 			HandlerFunc: pprof.Trace,
-			noJSON:      true,
+			NoJSON:      true,
 		},
 		{
 			Method:      "GET",
@@ -300,10 +301,10 @@ func (h *Handler) addRawRoute(r Route) error {
 	}
 
 	// Set basic handlers for all requests
-	if !r.noJSON {
+	if !r.NoJSON {
 		handler = jsonContent(handler)
 	}
-	if h.allowGzip {
+	if !r.NoGzip && h.allowGzip {
 		handler = gzipFilter(handler)
 	}
 	handler = versionHeader(handler, h)

--- a/services/replay/dao.go
+++ b/services/replay/dao.go
@@ -40,8 +40,8 @@ type RecordingDAO interface {
 	// More results may exist while the number of returned items is equal to limit.
 	List(pattern string, offset, limit int) ([]Recording, error)
 
-	// Repair fixes all indexes of the data.
-	Repair() error
+	// Rebuild fixes all indexes of the data.
+	Rebuild() error
 }
 
 //--------------------------------------------------------------------
@@ -127,8 +127,8 @@ func newRecordingKV(store storage.Interface) (*recordingKV, error) {
 	}, nil
 }
 
-func (kv *recordingKV) Repair() error {
-	return kv.store.Repair()
+func (kv *recordingKV) Rebuild() error {
+	return kv.store.Rebuild()
 }
 
 func (kv *recordingKV) error(err error) error {
@@ -202,6 +202,9 @@ type ReplayDAO interface {
 	// Offset and limit are pagination bounds. Offset is inclusive starting at index 0.
 	// More results may exist while the number of returned items is equal to limit.
 	List(pattern string, offset, limit int) ([]Replay, error)
+
+	// Rebuild rebuilds all indexes for the storage
+	Rebuild() error
 }
 
 type Clock int
@@ -317,4 +320,8 @@ func (kv *replayKV) List(pattern string, offset, limit int) ([]Replay, error) {
 		replays[i] = *r
 	}
 	return replays, nil
+}
+
+func (kv *replayKV) Rebuild() error {
+	return kv.store.Rebuild()
 }

--- a/services/replay/dao.go
+++ b/services/replay/dao.go
@@ -39,6 +39,9 @@ type RecordingDAO interface {
 	// Offset and limit are pagination bounds. Offset is inclusive starting at index 0.
 	// More results may exist while the number of returned items is equal to limit.
 	List(pattern string, offset, limit int) ([]Recording, error)
+
+	// Repair fixes all indexes of the data.
+	Repair() error
 }
 
 //--------------------------------------------------------------------
@@ -122,6 +125,10 @@ func newRecordingKV(store storage.Interface) (*recordingKV, error) {
 	return &recordingKV{
 		store: istore,
 	}, nil
+}
+
+func (kv *recordingKV) Repair() error {
+	return kv.store.Repair()
 }
 
 func (kv *recordingKV) error(err error) error {

--- a/services/storage/api.go
+++ b/services/storage/api.go
@@ -1,0 +1,133 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/boltdb/bolt"
+	client "github.com/influxdata/kapacitor/client/v1"
+	"github.com/influxdata/kapacitor/services/httpd"
+)
+
+const (
+	storagePath            = "/storage"
+	storagePathAnchored    = storagePath + "/"
+	backupPath             = storagePath + "/backup"
+	storesPath             = storagePath + "/stores"
+	storesPathAnchored     = storesPath + "/"
+	storesBasePath         = httpd.BasePath + storesPath
+	storesBasePathAnchored = httpd.BasePath + storesPathAnchored
+)
+
+type APIServer struct {
+	Registrar StoreActionerRegistrar
+	DB        *bolt.DB
+	routes    []httpd.Route
+	logger    *log.Logger
+
+	HTTPDService interface {
+		AddRoutes([]httpd.Route) error
+		DelRoutes([]httpd.Route)
+	}
+}
+
+func (s *APIServer) Open() error {
+	s.routes = []httpd.Route{
+		{
+			Method:      "GET",
+			Pattern:     backupPath,
+			HandlerFunc: s.handleBackup,
+			// Do not gzip the data so that Content-Length is preserved.
+			NoGzip: true,
+			NoJSON: true,
+		},
+		{
+			Method:      "GET",
+			Pattern:     storesPath,
+			HandlerFunc: s.handleListStores,
+		},
+		{
+			Method:      "POST",
+			Pattern:     storagePathAnchored,
+			HandlerFunc: s.handleStoreAction,
+		},
+	}
+	err := s.HTTPDService.AddRoutes(s.routes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *APIServer) Close() error {
+	s.HTTPDService.DelRoutes(s.routes)
+	return nil
+}
+
+func (s *APIServer) handleBackup(w http.ResponseWriter, r *http.Request) {
+	err := s.DB.View(func(tx *bolt.Tx) error {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="kapacitor.db"`)
+		w.Header().Set("Content-Length", strconv.Itoa(int(tx.Size())))
+		w.WriteHeader(http.StatusOK)
+		_, err := tx.WriteTo(w)
+		return err
+	})
+	if err != nil {
+		// We only log the error since we can't send it to the client
+		// since the headers have already been sent.
+		// The client can simply check that the Content-Length matches
+		// the amount of data to ensure a successful backup was performed.
+		s.logger.Println("E! failed to send backup data:", err)
+	}
+}
+
+func (s *APIServer) handleListStores(w http.ResponseWriter, r *http.Request) {
+	storages := s.Registrar.List()
+	list := client.StorageList{
+		Link:    client.Link{Relation: client.Self, Href: storesBasePath},
+		Storage: make([]client.Storage, len(storages)),
+	}
+	for i, name := range storages {
+		list.Storage[i] = client.Storage{
+			Link: client.Link{Relation: client.Self, Href: path.Join(storesBasePath, name)},
+			Name: name,
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(httpd.MarshalJSON(list, true))
+}
+
+func (s *APIServer) handleStoreAction(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimPrefix(r.URL.Path, storesBasePathAnchored)
+	store, ok := s.Registrar.Get(name)
+	if !ok {
+		httpd.HttpError(w, fmt.Sprintf("unknown storage %q", name), true, http.StatusNotFound)
+		return
+	}
+
+	action := client.StorageActionOptions{}
+	err := json.NewDecoder(r.Body).Decode(&action)
+	if err != nil {
+		httpd.HttpError(w, fmt.Sprintf("failed to unmarshal storage action %v", err), true, http.StatusBadRequest)
+		return
+	}
+
+	switch action.Action {
+	case client.StorageRebuild:
+		err := store.Rebuild()
+		if err != nil {
+			httpd.HttpError(w, fmt.Sprintf("failed to rebuild %q: %v", name, err), true, http.StatusInternalServerError)
+			return
+		}
+	default:
+		httpd.HttpError(w, fmt.Sprintf("unkown storage action %q", action.Action), true, http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/services/storage/indexed.go
+++ b/services/storage/indexed.go
@@ -372,16 +372,18 @@ func (s *IndexedStore) list(tx ReadOnlyTx, index, pattern string, offset, limit 
 	return objects, nil
 }
 
-func (s *IndexedStore) Repair() error {
+// Rebuild completely rebuilds all indexes for the store.
+func (s *IndexedStore) Rebuild() error {
 	return s.store.Update(func(tx Tx) error {
-		return s.RepairTx(tx)
+		return s.RebuildTx(tx)
 	})
 }
 
-func (s *IndexedStore) RepairTx(tx Tx) error {
-	// Clean all indexes
+// Rebuild completely rebuilds all indexes for the store using the provided transaction.
+func (s *IndexedStore) RebuildTx(tx Tx) error {
+	// Delete all indexes
 	for _, idx := range s.indexes {
-		if err := s.cleanIndex(tx, idx.Name); err != nil {
+		if err := s.deleteIndex(tx, idx.Name); err != nil {
 			return errors.Wrapf(err, "failed to clean index %s", idx.Name)
 		}
 	}
@@ -411,8 +413,8 @@ func (s *IndexedStore) RepairTx(tx Tx) error {
 	return nil
 }
 
-// Clean index deletes all indexes entries.
-func (s *IndexedStore) cleanIndex(tx Tx, index string) error {
+// deleteIndex deletes all indexes entries.
+func (s *IndexedStore) deleteIndex(tx Tx, index string) error {
 	entries, err := tx.List(s.indexKey(index, "") + "/")
 	if err != nil {
 		return err

--- a/services/storage/registrar.go
+++ b/services/storage/registrar.go
@@ -1,0 +1,49 @@
+package storage
+
+import "sync"
+
+// StoreActioner exposes and interface for various actions that can be performed on a store.
+type StoreActioner interface {
+	// Rebuild the entire store, this should be considered to be an expensive action.
+	Rebuild() error
+}
+
+type StoreActionerRegistrar interface {
+	List() []string
+	Register(name string, store StoreActioner)
+	Get(name string) (StoreActioner, bool)
+}
+
+func NewStorageResitrar() StoreActionerRegistrar {
+	return &storeActionerRegistrar{
+		stores: make(map[string]StoreActioner),
+	}
+}
+
+type storeActionerRegistrar struct {
+	mu     sync.RWMutex
+	stores map[string]StoreActioner
+}
+
+func (sr *storeActionerRegistrar) List() []string {
+	sr.mu.RLock()
+	defer sr.mu.RUnlock()
+	list := make([]string, 0, len(sr.stores))
+	for name := range sr.stores {
+		list = append(list, name)
+	}
+	return list
+}
+
+func (sr *storeActionerRegistrar) Register(name string, store StoreActioner) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	sr.stores[name] = store
+}
+
+func (sr *storeActionerRegistrar) Get(name string) (store StoreActioner, ok bool) {
+	sr.mu.RLock()
+	defer sr.mu.RUnlock()
+	store, ok = sr.stores[name]
+	return
+}

--- a/services/storage/storagetest/storage.go
+++ b/services/storage/storagetest/storage.go
@@ -3,12 +3,14 @@ package storagetest
 import "github.com/influxdata/kapacitor/services/storage"
 
 type TestStore struct {
-	versions storage.Versions
+	versions  storage.Versions
+	registrar storage.StoreActionerRegistrar
 }
 
 func New() TestStore {
 	return TestStore{
-		versions: storage.NewVersions(storage.NewMemStore("versions")),
+		versions:  storage.NewVersions(storage.NewMemStore("versions")),
+		registrar: storage.NewStorageResitrar(),
 	}
 }
 
@@ -18,4 +20,7 @@ func (s TestStore) Store(name string) storage.Interface {
 
 func (s TestStore) Versions() storage.Versions {
 	return s.versions
+}
+func (s TestStore) Register(name string, store storage.StoreActioner) {
+	s.registrar.Register(name, store)
 }

--- a/services/task_store/dao.go
+++ b/services/task_store/dao.go
@@ -41,6 +41,8 @@ type TaskDAO interface {
 	// Offset and limit are pagination bounds. Offset is inclusive starting at index 0.
 	// More results may exist while the number of returned items is equal to limit.
 	List(pattern string, offset, limit int) ([]Task, error)
+
+	Rebuild() error
 }
 
 // Data access object for Template data.
@@ -244,6 +246,10 @@ func (kv *taskKV) List(pattern string, offset, limit int) ([]Task, error) {
 		tasks[i] = *t
 	}
 	return tasks, nil
+}
+
+func (kv *taskKV) Rebuild() error {
+	return kv.store.Rebuild()
 }
 
 const (

--- a/services/task_store/service.go
+++ b/services/task_store/service.go
@@ -42,6 +42,7 @@ type Service struct {
 	snapshotInterval time.Duration
 	StorageService   interface {
 		Store(namespace string) storage.Interface
+		Register(name string, store storage.StoreActioner)
 	}
 	HTTPDService interface {
 		AddRoutes([]httpd.Route) error
@@ -71,8 +72,12 @@ func NewService(conf Config, l *log.Logger) *Service {
 	}
 }
 
-// The storage namespace for all task data.
-const taskNamespace = "task_store"
+const (
+	// Public name for the task storage layer
+	tasksAPIName = "tasks"
+	// The storage namespace for all task data.
+	taskNamespace = "task_store"
+)
 
 func (ts *Service) Open() error {
 	// Create DAO
@@ -82,6 +87,7 @@ func (ts *Service) Open() error {
 		return err
 	}
 	ts.tasks = tasksDAO
+	ts.StorageService.Register(tasksAPIName, ts.tasks)
 	ts.templates = newTemplateKV(store)
 	ts.snapshots = newSnapshotKV(store)
 

--- a/usr/share/bash-completion/completions/kapacitor
+++ b/usr/share/bash-completion/completions/kapacitor
@@ -186,6 +186,8 @@ _kapacitor()
         show-topic)
             words=$(_kapacitor_list topics "$cur")
             ;;
+        backup)
+            ;;
         level)
             words='debug info warn error'
             ;;
@@ -200,7 +202,7 @@ _kapacitor()
             ;;
         *)
             words='record define define-template define-topic-handler replay replay-live enable disable \
-                reload delete list show show-template show-topic-handler show-topic level stats version vars service-tests help'
+                reload delete list show show-template show-topic-handler show-topic backup level stats version vars service-tests help'
             ;;
     esac
     if [ -z "$COMPREPLY" ]

--- a/vendor/github.com/boltdb/bolt/.gitrepo
+++ b/vendor/github.com/boltdb/bolt/.gitrepo
@@ -4,8 +4,8 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = http://github.com/boltdb/bolt.git
+	remote = https://github.com/boltdb/bolt.git
 	branch = master
-	commit = 05e441d7b3ded9164c5b912521504e7711dd0ba2
-	parent = 99c9d17eb5416a4fdce216714d4585bb0847a582
+	commit = e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
+	parent = bc2ebfabb1c756fb69dbcf23f4806b845adb3d1f
 	cmdver = 0.3.0

--- a/vendor/github.com/boltdb/bolt/README.md
+++ b/vendor/github.com/boltdb/bolt/README.md
@@ -15,11 +15,11 @@ and setting values. That's it.
 
 ## Project Status
 
-Bolt is stable and the API is fixed. Full unit test coverage and randomized
-black box testing are used to ensure database consistency and thread safety.
-Bolt is currently in high-load production environments serving databases as
-large as 1TB. Many companies such as Shopify and Heroku use Bolt-backed
-services every day.
+Bolt is stable, the API is fixed, and the file format is fixed. Full unit
+test coverage and randomized black box testing are used to ensure database
+consistency and thread safety. Bolt is currently used in high-load production
+environments serving databases as large as 1TB. Many companies such as
+Shopify and Heroku use Bolt-backed services every day.
 
 ## Table of Contents
 
@@ -209,7 +209,7 @@ and then safely close your transaction if an error is returned. This is the
 recommended way to use Bolt transactions.
 
 However, sometimes you may want to manually start and end your transactions.
-You can use the `Tx.Begin()` function directly but **please** be sure to close
+You can use the `DB.Begin()` function directly but **please** be sure to close
 the transaction.
 
 ```go
@@ -313,7 +313,7 @@ func (s *Store) CreateUser(u *User) error {
         // Generate ID for the user.
         // This returns an error only if the Tx is closed or not writeable.
         // That can't happen in an Update() call so I ignore the error check.
-        id, _ = b.NextSequence()
+        id, _ := b.NextSequence()
         u.ID = int(id)
 
         // Marshal user data into bytes.
@@ -395,7 +395,7 @@ db.View(func(tx *bolt.Tx) error {
 	c := tx.Bucket([]byte("MyBucket")).Cursor()
 
 	prefix := []byte("1234")
-	for k, v := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, v = c.Next() {
+	for k, v := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
 		fmt.Printf("key=%s, value=%s\n", k, v)
 	}
 
@@ -448,6 +448,10 @@ db.View(func(tx *bolt.Tx) error {
 })
 ```
 
+Please note that keys and values in `ForEach()` are only valid while
+the transaction is open. If you need to use a key or value outside of
+the transaction, you must use `copy()` to copy it to another byte
+slice.
 
 ### Nested buckets
 
@@ -459,6 +463,55 @@ func (*Bucket) CreateBucket(key []byte) (*Bucket, error)
 func (*Bucket) CreateBucketIfNotExists(key []byte) (*Bucket, error)
 func (*Bucket) DeleteBucket(key []byte) error
 ```
+
+Say you had a multi-tenant application where the root level bucket was the account bucket. Inside of this bucket was a sequence of accounts which themselves are buckets. And inside the sequence bucket you could have many buckets pertaining to the Account itself (Users, Notes, etc) isolating the information into logical groupings.
+
+```go
+
+// createUser creates a new user in the given account.
+func createUser(accountID int, u *User) error {
+    // Start the transaction.
+    tx, err := db.Begin(true)
+    if err != nil {
+        return err
+    }
+    defer tx.Rollback()
+
+    // Retrieve the root bucket for the account.
+    // Assume this has already been created when the account was set up.
+    root := tx.Bucket([]byte(strconv.FormatUint(accountID, 10)))
+
+    // Setup the users bucket.
+    bkt, err := root.CreateBucketIfNotExists([]byte("USERS"))
+    if err != nil {
+        return err
+    }
+
+    // Generate an ID for the new user.
+    userID, err := bkt.NextSequence()
+    if err != nil {
+        return err
+    }
+    u.ID = userID
+
+    // Marshal and save the encoded user.
+    if buf, err := json.Marshal(u); err != nil {
+        return err
+    } else if err := bkt.Put([]byte(strconv.FormatUint(u.ID, 10)), buf); err != nil {
+        return err
+    }
+
+    // Commit the transaction.
+    if err := tx.Commit(); err != nil {
+        return err
+    }
+
+    return nil
+}
+
+```
+
+
 
 
 ### Database backups
@@ -715,6 +768,9 @@ Here are a few things to note when evaluating and using Bolt:
   can be reused by a new page or can be unmapped from virtual memory and you'll
   see an `unexpected fault address` panic when accessing it.
 
+* Bolt uses an exclusive write lock on the database file so it cannot be
+  shared by multiple processes.
+
 * Be careful when using `Bucket.FillPercent`. Setting a high fill percent for
   buckets that have random inserts will cause your database to have very poor
   page utilization.
@@ -807,6 +863,7 @@ them via pull request.
 
 Below is a list of public, open source projects that use Bolt:
 
+* [BoltDbWeb](https://github.com/evnix/boltdbweb) - A web based GUI for BoltDB files.
 * [Operation Go: A Routine Mission](http://gocode.io) - An online programming game for Golang using Bolt for user accounts and a leaderboard.
 * [Bazil](https://bazil.org/) - A file system that lets your data reside where it is most convenient for it to reside.
 * [DVID](https://github.com/janelia-flyem/dvid) - Added Bolt as optional storage engine and testing it against Basho-tuned leveldb.
@@ -825,7 +882,6 @@ Below is a list of public, open source projects that use Bolt:
 * [cayley](https://github.com/google/cayley) - Cayley is an open-source graph database using Bolt as optional backend.
 * [bleve](http://www.blevesearch.com/) - A pure Go search engine similar to ElasticSearch that uses Bolt as the default storage backend.
 * [tentacool](https://github.com/optiflows/tentacool) - REST api server to manage system stuff (IP, DNS, Gateway...) on a linux server.
-* [SkyDB](https://github.com/skydb/sky) - Behavioral analytics database.
 * [Seaweed File System](https://github.com/chrislusf/seaweedfs) - Highly scalable distributed key~file system with O(1) disk read.
 * [InfluxDB](https://influxdata.com) - Scalable datastore for metrics, events, and real-time analytics.
 * [Freehold](http://tshannon.bitbucket.org/freehold/) - An open, secure, and lightweight platform for your files and data.
@@ -842,10 +898,18 @@ Below is a list of public, open source projects that use Bolt:
 * [Go Report Card](https://goreportcard.com/) - Go code quality report cards as a (free and open source) service.
 * [Boltdb Boilerplate](https://github.com/bobintornado/boltdb-boilerplate) - Boilerplate wrapper around bolt aiming to make simple calls one-liners.
 * [lru](https://github.com/crowdriff/lru) - Easy to use Bolt-backed Least-Recently-Used (LRU) read-through cache with chainable remote stores.
-* [Storm](https://github.com/asdine/storm) - A simple ORM around BoltDB.
+* [Storm](https://github.com/asdine/storm) - Simple and powerful ORM for BoltDB.
 * [GoWebApp](https://github.com/josephspurrier/gowebapp) - A basic MVC web application in Go using BoltDB.
 * [SimpleBolt](https://github.com/xyproto/simplebolt) - A simple way to use BoltDB. Deals mainly with strings.
 * [Algernon](https://github.com/xyproto/algernon) - A HTTP/2 web server with built-in support for Lua. Uses BoltDB as the default database backend.
 * [MuLiFS](https://github.com/dankomiocevic/mulifs) - Music Library Filesystem creates a filesystem to organise your music files.
+* [GoShort](https://github.com/pankajkhairnar/goShort) - GoShort is a URL shortener written in Golang and BoltDB for persistent key/value storage and for routing it's using high performent HTTPRouter.
+* [torrent](https://github.com/anacrolix/torrent) - Full-featured BitTorrent client package and utilities in Go. BoltDB is a storage backend in development.
+* [gopherpit](https://github.com/gopherpit/gopherpit) - A web service to manage Go remote import paths with custom domains
+* [bolter](https://github.com/hasit/bolter) - Command-line app for viewing BoltDB file in your terminal.
+* [btcwallet](https://github.com/btcsuite/btcwallet) - A bitcoin wallet.
+* [dcrwallet](https://github.com/decred/dcrwallet) - A wallet for the Decred cryptocurrency.
+* [Ironsmith](https://github.com/timshannon/ironsmith) - A simple, script-driven continuous integration (build - > test -> release) tool, with no external dependencies
+* [BoltHold](https://github.com/timshannon/bolthold) - An embeddable NoSQL store for Go types built on BoltDB
 
 If you are using Bolt in a project please send a pull request to add it to the list.

--- a/vendor/github.com/boltdb/bolt/bolt_386.go
+++ b/vendor/github.com/boltdb/bolt/bolt_386.go
@@ -5,3 +5,6 @@ const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/boltdb/bolt/bolt_amd64.go
+++ b/vendor/github.com/boltdb/bolt/bolt_amd64.go
@@ -5,3 +5,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/boltdb/bolt/bolt_arm.go
+++ b/vendor/github.com/boltdb/bolt/bolt_arm.go
@@ -1,7 +1,28 @@
 package bolt
 
+import "unsafe"
+
 // maxMapSize represents the largest mmap size supported by Bolt.
 const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned bool
+
+func init() {
+	// Simple check to see whether this arch handles unaligned load/stores
+	// correctly.
+
+	// ARM9 and older devices require load/stores to be from/to aligned
+	// addresses. If not, the lower 2 bits are cleared and that address is
+	// read in a jumbled up order.
+
+	// See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html
+
+	raw := [6]byte{0xfe, 0xef, 0x11, 0x22, 0x22, 0x11}
+	val := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&raw)) + 2))
+
+	brokenUnaligned = val != 0x11222211
+}

--- a/vendor/github.com/boltdb/bolt/bolt_arm64.go
+++ b/vendor/github.com/boltdb/bolt/bolt_arm64.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/boltdb/bolt/bolt_ppc64.go
+++ b/vendor/github.com/boltdb/bolt/bolt_ppc64.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/boltdb/bolt/bolt_ppc64le.go
+++ b/vendor/github.com/boltdb/bolt/bolt_ppc64le.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/boltdb/bolt/bolt_s390x.go
+++ b/vendor/github.com/boltdb/bolt/bolt_s390x.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/vendor/github.com/boltdb/bolt/bolt_windows.go
+++ b/vendor/github.com/boltdb/bolt/bolt_windows.go
@@ -89,7 +89,7 @@ func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) erro
 func funlock(db *DB) error {
 	err := unlockFileEx(syscall.Handle(db.lockfile.Fd()), 0, 1, 0, &syscall.Overlapped{})
 	db.lockfile.Close()
-	os.Remove(db.path+lockExt)
+	os.Remove(db.path + lockExt)
 	return err
 }
 

--- a/vendor/github.com/boltdb/bolt/bucket.go
+++ b/vendor/github.com/boltdb/bolt/bucket.go
@@ -130,9 +130,17 @@ func (b *Bucket) Bucket(name []byte) *Bucket {
 func (b *Bucket) openBucket(value []byte) *Bucket {
 	var child = newBucket(b.tx)
 
+	// If unaligned load/stores are broken on this arch and value is
+	// unaligned simply clone to an aligned byte array.
+	unaligned := brokenUnaligned && uintptr(unsafe.Pointer(&value[0]))&3 != 0
+
+	if unaligned {
+		value = cloneBytes(value)
+	}
+
 	// If this is a writable transaction then we need to copy the bucket entry.
 	// Read-only transactions can point directly at the mmap entry.
-	if b.tx.writable {
+	if b.tx.writable && !unaligned {
 		child.bucket = &bucket{}
 		*child.bucket = *(*bucket)(unsafe.Pointer(&value[0]))
 	} else {
@@ -167,9 +175,8 @@ func (b *Bucket) CreateBucket(key []byte) (*Bucket, error) {
 	if bytes.Equal(key, k) {
 		if (flags & bucketLeafFlag) != 0 {
 			return nil, ErrBucketExists
-		} else {
-			return nil, ErrIncompatibleValue
 		}
+		return nil, ErrIncompatibleValue
 	}
 
 	// Create empty, inline bucket.
@@ -326,6 +333,28 @@ func (b *Bucket) Delete(key []byte) error {
 	// Delete the node if we have a matching key.
 	c.node().del(key)
 
+	return nil
+}
+
+// Sequence returns the current integer for the bucket without incrementing it.
+func (b *Bucket) Sequence() uint64 { return b.bucket.sequence }
+
+// SetSequence updates the sequence number for the bucket.
+func (b *Bucket) SetSequence(v uint64) error {
+	if b.tx.db == nil {
+		return ErrTxClosed
+	} else if !b.Writable() {
+		return ErrTxNotWritable
+	}
+
+	// Materialize the root node if it hasn't been already so that the
+	// bucket will be saved during commit.
+	if b.rootNode == nil {
+		_ = b.node(b.root, nil)
+	}
+
+	// Increment and return the sequence.
+	b.bucket.sequence = v
 	return nil
 }
 

--- a/vendor/github.com/boltdb/bolt/bucket_test.go
+++ b/vendor/github.com/boltdb/bolt/bucket_test.go
@@ -782,6 +782,48 @@ func TestBucket_DeleteBucket_IncompatibleValue(t *testing.T) {
 	}
 }
 
+// Ensure bucket can set and update its sequence number.
+func TestBucket_Sequence(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		bkt, err := tx.CreateBucket([]byte("0"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Retrieve sequence.
+		if v := bkt.Sequence(); v != 0 {
+			t.Fatalf("unexpected sequence: %d", v)
+		}
+
+		// Update sequence.
+		if err := bkt.SetSequence(1000); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read sequence again.
+		if v := bkt.Sequence(); v != 1000 {
+			t.Fatalf("unexpected sequence: %d", v)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify sequence in separate transaction.
+	if err := db.View(func(tx *bolt.Tx) error {
+		if v := tx.Bucket([]byte("0")).Sequence(); v != 1000 {
+			t.Fatalf("unexpected sequence: %d", v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Ensure that a bucket can return an autoincrementing sequence.
 func TestBucket_NextSequence(t *testing.T) {
 	db := MustOpenDB()

--- a/vendor/github.com/boltdb/bolt/cmd/bolt/main.go
+++ b/vendor/github.com/boltdb/bolt/cmd/bolt/main.go
@@ -102,6 +102,8 @@ func (m *Main) Run(args ...string) error {
 		return newBenchCommand(m).Run(args[1:]...)
 	case "check":
 		return newCheckCommand(m).Run(args[1:]...)
+	case "compact":
+		return newCompactCommand(m).Run(args[1:]...)
 	case "dump":
 		return newDumpCommand(m).Run(args[1:]...)
 	case "info":
@@ -130,6 +132,7 @@ The commands are:
 
     bench       run synthetic benchmark against bolt
     check       verifies integrity of bolt database
+    compact     copies a bolt database, compacting it in the process
     info        print basic info
     help        print this screen
     pages       print list of pages with their types
@@ -356,7 +359,7 @@ func (cmd *DumpCommand) Run(args ...string) error {
 	return nil
 }
 
-// PrintPage prints a given page as hexidecimal.
+// PrintPage prints a given page as hexadecimal.
 func (cmd *DumpCommand) PrintPage(w io.Writer, r io.ReaderAt, pageID int, pageSize int) error {
 	const bytesPerLineN = 16
 
@@ -406,7 +409,7 @@ func (cmd *DumpCommand) Usage() string {
 	return strings.TrimLeft(`
 usage: bolt dump -page PAGEID PATH
 
-Dump prints a hexidecimal dump of a single page.
+Dump prints a hexadecimal dump of a single page.
 `, "\n")
 }
 
@@ -539,9 +542,9 @@ func (cmd *PageCommand) PrintLeaf(w io.Writer, buf []byte) error {
 			b := (*bucket)(unsafe.Pointer(&e.value()[0]))
 			v = fmt.Sprintf("<pgid=%d,seq=%d>", b.root, b.sequence)
 		} else if isPrintable(string(e.value())) {
-			k = fmt.Sprintf("%q", string(e.value()))
+			v = fmt.Sprintf("%q", string(e.value()))
 		} else {
-			k = fmt.Sprintf("%x", string(e.value()))
+			v = fmt.Sprintf("%x", string(e.value()))
 		}
 
 		fmt.Fprintf(w, "%s: %s\n", k, v)
@@ -593,7 +596,7 @@ func (cmd *PageCommand) PrintFreelist(w io.Writer, buf []byte) error {
 	return nil
 }
 
-// PrintPage prints a given page as hexidecimal.
+// PrintPage prints a given page as hexadecimal.
 func (cmd *PageCommand) PrintPage(w io.Writer, r io.ReaderAt, pageID int, pageSize int) error {
 	const bytesPerLineN = 16
 
@@ -1529,4 +1532,209 @@ func (n *leafPageElement) key() []byte {
 func (n *leafPageElement) value() []byte {
 	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
 	return buf[n.pos+n.ksize : n.pos+n.ksize+n.vsize]
+}
+
+// CompactCommand represents the "compact" command execution.
+type CompactCommand struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	SrcPath   string
+	DstPath   string
+	TxMaxSize int64
+}
+
+// newCompactCommand returns a CompactCommand.
+func newCompactCommand(m *Main) *CompactCommand {
+	return &CompactCommand{
+		Stdin:  m.Stdin,
+		Stdout: m.Stdout,
+		Stderr: m.Stderr,
+	}
+}
+
+// Run executes the command.
+func (cmd *CompactCommand) Run(args ...string) (err error) {
+	// Parse flags.
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.SetOutput(ioutil.Discard)
+	fs.StringVar(&cmd.DstPath, "o", "", "")
+	fs.Int64Var(&cmd.TxMaxSize, "tx-max-size", 65536, "")
+	if err := fs.Parse(args); err == flag.ErrHelp {
+		fmt.Fprintln(cmd.Stderr, cmd.Usage())
+		return ErrUsage
+	} else if err != nil {
+		return err
+	} else if cmd.DstPath == "" {
+		return fmt.Errorf("output file required")
+	}
+
+	// Require database paths.
+	cmd.SrcPath = fs.Arg(0)
+	if cmd.SrcPath == "" {
+		return ErrPathRequired
+	}
+
+	// Ensure source file exists.
+	fi, err := os.Stat(cmd.SrcPath)
+	if os.IsNotExist(err) {
+		return ErrFileNotFound
+	} else if err != nil {
+		return err
+	}
+	initialSize := fi.Size()
+
+	// Open source database.
+	src, err := bolt.Open(cmd.SrcPath, 0444, nil)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	// Open destination database.
+	dst, err := bolt.Open(cmd.DstPath, fi.Mode(), nil)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	// Run compaction.
+	if err := cmd.compact(dst, src); err != nil {
+		return err
+	}
+
+	// Report stats on new size.
+	fi, err = os.Stat(cmd.DstPath)
+	if err != nil {
+		return err
+	} else if fi.Size() == 0 {
+		return fmt.Errorf("zero db size")
+	}
+	fmt.Fprintf(cmd.Stdout, "%d -> %d bytes (gain=%.2fx)\n", initialSize, fi.Size(), float64(initialSize)/float64(fi.Size()))
+
+	return nil
+}
+
+func (cmd *CompactCommand) compact(dst, src *bolt.DB) error {
+	// commit regularly, or we'll run out of memory for large datasets if using one transaction.
+	var size int64
+	tx, err := dst.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err := cmd.walk(src, func(keys [][]byte, k, v []byte, seq uint64) error {
+		// On each key/value, check if we have exceeded tx size.
+		sz := int64(len(k) + len(v))
+		if size+sz > cmd.TxMaxSize && cmd.TxMaxSize != 0 {
+			// Commit previous transaction.
+			if err := tx.Commit(); err != nil {
+				return err
+			}
+
+			// Start new transaction.
+			tx, err = dst.Begin(true)
+			if err != nil {
+				return err
+			}
+			size = 0
+		}
+		size += sz
+
+		// Create bucket on the root transaction if this is the first level.
+		nk := len(keys)
+		if nk == 0 {
+			bkt, err := tx.CreateBucket(k)
+			if err != nil {
+				return err
+			}
+			if err := bkt.SetSequence(seq); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Create buckets on subsequent levels, if necessary.
+		b := tx.Bucket(keys[0])
+		if nk > 1 {
+			for _, k := range keys[1:] {
+				b = b.Bucket(k)
+			}
+		}
+
+		// If there is no value then this is a bucket call.
+		if v == nil {
+			bkt, err := b.CreateBucket(k)
+			if err != nil {
+				return err
+			}
+			if err := bkt.SetSequence(seq); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Otherwise treat it as a key/value pair.
+		return b.Put(k, v)
+	}); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// walkFunc is the type of the function called for keys (buckets and "normal"
+// values) discovered by Walk. keys is the list of keys to descend to the bucket
+// owning the discovered key/value pair k/v.
+type walkFunc func(keys [][]byte, k, v []byte, seq uint64) error
+
+// walk walks recursively the bolt database db, calling walkFn for each key it finds.
+func (cmd *CompactCommand) walk(db *bolt.DB, walkFn walkFunc) error {
+	return db.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			return cmd.walkBucket(b, nil, name, nil, b.Sequence(), walkFn)
+		})
+	})
+}
+
+func (cmd *CompactCommand) walkBucket(b *bolt.Bucket, keypath [][]byte, k, v []byte, seq uint64, fn walkFunc) error {
+	// Execute callback.
+	if err := fn(keypath, k, v, seq); err != nil {
+		return err
+	}
+
+	// If this is not a bucket then stop.
+	if v != nil {
+		return nil
+	}
+
+	// Iterate over each child key/value.
+	keypath = append(keypath, k)
+	return b.ForEach(func(k, v []byte) error {
+		if v == nil {
+			bkt := b.Bucket(k)
+			return cmd.walkBucket(bkt, keypath, k, nil, bkt.Sequence(), fn)
+		}
+		return cmd.walkBucket(b, keypath, k, v, b.Sequence(), fn)
+	})
+}
+
+// Usage returns the help message.
+func (cmd *CompactCommand) Usage() string {
+	return strings.TrimLeft(`
+usage: bolt compact [options] -o DST SRC
+
+Compact opens a database at SRC path and walks it recursively, copying keys
+as they are found from all buckets, to a newly created database at DST path.
+
+The original database is left untouched.
+
+Additional options include:
+
+	-tx-max-size NUM
+		Specifies the maximum size of individual transactions.
+		Defaults to 64KB.
+`, "\n")
 }

--- a/vendor/github.com/boltdb/bolt/cmd/bolt/main_test.go
+++ b/vendor/github.com/boltdb/bolt/cmd/bolt/main_test.go
@@ -2,7 +2,12 @@ package main_test
 
 import (
 	"bytes"
+	crypto "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strconv"
 	"testing"
@@ -182,4 +187,170 @@ type DB struct {
 func (db *DB) Close() error {
 	defer os.Remove(db.Path)
 	return db.DB.Close()
+}
+
+func TestCompactCommand_Run(t *testing.T) {
+	var s int64
+	if err := binary.Read(crypto.Reader, binary.BigEndian, &s); err != nil {
+		t.Fatal(err)
+	}
+	rand.Seed(s)
+
+	dstdb := MustOpen(0666, nil)
+	dstdb.Close()
+
+	// fill the db
+	db := MustOpen(0666, nil)
+	if err := db.Update(func(tx *bolt.Tx) error {
+		n := 2 + rand.Intn(5)
+		for i := 0; i < n; i++ {
+			k := []byte(fmt.Sprintf("b%d", i))
+			b, err := tx.CreateBucketIfNotExists(k)
+			if err != nil {
+				return err
+			}
+			if err := b.SetSequence(uint64(i)); err != nil {
+				return err
+			}
+			if err := fillBucket(b, append(k, '.')); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+
+	// make the db grow by adding large values, and delete them.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("large_vals"))
+		if err != nil {
+			return err
+		}
+		n := 5 + rand.Intn(5)
+		for i := 0; i < n; i++ {
+			v := make([]byte, 1000*1000*(1+rand.Intn(5)))
+			_, err := crypto.Read(v)
+			if err != nil {
+				return err
+			}
+			if err := b.Put([]byte(fmt.Sprintf("l%d", i)), v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("large_vals")).Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if err := c.Delete(); err != nil {
+				return err
+			}
+		}
+		return tx.DeleteBucket([]byte("large_vals"))
+	}); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	db.DB.Close()
+	defer db.Close()
+	defer dstdb.Close()
+
+	dbChk, err := chkdb(db.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewMain()
+	if err := m.Run("compact", "-o", dstdb.Path, db.Path); err != nil {
+		t.Fatal(err)
+	}
+
+	dbChkAfterCompact, err := chkdb(db.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstdbChk, err := chkdb(dstdb.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(dbChk, dbChkAfterCompact) {
+		t.Error("the original db has been touched")
+	}
+	if !bytes.Equal(dbChk, dstdbChk) {
+		t.Error("the compacted db data isn't the same than the original db")
+	}
+}
+
+func fillBucket(b *bolt.Bucket, prefix []byte) error {
+	n := 10 + rand.Intn(50)
+	for i := 0; i < n; i++ {
+		v := make([]byte, 10*(1+rand.Intn(4)))
+		_, err := crypto.Read(v)
+		if err != nil {
+			return err
+		}
+		k := append(prefix, []byte(fmt.Sprintf("k%d", i))...)
+		if err := b.Put(k, v); err != nil {
+			return err
+		}
+	}
+	// limit depth of subbuckets
+	s := 2 + rand.Intn(4)
+	if len(prefix) > (2*s + 1) {
+		return nil
+	}
+	n = 1 + rand.Intn(3)
+	for i := 0; i < n; i++ {
+		k := append(prefix, []byte(fmt.Sprintf("b%d", i))...)
+		sb, err := b.CreateBucket(k)
+		if err != nil {
+			return err
+		}
+		if err := fillBucket(sb, append(k, '.')); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func chkdb(path string) ([]byte, error) {
+	db, err := bolt.Open(path, 0666, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	var buf bytes.Buffer
+	err = db.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			return walkBucket(b, name, nil, &buf)
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func walkBucket(parent *bolt.Bucket, k []byte, v []byte, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%d:%x=%x\n", parent.Sequence(), k, v); err != nil {
+		return err
+	}
+
+	// not a bucket, exit.
+	if v != nil {
+		return nil
+	}
+	return parent.ForEach(func(k, v []byte) error {
+		if v == nil {
+			return walkBucket(parent.Bucket(k), k, nil, w)
+		}
+		return walkBucket(parent, k, v, w)
+	})
 }

--- a/vendor/github.com/boltdb/bolt/db.go
+++ b/vendor/github.com/boltdb/bolt/db.go
@@ -552,7 +552,10 @@ func (db *DB) removeTx(tx *Tx) {
 	// Remove the transaction.
 	for i, t := range db.txs {
 		if t == tx {
-			db.txs = append(db.txs[:i], db.txs[i+1:]...)
+			last := len(db.txs) - 1
+			db.txs[i] = db.txs[last]
+			db.txs[last] = nil
+			db.txs = db.txs[:last]
 			break
 		}
 	}
@@ -952,7 +955,7 @@ func (s *Stats) Sub(other *Stats) Stats {
 	diff.PendingPageN = s.PendingPageN
 	diff.FreeAlloc = s.FreeAlloc
 	diff.FreelistInuse = s.FreelistInuse
-	diff.TxN = other.TxN - s.TxN
+	diff.TxN = s.TxN - other.TxN
 	diff.TxStats = s.TxStats.Sub(&other.TxStats)
 	return diff
 }

--- a/vendor/github.com/boltdb/bolt/freelist.go
+++ b/vendor/github.com/boltdb/bolt/freelist.go
@@ -24,7 +24,12 @@ func newFreelist() *freelist {
 
 // size returns the size of the page after serialization.
 func (f *freelist) size() int {
-	return pageHeaderSize + (int(unsafe.Sizeof(pgid(0))) * f.count())
+	n := f.count()
+	if n >= 0xFFFF {
+		// The first element will be used to store the count. See freelist.write.
+		n++
+	}
+	return pageHeaderSize + (int(unsafe.Sizeof(pgid(0))) * n)
 }
 
 // count returns count of pages on the freelist
@@ -46,16 +51,15 @@ func (f *freelist) pending_count() int {
 	return count
 }
 
-// all returns a list of all free ids and all pending ids in one sorted list.
-func (f *freelist) all() []pgid {
-	m := make(pgids, 0)
-
+// copyall copies into dst a list of all free ids and all pending ids in one sorted list.
+// f.count returns the minimum length required for dst.
+func (f *freelist) copyall(dst []pgid) {
+	m := make(pgids, 0, f.pending_count())
 	for _, list := range f.pending {
 		m = append(m, list...)
 	}
-
 	sort.Sort(m)
-	return pgids(f.ids).merge(m)
+	mergepgids(dst, f.ids, m)
 }
 
 // allocate returns the starting page id of a contiguous list of pages of a given size.
@@ -166,12 +170,16 @@ func (f *freelist) read(p *page) {
 	}
 
 	// Copy the list of page ids from the freelist.
-	ids := ((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[idx:count]
-	f.ids = make([]pgid, len(ids))
-	copy(f.ids, ids)
+	if count == 0 {
+		f.ids = nil
+	} else {
+		ids := ((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[idx:count]
+		f.ids = make([]pgid, len(ids))
+		copy(f.ids, ids)
 
-	// Make sure they're sorted.
-	sort.Sort(pgids(f.ids))
+		// Make sure they're sorted.
+		sort.Sort(pgids(f.ids))
+	}
 
 	// Rebuild the page cache.
 	f.reindex()
@@ -182,20 +190,22 @@ func (f *freelist) read(p *page) {
 // become free.
 func (f *freelist) write(p *page) error {
 	// Combine the old free pgids and pgids waiting on an open transaction.
-	ids := f.all()
 
 	// Update the header flag.
 	p.flags |= freelistPageFlag
 
 	// The page.count can only hold up to 64k elements so if we overflow that
 	// number then we handle it by putting the size in the first element.
-	if len(ids) < 0xFFFF {
-		p.count = uint16(len(ids))
-		copy(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[:], ids)
+	lenids := f.count()
+	if lenids == 0 {
+		p.count = uint16(lenids)
+	} else if lenids < 0xFFFF {
+		p.count = uint16(lenids)
+		f.copyall(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[:])
 	} else {
 		p.count = 0xFFFF
-		((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[0] = pgid(len(ids))
-		copy(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[1:], ids)
+		((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[0] = pgid(lenids)
+		f.copyall(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[1:])
 	}
 
 	return nil
@@ -230,7 +240,7 @@ func (f *freelist) reload(p *page) {
 
 // reindex rebuilds the free cache based on available and pending free lists.
 func (f *freelist) reindex() {
-	f.cache = make(map[pgid]bool)
+	f.cache = make(map[pgid]bool, len(f.ids))
 	for _, id := range f.ids {
 		f.cache[id] = true
 	}

--- a/vendor/github.com/boltdb/bolt/node.go
+++ b/vendor/github.com/boltdb/bolt/node.go
@@ -201,6 +201,11 @@ func (n *node) write(p *page) {
 	}
 	p.count = uint16(len(n.inodes))
 
+	// Stop here if there are no items to write.
+	if p.count == 0 {
+		return
+	}
+
 	// Loop over each item and write it to the page.
 	b := (*[maxAllocSize]byte)(unsafe.Pointer(&p.ptr))[n.pageElementSize()*len(n.inodes):]
 	for i, item := range n.inodes {

--- a/vendor/github.com/boltdb/bolt/page.go
+++ b/vendor/github.com/boltdb/bolt/page.go
@@ -62,6 +62,9 @@ func (p *page) leafPageElement(index uint16) *leafPageElement {
 
 // leafPageElements retrieves a list of leaf nodes.
 func (p *page) leafPageElements() []leafPageElement {
+	if p.count == 0 {
+		return nil
+	}
 	return ((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 
@@ -72,6 +75,9 @@ func (p *page) branchPageElement(index uint16) *branchPageElement {
 
 // branchPageElements retrieves a list of branch nodes.
 func (p *page) branchPageElements() []branchPageElement {
+	if p.count == 0 {
+		return nil
+	}
 	return ((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 
@@ -139,12 +145,33 @@ func (a pgids) merge(b pgids) pgids {
 	// Return the opposite slice if one is nil.
 	if len(a) == 0 {
 		return b
-	} else if len(b) == 0 {
+	}
+	if len(b) == 0 {
 		return a
 	}
+	merged := make(pgids, len(a)+len(b))
+	mergepgids(merged, a, b)
+	return merged
+}
 
-	// Create a list to hold all elements from both lists.
-	merged := make(pgids, 0, len(a)+len(b))
+// mergepgids copies the sorted union of a and b into dst.
+// If dst is too small, it panics.
+func mergepgids(dst, a, b pgids) {
+	if len(dst) < len(a)+len(b) {
+		panic(fmt.Errorf("mergepgids bad len %d < %d + %d", len(dst), len(a), len(b)))
+	}
+	// Copy in the opposite slice if one is nil.
+	if len(a) == 0 {
+		copy(dst, b)
+		return
+	}
+	if len(b) == 0 {
+		copy(dst, a)
+		return
+	}
+
+	// Merged will hold all elements from both lists.
+	merged := dst[:0]
 
 	// Assign lead to the slice with a lower starting value, follow to the higher value.
 	lead, follow := a, b
@@ -166,7 +193,5 @@ func (a pgids) merge(b pgids) pgids {
 	}
 
 	// Append what's left in follow.
-	merged = append(merged, follow...)
-
-	return merged
+	_ = append(merged, follow...)
 }

--- a/vendor/github.com/boltdb/bolt/quick_test.go
+++ b/vendor/github.com/boltdb/bolt/quick_test.go
@@ -50,9 +50,17 @@ func (t testdata) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key)
 func (t testdata) Generate(rand *rand.Rand, size int) reflect.Value {
 	n := rand.Intn(qmaxitems-1) + 1
 	items := make(testdata, n)
+	used := make(map[string]bool)
 	for i := 0; i < n; i++ {
 		item := &items[i]
-		item.Key = randByteSlice(rand, 1, qmaxksize)
+		// Ensure that keys are unique by looping until we find one that we have not already used.
+		for {
+			item.Key = randByteSlice(rand, 1, qmaxksize)
+			if !used[string(item.Key)] {
+				used[string(item.Key)] = true
+				break
+			}
+		}
 		item.Value = randByteSlice(rand, 0, qmaxvsize)
 	}
 	return reflect.ValueOf(items)

--- a/vendor/github.com/boltdb/bolt/tx.go
+++ b/vendor/github.com/boltdb/bolt/tx.go
@@ -381,7 +381,9 @@ func (tx *Tx) Check() <-chan error {
 func (tx *Tx) check(ch chan error) {
 	// Check if any pages are double freed.
 	freed := make(map[pgid]bool)
-	for _, id := range tx.db.freelist.all() {
+	all := make([]pgid, tx.db.freelist.count())
+	tx.db.freelist.copyall(all)
+	for _, id := range all {
 		if freed[id] {
 			ch <- fmt.Errorf("page %d: already freed", id)
 		}


### PR DESCRIPTION
Fixes #1295 

Also Fixes #507 since using any of these operations is potentially destructive we needed a backup endpoint.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x]  Migrate the repair process to be an API call instead of a startup action.