### PR TITLE
Add kapacitor loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1284](https://github.com/influxdata/kapacitor/pull/1284): Add type signatures to Kapacitor functions.
 - [#1203](https://github.com/influxdata/kapacitor/issues/1203): Add `isPresent` operator for verifying whether a value is present (part of [#1284](https://github.com/influxdata/kapacitor/pull/1284)).
 - [#1354](https://github.com/influxdata/kapacitor/pull/1354): Add Kubernetes scraping support.
+- [#1360](https://github.com/influxdata/kapacitor/pull/1360): Add KapacitorLoopback node to be able to send data from a task back into Kapacitor.
 
 ### Bugfixes
 

--- a/integrations/data/TestStream_KapacitorLoopback.srpl
+++ b/integrations/data/TestStream_KapacitorLoopback.srpl
@@ -1,0 +1,21 @@
+dbname
+rpname
+cpu value=45 0000000001
+dbname
+rpname
+cpu value=25 0000000002
+dbname
+rpname
+cpu value=23 0000000003
+dbname
+rpname
+cpu value=78 0000000010
+dbname
+rpname
+cpu value=97 0000000011
+dbname
+rpname
+cpu value=62 0000000012
+dbname
+rpname
+cpu value=32 0000000016

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -8755,6 +8755,298 @@ stream
 	}
 }
 
+func TestStream_KapacitorLoopback_PreventLoop(t *testing.T) {
+
+	var script = `
+stream
+	|from()
+		.measurement('cpu')
+		.where(lambda: "host" == 'serverA')
+	|kapacitorLoopback()
+		.database('dbname')
+		.retentionPolicy('rpname')
+`
+
+	// Create a new execution env
+	tm, err := createTaskMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Open()
+
+	// Create the task
+	task, err := tm.NewTask("KapacitorLoopbackWithLoop", script, kapacitor.StreamTask, dbrps, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Start the task
+	_, err = tm.StartTask(task)
+	if err == nil {
+		t.Error("expected error about starting a task with a loop")
+	}
+}
+
+func TestStream_KapacitorLoopback(t *testing.T) {
+	var scriptLoop = `
+stream
+	|from()
+		.measurement('cpu')
+	|kapacitorLoopback()
+		.database('new-dbname')
+		.retentionPolicy('new-rpname')
+`
+	var scriptCount = `
+stream
+	|from()
+		.measurement('cpu')
+	|window()
+		.every(10s)
+		.period(10s)
+	|count('value')
+	|httpOut('TestStream_KapacitorLoopback')
+`
+	er := models.Result{
+		Series: models.Rows{
+			{
+				Name:    "cpu",
+				Columns: []string{"time", "count"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					4.0,
+				}},
+			},
+		},
+	}
+	var newDBRPs = []kapacitor.DBRP{
+		{
+			Database:        "new-dbname",
+			RetentionPolicy: "new-rpname",
+		},
+	}
+	// Create a new execution env
+	tm, err := createTaskMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Open()
+	defer tm.Close()
+
+	// Create the loopback task
+	taskLoop, err := tm.NewTask("KapacitorLoopback-Loop", scriptLoop, kapacitor.StreamTask, dbrps, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create the count task
+	taskCount, err := tm.NewTask("KapacitorLoopback-Count", scriptCount, kapacitor.StreamTask, newDBRPs, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Load test data
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := "TestStream_KapacitorLoopback"
+	data, err := os.Open(path.Join(dir, "data", name+".srpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the tasks
+	etLoop, err := tm.StartTask(taskLoop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	etCount, err := tm.StartTask(taskCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Replay test data to executor
+	stream, err := tm.Stream(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Use 1971 so that we don't get true negatives on Epoch 0 collisions
+	clock := clock.New(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	replayErr := kapacitor.ReplayStreamFromIO(clock, data, stream, false, "s")
+
+	// Advance time
+	// Move time forward
+	clock.Set(clock.Zero().Add(20 * time.Second))
+	// Wait till the replay has finished
+	if err := <-replayErr; err != nil {
+		t.Fatal(err)
+	}
+	// Give the loopback data a chance to process, since we can't track it with the clock
+	time.Sleep(10 * time.Millisecond)
+	// Drain the task master and wait for the tasks to finish
+	tm.Drain()
+	etLoop.StopStats()
+	etCount.StopStats()
+	if err := etLoop.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if err := etCount.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the result
+	output, err := etCount.GetOutput(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(output.Endpoint())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert we got the expected result
+	result := models.Result{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eq, msg := compareResults(er, result); !eq {
+		t.Error(msg)
+	}
+}
+
+func TestBatch_KapacitorLoopback(t *testing.T) {
+	var scriptLoop = `
+stream
+	|from()
+		.measurement('cpu')
+	|window()
+		.every(5s)
+		.period(5s)
+	|kapacitorLoopback()
+		.database('new-dbname')
+		.retentionPolicy('new-rpname')
+`
+	var scriptCount = `
+stream
+	|from()
+		.measurement('cpu')
+	|window()
+		.every(10s)
+		.period(10s)
+	|count('value')
+	|httpOut('TestStream_KapacitorLoopback')
+`
+	er := models.Result{
+		Series: models.Rows{
+			{
+				Name:    "cpu",
+				Columns: []string{"time", "count"},
+				Values: [][]interface{}{[]interface{}{
+					time.Date(1971, 1, 1, 0, 0, 10, 0, time.UTC),
+					4.0,
+				}},
+			},
+		},
+	}
+	var newDBRPs = []kapacitor.DBRP{
+		{
+			Database:        "new-dbname",
+			RetentionPolicy: "new-rpname",
+		},
+	}
+	// Create a new execution env
+	tm, err := createTaskMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Open()
+	defer tm.Close()
+
+	// Create the loopback task
+	taskLoop, err := tm.NewTask("KapacitorLoopback-Loop", scriptLoop, kapacitor.StreamTask, dbrps, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create the count task
+	taskCount, err := tm.NewTask("KapacitorLoopback-Count", scriptCount, kapacitor.StreamTask, newDBRPs, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Load test data
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := "TestStream_KapacitorLoopback"
+	data, err := os.Open(path.Join(dir, "data", name+".srpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the tasks
+	etLoop, err := tm.StartTask(taskLoop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	etCount, err := tm.StartTask(taskCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Replay test data to executor
+	stream, err := tm.Stream(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Use 1971 so that we don't get true negatives on Epoch 0 collisions
+	clock := clock.New(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	replayErr := kapacitor.ReplayStreamFromIO(clock, data, stream, false, "s")
+
+	// Advance time
+	// Move time forward
+	clock.Set(clock.Zero().Add(20 * time.Second))
+	// Wait till the replay has finished
+	if err := <-replayErr; err != nil {
+		t.Fatal(err)
+	}
+	// Give the loopback data a chance to process, since we can't track it with the clock
+	time.Sleep(10 * time.Millisecond)
+	// Drain the task master and wait for the tasks to finish
+	tm.Drain()
+	etLoop.StopStats()
+	etCount.StopStats()
+	if err := etLoop.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if err := etCount.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the result
+	output, err := etCount.GetOutput(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(output.Endpoint())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert we got the expected result
+	result := models.Result{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eq, msg := compareResults(er, result); !eq {
+		t.Error(msg)
+	}
+}
+
 func TestStream_InfluxDBOut(t *testing.T) {
 
 	var script = `
@@ -8866,10 +9158,10 @@ stream
 	name := "TestStream_InfluxDBOut"
 
 	// Create a new execution env
-	tm := kapacitor.NewTaskMaster("testStreamer", logService)
-	tm.HTTPDService = newHTTPDService()
-	tm.TaskStore = taskStore{}
-	tm.DeadmanService = deadman{}
+	tm, err := createTaskMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
 	tm.InfluxDBService = influxdb
 	tm.Open()
 
@@ -8926,10 +9218,10 @@ stream
 	name := "TestStream_InfluxDBOut"
 
 	// Create a new execution env
-	tm := kapacitor.NewTaskMaster("testStreamer", logService)
-	tm.HTTPDService = newHTTPDService()
-	tm.TaskStore = taskStore{}
-	tm.DeadmanService = deadman{}
+	tm, err := createTaskMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
 	tm.InfluxDBService = influxdb
 	tm.Open()
 
@@ -9980,19 +10272,10 @@ func testStreamer(
 	}
 
 	// Create a new execution env
-	tm := kapacitor.NewTaskMaster("testStreamer", logService)
-	httpdService := newHTTPDService()
-	tm.HTTPDService = httpdService
-	tm.TaskStore = taskStore{}
-	tm.DeadmanService = deadman{}
-	tm.HTTPPostService = httppost.NewService(nil, logService.NewLogger("[httppost] ", log.LstdFlags))
-	as := alertservice.NewService(logService.NewLogger("[alert] ", log.LstdFlags))
-	as.StorageService = storagetest.New()
-	as.HTTPDService = httpdService
-	if err := as.Open(); err != nil {
+	tm, err := createTaskMaster()
+	if err != nil {
 		t.Fatal(err)
 	}
-	tm.AlertService = as
 	if tmInit != nil {
 		tmInit(tm)
 	}
@@ -10239,4 +10522,21 @@ func compareListIgnoreOrder(got, exp []interface{}, cmpF func(got, exp interface
 		}
 	}
 	return nil
+}
+
+func createTaskMaster() (*kapacitor.TaskMaster, error) {
+	tm := kapacitor.NewTaskMaster("testStreamer", logService)
+	httpdService := newHTTPDService()
+	tm.HTTPDService = httpdService
+	tm.TaskStore = taskStore{}
+	tm.DeadmanService = deadman{}
+	tm.HTTPPostService = httppost.NewService(nil, logService.NewLogger("[httppost] ", log.LstdFlags))
+	as := alertservice.NewService(logService.NewLogger("[alert] ", log.LstdFlags))
+	as.StorageService = storagetest.New()
+	as.HTTPDService = httpdService
+	if err := as.Open(); err != nil {
+		return nil, err
+	}
+	tm.AlertService = as
+	return tm, nil
 }

--- a/kapacitor_loopback.go
+++ b/kapacitor_loopback.go
@@ -1,0 +1,107 @@
+package kapacitor
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/influxdata/kapacitor/expvar"
+	"github.com/influxdata/kapacitor/models"
+	"github.com/influxdata/kapacitor/pipeline"
+)
+
+const (
+	statsKapacitorLoopbackPointsWritten = "points_written"
+)
+
+type KapacitorLoopbackNode struct {
+	node
+	k *pipeline.KapacitorLoopbackNode
+
+	pointsWritten *expvar.Int
+}
+
+func newKapacitorLoopbackNode(et *ExecutingTask, n *pipeline.KapacitorLoopbackNode, l *log.Logger) (*KapacitorLoopbackNode, error) {
+	kn := &KapacitorLoopbackNode{
+		node: node{Node: n, et: et, logger: l},
+		k:    n,
+	}
+	kn.node.runF = kn.runOut
+	// Check that a loop has not been created within this task
+	for _, dbrp := range et.Task.DBRPs {
+		if dbrp.Database == n.Database && dbrp.RetentionPolicy == n.RetentionPolicy {
+			return nil, fmt.Errorf("loop detected on dbrp: %v", dbrp)
+		}
+	}
+	return kn, nil
+}
+
+func (k *KapacitorLoopbackNode) runOut([]byte) error {
+	k.pointsWritten = &expvar.Int{}
+
+	k.statMap.Set(statsInfluxDBPointsWritten, k.pointsWritten)
+
+	switch k.Wants() {
+	case pipeline.StreamEdge:
+		for p, ok := k.ins[0].NextPoint(); ok; p, ok = k.ins[0].NextPoint() {
+			k.timer.Start()
+			if k.k.Database != "" {
+				p.Database = k.k.Database
+			}
+			if k.k.RetentionPolicy != "" {
+				p.RetentionPolicy = k.k.RetentionPolicy
+			}
+			if k.k.Measurement != "" {
+				p.Name = k.k.Measurement
+			}
+			if len(k.k.Tags) > 0 {
+				p.Tags = p.Tags.Copy()
+				for k, v := range k.k.Tags {
+					p.Tags[k] = v
+				}
+			}
+			err := k.et.tm.WriteKapacitorPoint(p)
+			if err != nil {
+				k.incrementErrorCount()
+				k.logger.Println("E! failed to write point over loopback")
+			} else {
+				k.pointsWritten.Add(1)
+			}
+			k.timer.Stop()
+		}
+	case pipeline.BatchEdge:
+		for b, ok := k.ins[0].NextBatch(); ok; b, ok = k.ins[0].NextBatch() {
+			k.timer.Start()
+			if k.k.Measurement != "" {
+				b.Name = k.k.Measurement
+			}
+			written := int64(0)
+			for _, bp := range b.Points {
+				tags := bp.Tags
+				if len(k.k.Tags) > 0 {
+					tags = bp.Tags.Copy()
+					for k, v := range k.k.Tags {
+						tags[k] = v
+					}
+				}
+				p := models.Point{
+					Database:        k.k.Database,
+					RetentionPolicy: k.k.RetentionPolicy,
+					Name:            b.Name,
+					Tags:            tags,
+					Fields:          bp.Fields,
+					Time:            bp.Time,
+				}
+				err := k.et.tm.WriteKapacitorPoint(p)
+				if err != nil {
+					k.incrementErrorCount()
+					k.logger.Println("E! failed to write point over loopback")
+				} else {
+					written++
+				}
+			}
+			k.pointsWritten.Add(written)
+			k.timer.Stop()
+		}
+	}
+	return nil
+}

--- a/pipeline/influxdb_out.go
+++ b/pipeline/influxdb_out.go
@@ -9,6 +9,8 @@ const DefaultFlushInterval = time.Second * 10
 //
 // Example:
 //    stream
+//        |from()
+//            .measurement('requests')
 //        |eval(lambda: "errors" / "total")
 //            .as('error_percent')
 //        // Write the transformed data to InfluxDB

--- a/pipeline/kapacitor_loopback.go
+++ b/pipeline/kapacitor_loopback.go
@@ -1,0 +1,68 @@
+package pipeline
+
+import (
+	"errors"
+)
+
+// Writes the data back into the Kapacitor stream.
+// To write data to a remote Kapacitor instance use the InfluxDBOut node.
+//
+// Example:
+//        |kapacitorLoopback()
+//            .database('mydb')
+//            .retentionPolicy('myrp')
+//            .measurement('errors')
+//            .tag('kapacitor', 'true')
+//            .tag('version', '0.2')
+//
+//
+// NOTE: It is possible to create infinite loops using this node.
+// Take care to ensure you do not chain tasks together creating a loop.
+//
+// Available Statistics:
+//
+//    * points_written -- number of points written back to Kapacitor
+//
+type KapacitorLoopbackNode struct {
+	node
+
+	// The name of the database.
+	Database string
+	// The name of the retention policy.
+	RetentionPolicy string
+	// The name of the measurement.
+	Measurement string
+	// Static set of tags to add to all data points before writing them.
+	// tick:ignore
+	Tags map[string]string `tick:"Tag"`
+}
+
+func newKapacitorLoopbackNode(wants EdgeType) *KapacitorLoopbackNode {
+	return &KapacitorLoopbackNode{
+		node: node{
+			desc:     "kapacitor_loopback",
+			wants:    wants,
+			provides: NoEdge,
+		},
+		Tags: make(map[string]string),
+	}
+}
+
+// Add a static tag to all data points.
+// Tag can be called more than once.
+//
+// tick:property
+func (k *KapacitorLoopbackNode) Tag(key, value string) *KapacitorLoopbackNode {
+	k.Tags[key] = value
+	return k
+}
+
+func (k *KapacitorLoopbackNode) validate() error {
+	if k.Database == "" {
+		return errors.New("must specify a database")
+	}
+	if k.RetentionPolicy == "" {
+		return errors.New("must specify a retention policy")
+	}
+	return nil
+}

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -342,6 +342,13 @@ func (n *chainnode) InfluxDBOut() *InfluxDBOutNode {
 	return i
 }
 
+// Create an kapacitor loopback node that will send data back into Kapacitor as a stream.
+func (n *chainnode) KapacitorLoopback() *KapacitorLoopbackNode {
+	k := newKapacitorLoopbackNode(n.provides)
+	n.linkChild(k)
+	return k
+}
+
 // Create an alert node, which can trigger alerts.
 func (n *chainnode) Alert() *AlertNode {
 	a := newAlertNode(n.provides)

--- a/task.go
+++ b/task.go
@@ -458,6 +458,8 @@ func (et *ExecutingTask) createNode(p pipeline.Node, l *log.Logger) (n Node, err
 		n, err = newHTTPPostNode(et, t, l)
 	case *pipeline.InfluxDBOutNode:
 		n, err = newInfluxDBOutNode(et, t, l)
+	case *pipeline.KapacitorLoopbackNode:
+		n, err = newKapacitorLoopbackNode(et, t, l)
 	case *pipeline.AlertNode:
 		n, err = newAlertNode(et, t, l)
 	case *pipeline.GroupByNode:


### PR DESCRIPTION
Adds the ability to natively emit data back into Kapacitor from a task

Does this break the order guarantee? No, not anymore than you could have done using InfluxDBOut.
We can always gate loopback writes through a reorder step if it does become something that is hard to manage in practice.

Does this allow creation of infinite loops? Yes, but not within the same task. To create an infinite loop you would need to use at least two task each with a loopback pointing at the other. A warning has been added to the docs, but this should be rare.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Add tests for batch/stream