### PR TITLE
Fix two flaky tests

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7543,6 +7543,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 				c.SNMPTrap.Enabled = true
 				c.SNMPTrap.Addr = ts.Addr
 				c.SNMPTrap.Community = ts.Community
+				c.SNMPTrap.Retries = 3
 				return ctxt, nil
 			},
 			result: func(ctxt context.Context) error {


### PR DESCRIPTION

Fixes #1307
There was a race in the config service test which has been removed.
The SNMPTrap test would drop UDP packets on occasion. I have increased the retry count for the test.

- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated