### PR TITLE
Update static-discovery config to supply __address__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ For more details on the alerting system see the full documentation [here](https:
 ### Bugfixes
 
 - [#1369](https://github.com/influxdata/kapacitor/issues/1369): Fix panic with concurrent writes to same points in state tracking nodes.
+- [#1387](https://github.com/influxdata/kapacitor/pull/1387): static-discovery configuration simplified
 
 ## v1.3.0-rc2 [2017-05-11]
 

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -574,8 +574,9 @@ default-retention-policy = ""
 #[[static-discovery]]
 #  enabled = false
 #  id = "mystatic"
-#  targets = []
+#  targets = ["localhost:9100"]
 #  [static.labels]
+#    region = "us-east-1"
 #
 #[[triton]]
 #  enabled = false

--- a/services/static_discovery/config.go
+++ b/services/static_discovery/config.go
@@ -13,14 +13,14 @@ type Config struct {
 	ID      string `toml:"id" override:"id"`
 	// Targets is a list of targets identified by a label set. Each target is
 	// uniquely identifiable in the group by its address label.
-	Targets []map[string]string `toml:"targets" override:"targets"`
+	Targets []string `toml:"targets" override:"targets"`
 	// Labels is a set of labels that is common across all targets in the group.
 	Labels map[string]string `toml:"labels" override:"labels"`
 }
 
 // Init the static configuration to an empty set of structures
 func (s *Config) Init() {
-	s.Targets = []map[string]string{}
+	s.Targets = []string{}
 	s.Labels = map[string]string{}
 }
 
@@ -46,10 +46,12 @@ func (s Config) PromConfig() []*config.TargetGroup {
 		}
 		return res
 	}
-	target := func(t []map[string]string) []model.LabelSet {
+	target := func(t []string) []model.LabelSet {
 		res := make([]model.LabelSet, len(t))
 		for i, l := range t {
-			res[i] = set(l)
+			res[i] = model.LabelSet{
+				model.LabelName(model.AddressLabel): model.LabelValue(l),
+			}
 		}
 		return res
 	}

--- a/services/static_discovery/config_test.go
+++ b/services/static_discovery/config_test.go
@@ -1,0 +1,64 @@
+package static_discovery
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+)
+
+func TestConfig_PromConfig(t *testing.T) {
+	type fields struct {
+		Enabled bool
+		ID      string
+		Targets []string
+		Labels  map[string]string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []*config.TargetGroup
+	}{
+		{
+			name: "Test Address Label",
+			fields: fields{
+				ID: "mylocalhost",
+				Targets: []string{
+					"localhost:9100",
+					"localhost:9200",
+				},
+				Labels: map[string]string{
+					"my":      "neat",
+					"metrics": "host",
+				},
+			},
+			want: []*config.TargetGroup{
+				&config.TargetGroup{
+					Source: "mylocalhost",
+					Targets: []model.LabelSet{
+						{model.AddressLabel: "localhost:9100"},
+						{model.AddressLabel: "localhost:9200"},
+					},
+					Labels: model.LabelSet{
+						"my":      "neat",
+						"metrics": "host",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Config{
+				Enabled: tt.fields.Enabled,
+				ID:      tt.fields.ID,
+				Targets: tt.fields.Targets,
+				Labels:  tt.fields.Labels,
+			}
+			if got := s.PromConfig(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Config.PromConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Problem
The static-discovery configuration was difficult to use:
Previously, it had a prometheus assumption of `__address__` as a target:
```toml
[[static-discovery]]
  enabled = true
  id = "mystatic"
  targets = [{ "__address__" = "localhost:9100"}]
  [static.labels]
    region = "us-east-1"
```

### Solution
The `static-discovery` configuration section has been simplified to look like this:

```toml
[[static-discovery]]
  enabled = true
  id = "mystatic"
  targets = ["localhost:9100"]
  [static.labels]
    region = "us-east-1"
```

