### PR TITLE
Use the Prometheus metric name as the measurement name by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # Bugfixes
 
 - [#1379](https://github.com/influxdata/kapacitor/issues/1379): Copy batch points slice before modification, fixes potential panics and data corruption.
+- [#1394](https://github.com/influxdata/kapacitor/pull/1394): Use the Prometheus metric name as the measurement name by default for scrape data.
+- [#1392](https://github.com/influxdata/kapacitor/pull/1392): Fix possible deadlock for scraper configuration updating.
 
 ## v1.3.0-rc3 [2017-05-18]
 
@@ -105,7 +107,6 @@ For more details on the alerting system see the full documentation [here](https:
 - [#1369](https://github.com/influxdata/kapacitor/issues/1369): Fix panic with concurrent writes to same points in state tracking nodes.
 - [#1387](https://github.com/influxdata/kapacitor/pull/1387): static-discovery configuration simplified
 - [#1378](https://github.com/influxdata/kapacitor/issues/1378): Fix panic in InfluxQL node with missing field.
-- [#1392](https://github.com/influxdata/kapacitor/pull/1392): Fix possible deadlock for scraper configuration updating.
 
 ## v1.3.0-rc2 [2017-05-11]
 

--- a/services/scraper/config.go
+++ b/services/scraper/config.go
@@ -127,7 +127,7 @@ func encodeJobName(db, rp, name string) string {
 func decodeJobName(job string) (string, string, string, error) {
 	split := strings.Split(job, "|")
 	if len(split) != 3 {
-		return "", "", "", fmt.Errorf("unable to decode job name")
+		return "", "", "", fmt.Errorf("unable to decode job name %q", job)
 	}
 	return split[0], split[1], split[2], nil
 }


### PR DESCRIPTION

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Problem:

Raw scrape data from Prometheus targets was all in a single measurement and essentially unusable as a result.  Currently you must use some kind of TICKscript to transform the data to something more usable.

Solution:

Use the `__name__` tag as the measurement name, but leave the `__name__` tag on the raw data. This allows for transformations to be easily made if desired and for the default raw data to more accessible. 