### PR TITLE
Copy batch points slice before modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased [unreleased]
 
+# Bugfixes
+
+- [#1379](https://github.com/influxdata/kapacitor/issues/1379): Copy batch points slice before modification, fixes potential panics and data corruption.
+
 ## v1.3.0-rc3 [2017-05-18]
 
 ### Release Notes

--- a/default.go
+++ b/default.go
@@ -54,6 +54,7 @@ func (e *DefaultNode) runDefault(snapshot []byte) error {
 	case pipeline.BatchEdge:
 		for b, ok := e.ins[0].NextBatch(); ok; b, ok = e.ins[0].NextBatch() {
 			e.timer.Start()
+			b.Points = b.ShallowCopyPoints()
 			_, b.Tags = e.setDefaults(nil, b.Tags)
 			b.UpdateGroup()
 			for i := range b.Points {

--- a/delete.go
+++ b/delete.go
@@ -77,6 +77,7 @@ func (e *DeleteNode) runDelete(snapshot []byte) error {
 	case pipeline.BatchEdge:
 		for b, ok := e.ins[0].NextBatch(); ok; b, ok = e.ins[0].NextBatch() {
 			e.timer.Start()
+			b.Points = b.ShallowCopyPoints()
 			for i := range b.Points {
 				b.Points[i].Fields, b.Points[i].Tags = e.doDeletes(b.Points[i].Fields, b.Points[i].Tags)
 			}

--- a/derivative.go
+++ b/derivative.go
@@ -69,6 +69,7 @@ func (d *DerivativeNode) runDerivative([]byte) error {
 	case pipeline.BatchEdge:
 		for b, ok := d.ins[0].NextBatch(); ok; b, ok = d.ins[0].NextBatch() {
 			d.timer.Start()
+			b.Points = b.ShallowCopyPoints()
 			var pr, p models.BatchPoint
 			for i := 0; i < len(b.Points); i++ {
 				p = b.Points[i]

--- a/eval.go
+++ b/eval.go
@@ -104,6 +104,7 @@ func (e *EvalNode) runEval(snapshot []byte) error {
 		var err error
 		for b, ok := e.ins[0].NextBatch(); ok; b, ok = e.ins[0].NextBatch() {
 			e.timer.Start()
+			b.Points = b.ShallowCopyPoints()
 			for i := 0; i < len(b.Points); {
 				p := b.Points[i]
 				b.Points[i].Fields, b.Points[i].Tags, err = e.eval(p.Time, b.Group, p.Fields, p.Tags)

--- a/models/batch.go
+++ b/models/batch.go
@@ -78,6 +78,14 @@ func (b Batch) Copy() PointInterface {
 	return cb
 }
 
+// ShallowCopyPoints creates a new slice for the points but only shallow copies the points themselves.
+// Then if a single point needs to be modified it must first be copied.
+func (b Batch) ShallowCopyPoints() []BatchPoint {
+	points := make([]BatchPoint, len(b.Points))
+	copy(points, b.Points)
+	return points
+}
+
 func (b Batch) Setter() PointSetter {
 	return &b
 }

--- a/shift.go
+++ b/shift.go
@@ -47,6 +47,7 @@ func (s *ShiftNode) runShift([]byte) error {
 		for b, ok := s.ins[0].NextBatch(); ok; b, ok = s.ins[0].NextBatch() {
 			s.timer.Start()
 			b.TMax = b.TMax.Add(s.shift)
+			b.Points = b.ShallowCopyPoints()
 			for i, p := range b.Points {
 				b.Points[i].Time = p.Time.Add(s.shift)
 			}

--- a/state_tracking.go
+++ b/state_tracking.go
@@ -115,7 +115,7 @@ func (stn *StateTrackingNode) runStateTracking(_ []byte) error {
 			}
 			stg.tracker.reset()
 
-			b = b.Copy().(models.Batch)
+			b.Points = b.ShallowCopyPoints()
 			for i := 0; i < len(b.Points); {
 				p := &b.Points[i]
 				pass, err := EvalPredicate(stg.Expression, stg.ScopePool, p.Time, p.Fields, p.Tags)


### PR DESCRIPTION
Fixes #1379 
The idea of this change is to shallow copy the batch points slice so that nodes which modify the batch points slice do not collide.

The existing code already takes care to copy the maps before modification, but that didn't matter since the underlying slice was shared. This change copies the slice to prevent those issues.

This is horrible :), I really dislike how this came together and we need a better way to manage copying/modifying data. My hope is that the migration to message passing #1319 will open up a way to manage this better. There is simply too much onus on each implementation of a node to keep everything straight and not introduce new bugs.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
