### PR TITLE
Fix scraper timeout not being used

### DIFF
--- a/services/scraper/config.go
+++ b/services/scraper/config.go
@@ -95,6 +95,7 @@ func (c *Config) Prom() *config.ScrapeConfig {
 		MetricsPath:    c.MetricsPath,
 		Params:         c.Params,
 		ScrapeInterval: model.Duration(c.ScrapeInterval),
+		ScrapeTimeout:  model.Duration(c.ScrapeTimeout),
 		HTTPClientConfig: config.HTTPClientConfig{
 			BasicAuth: &config.BasicAuth{
 				Username: c.Username,


### PR DESCRIPTION
Scraper timeout was not being sent along to underlying scraper.