### PR TITLE
fix stateDuration & stateCount adding fields to wrong point in batch

### DIFF
--- a/integrations/batcher_test.go
+++ b/integrations/batcher_test.go
@@ -2363,15 +2363,18 @@ batch
 
 func TestBatch_StateDuration(t *testing.T) {
 	var script = `
-batch
+var data = batch
 	|query('SELECT value FROM "telegraf"."default"."cpu"')
 		.period(4s)
 		.every(4s)
 		.groupBy('host')
+data
 	|stateDuration(lambda: "value" > 95)
 		.unit(1ms)
 		.as('my_duration')
 	|httpOut('TestBatch_StateTracking')
+data
+	|stateDuration(lambda: "value" > 95) // discard
 `
 	er := models.Result{
 		Series: models.Rows{
@@ -2432,14 +2435,17 @@ batch
 
 func TestBatch_StateCount(t *testing.T) {
 	var script = `
-batch
+var data = batch
 	|query('SELECT value FROM "telegraf"."default"."cpu"')
 		.period(4s)
 		.every(4s)
 		.groupBy('host')
+data
 	|stateCount(lambda: "value" > 95)
 		.as('my_count')
 	|httpOut('TestBatch_StateTracking')
+data
+	|stateCount(lambda: "value" > 95) // discard
 `
 	er := models.Result{
 		Series: models.Rows{

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -10240,14 +10240,17 @@ func testStreamerCardinality(
 
 func TestStream_StateDuration(t *testing.T) {
 	var script = `
-stream
+var data = stream
 	|from().measurement('cpu')
 	|groupBy('host')
+data
 	|stateDuration(lambda: "value" > 95)
 		.unit(1ms)
 		.as('my_duration')
 	|window().period(4s).every(4s)
 	|httpOut('TestStream_StateTracking')
+data
+	|stateDuration(lambda: "value" > 95) // discard
 `
 	er := models.Result{
 		Series: models.Rows{
@@ -10308,13 +10311,16 @@ stream
 
 func TestStream_StateCount(t *testing.T) {
 	var script = `
-stream
+var data = stream
 	|from().measurement('cpu')
 	|groupBy('host')
+data
 	|stateCount(lambda: "value" > 95)
 		.as('my_count')
 	|window().period(4s).every(4s)
 	|httpOut('TestStream_StateTracking')
+data
+	|stateCount(lambda: "value" > 95) // discard
 `
 	er := models.Result{
 		Series: models.Rows{

--- a/state_tracking.go
+++ b/state_tracking.go
@@ -115,6 +115,7 @@ func (stn *StateTrackingNode) runStateTracking(_ []byte) error {
 			}
 			stg.tracker.reset()
 
+			b = b.Copy().(models.Batch)
 			for i := 0; i < len(b.Points); {
 				p := &b.Points[i]
 				pass, err := EvalPredicate(stg.Expression, stg.ScopePool, p.Time, p.Fields, p.Tags)


### PR DESCRIPTION
This fixes the map write race condition reported in https://github.com/influxdata/kapacitor/issues/1369#issuecomment-301778741 as well as the point sharing issue reported in #1379, but only for stateDuration & stateCount. If this is the solution we want to go with (copying the batch), I can implement on the other nodes.

###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
