### PR TITLE
Update client if credentials have changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.1 [2017-04-13]
+
+### Bugfixes
+
+- [#1323](https://github.com/influxdata/kapacitor/pull/1323): Fix issue where credentials to InfluxDB could not be updated dynamically.
+
 ## v1.2.0 [2017-01-23]
 
 ### Release Notes

--- a/influxdb/client.go
+++ b/influxdb/client.go
@@ -193,7 +193,9 @@ func (c *HTTPClient) Update(new Config) error {
 		return err
 	}
 	c.urls = urls
-	if old.Timeout != new.Timeout || old.Transport != new.Transport {
+	if old.Credentials != new.Credentials ||
+		old.Timeout != new.Timeout ||
+		old.Transport != new.Transport {
 		//Replace the client
 		tr := new.Transport
 		if tr == nil {


### PR DESCRIPTION
Fix for InfluxDB client not updating if the client credentials have changed.


- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated