### PR TITLE
Fix deadlock if Append happens at same time as Commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ For more details on the alerting system see the full documentation [here](https:
 - [#1369](https://github.com/influxdata/kapacitor/issues/1369): Fix panic with concurrent writes to same points in state tracking nodes.
 - [#1387](https://github.com/influxdata/kapacitor/pull/1387): static-discovery configuration simplified
 - [#1378](https://github.com/influxdata/kapacitor/issues/1378): Fix panic in InfluxQL node with missing field.
+- [#1392](https://github.com/influxdata/kapacitor/pull/1392): Fix possible deadlock for scraper configuration updating.
 
 ## v1.3.0-rc2 [2017-05-11]
 

--- a/services/scraper/service.go
+++ b/services/scraper/service.go
@@ -316,11 +316,11 @@ func (s *Service) RemoveScrapers(scrapers []Config) {
 		return
 	}
 
-	configs := s.loadConfigs()
+	configs := s.loadConfigs()[0:0]
 	for _, rm := range scrapers {
-		for i, c := range configs {
-			if c.Name == rm.Name {
-				configs = append(configs, configs[i+1:]...)
+		for _, c := range configs {
+			if c.Name != rm.Name {
+				configs = append(configs, c)
 			}
 		}
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

#### Problem
If an Append happened at the same time as a Commit of a configuration change it was possible to deadlock the scraper.

#### Solution

Update the Scraper config to be atomic.  This implies that the configuration is on a different lifecycle than the Append.
