### PR TITLE
Add groupBy exclude, Add dropOriginalFieldName to flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1284](https://github.com/influxdata/kapacitor/pull/1284): Add type signatures to Kapacitor functions.
 - [#1203](https://github.com/influxdata/kapacitor/issues/1203): Add `isPresent` operator for verifying whether a value is present (part of [#1284](https://github.com/influxdata/kapacitor/pull/1284)).
 - [#1354](https://github.com/influxdata/kapacitor/pull/1354): Add Kubernetes scraping support.
+- [#1359](https://github.com/influxdata/kapacitor/pull/1359): Add groupBy exclude and Add dropOriginalFieldName to flatten.
 
 ### Bugfixes
 

--- a/flatten.go
+++ b/flatten.go
@@ -205,10 +205,12 @@ func (n *FlattenNode) flatten(points []models.RawPoint) (models.Fields, error) {
 	defer n.bufPool.Put(fieldPrefix)
 POINTS:
 	for _, p := range points {
-		for _, tag := range n.f.Dimensions {
+		for i, tag := range n.f.Dimensions {
 			if v, ok := p.Tags[tag]; ok {
+				if i > 0 {
+					fieldPrefix.WriteString(n.f.Delimiter)
+				}
 				fieldPrefix.WriteString(v)
-				fieldPrefix.WriteString(n.f.Delimiter)
 			} else {
 				n.incrementErrorCount()
 				n.logger.Printf("E! point missing tag %q for flatten operation", tag)
@@ -217,7 +219,12 @@ POINTS:
 		}
 		l := fieldPrefix.Len()
 		for fname, value := range p.Fields {
-			fieldPrefix.WriteString(fname)
+			if !n.f.DropOriginalFieldNameFlag {
+				if l > 0 {
+					fieldPrefix.WriteString(n.f.Delimiter)
+				}
+				fieldPrefix.WriteString(fname)
+			}
 			fields[fieldPrefix.String()] = value
 			fieldPrefix.Truncate(l)
 		}

--- a/integrations/data/TestStream_BatchGroupBy.srpl
+++ b/integrations/data/TestStream_BatchGroupBy.srpl
@@ -70,3 +70,21 @@ cpu,type=idle,host=serverA value=95.1 0000000012
 dbname
 rpname
 cpu,type=idle,host=serverB value=95.1 0000000012
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1 0000000013
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.1 0000000013
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1 0000000014
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.1 0000000014
+dbname
+rpname
+cpu,type=idle,host=serverA value=95.1 0000000015
+dbname
+rpname
+cpu,type=idle,host=serverB value=95.1 0000000015

--- a/integrations/data/TestStream_GroupByExclude.srpl
+++ b/integrations/data/TestStream_GroupByExclude.srpl
@@ -1,0 +1,48 @@
+dbname
+rpname
+mock,t=A,s=1 value=97.1 0000000001
+dbname
+rpname
+mock,t=A,s=2 value=97.1 0000000001
+dbname
+rpname
+mock,t=B,s=1 value=97.1 0000000001
+dbname
+rpname
+mock,t=B,s=2 value=97.1 0000000001
+dbname
+rpname
+mock,t=A,s=1 value=97.1 0000000002
+dbname
+rpname
+mock,t=A,s=2 value=97.1 0000000002
+dbname
+rpname
+mock,t=B,s=1 value=97.1 0000000002
+dbname
+rpname
+mock,t=B,s=2 value=97.1 0000000002
+dbname
+rpname
+mock,t=A,s=1 value=97.1 0000000003
+dbname
+rpname
+mock,t=A,s=2 value=97.1 0000000003
+dbname
+rpname
+mock,t=B,s=1 value=97.1 0000000003
+dbname
+rpname
+mock,t=B,s=2 value=97.1 0000000003
+dbname
+rpname
+mock,t=A,s=1 value=97.1 0000000004
+dbname
+rpname
+mock,t=A,s=2 value=97.1 0000000004
+dbname
+rpname
+mock,t=B,s=1 value=97.1 0000000004
+dbname
+rpname
+mock,t=B,s=2 value=97.1 0000000004

--- a/pipeline/flatten.go
+++ b/pipeline/flatten.go
@@ -52,6 +52,11 @@ type FlattenNode struct {
 	// The joined data point's time will be rounded to the nearest
 	// multiple of the tolerance duration.
 	Tolerance time.Duration
+
+	// DropOriginalFieldNameFlag indicates whether the original field name should
+	// be included in the final field name.
+	//tick:ignore
+	DropOriginalFieldNameFlag bool `tick:"DropOriginalFieldName"`
 }
 
 func newFlattenNode(e EdgeType) *FlattenNode {
@@ -66,5 +71,17 @@ func newFlattenNode(e EdgeType) *FlattenNode {
 // tick:property
 func (f *FlattenNode) On(dims ...string) *FlattenNode {
 	f.Dimensions = dims
+	return f
+}
+
+// DropOriginalFieldName indicates whether the original field name should
+// be dropped when constructing the final field name.
+// tick:property
+func (f *FlattenNode) DropOriginalFieldName(drop ...bool) *FlattenNode {
+	if len(drop) == 1 {
+		f.DropOriginalFieldNameFlag = drop[0]
+	} else {
+		f.DropOriginalFieldNameFlag = true
+	}
 	return f
 }

--- a/pipeline/group_by.go
+++ b/pipeline/group_by.go
@@ -26,6 +26,11 @@ type GroupByNode struct {
 	// tick:ignore
 	Dimensions []interface{}
 
+	// The dimensions to exclude.
+	// Useful for substractive tags from using *.
+	// tick:ignore
+	ExcludedDimensions []string `tick:"Exclude"`
+
 	// Whether to include the measurement in the group ID.
 	// tick:ignore
 	ByMeasurementFlag bool `tick:"ByMeasurement"`
@@ -82,5 +87,11 @@ func validateDimensions(dimensions []interface{}) error {
 // tick:property
 func (n *GroupByNode) ByMeasurement() *GroupByNode {
 	n.ByMeasurementFlag = true
+	return n
+}
+
+// Exclude removes any tags from the group.
+func (n *GroupByNode) Exclude(dims ...string) *GroupByNode {
+	n.ExcludedDimensions = append(n.ExcludedDimensions, dims...)
 	return n
 }

--- a/pipeline/group_by.go
+++ b/pipeline/group_by.go
@@ -44,10 +44,10 @@ func newGroupByNode(wants EdgeType, dims []interface{}) *GroupByNode {
 }
 
 func (n *GroupByNode) validate() error {
-	return validateDimensions(n.Dimensions)
+	return validateDimensions(n.Dimensions, n.ExcludedDimensions)
 }
 
-func validateDimensions(dimensions []interface{}) error {
+func validateDimensions(dimensions []interface{}, excludedDimensions []string) error {
 	hasStar := false
 	for _, d := range dimensions {
 		switch dim := d.(type) {
@@ -63,6 +63,9 @@ func validateDimensions(dimensions []interface{}) error {
 	}
 	if hasStar && len(dimensions) > 1 {
 		return errors.New("cannot group by both '*' and named dimensions.")
+	}
+	if !hasStar && len(excludedDimensions) > 0 {
+		return errors.New("exclude requires '*'")
 	}
 	return nil
 }

--- a/pipeline/stream.go
+++ b/pipeline/stream.go
@@ -271,5 +271,5 @@ func (n *FromNode) GroupByMeasurement() *FromNode {
 }
 
 func (s *FromNode) validate() error {
-	return validateDimensions(s.Dimensions)
+	return validateDimensions(s.Dimensions, nil)
 }

--- a/stream.go
+++ b/stream.go
@@ -88,7 +88,7 @@ func (s *FromNode) runStream([]byte) error {
 				pt.Time = pt.Time.Round(s.s.Round)
 			}
 			dims.TagNames = s.dimensions
-			pt = setGroupOnPoint(pt, s.allDimensions, dims)
+			pt = setGroupOnPoint(pt, s.allDimensions, dims, nil)
 			s.timer.Pause()
 			for _, child := range s.outs {
 				err := child.CollectPoint(pt)


### PR DESCRIPTION
Add the ability to exclude certain tags when grouping by *
Add a drop original field name to the flatten node.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Implement GroupBy exclude for batch edges
- [x] Add tests for batch/stream for groupby exclude
- [x] Add tests for batch/stream flatten dropOriginalFieldName
