### PR TITLE
Fix bug where env overrides stopped working for the k8s config section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 # Bugfixes
 
+- [#1396](https://github.com/influxdata/kapacitor/pull/1396): Fix broken ENV var config overrides for the kubernetes section.
+
 ## v1.3.0-rc4 [2017-05-19]
 
 - [#1379](https://github.com/influxdata/kapacitor/issues/1379): Copy batch points slice before modification, fixes potential panics and data corruption.

--- a/pipeline/k8s_autoscale.go
+++ b/pipeline/k8s_autoscale.go
@@ -144,7 +144,6 @@ type K8sAutoscaleNode struct {
 func newK8sAutoscaleNode(e EdgeType) *K8sAutoscaleNode {
 	k := &K8sAutoscaleNode{
 		chainnode:    newBasicChainNode("k8s_autoscale", e, StreamEdge),
-		Cluster:      "default",
 		Min:          1,
 		Kind:         client.DeploymentsKind,
 		NamespaceTag: DefaultNamespaceTag,


### PR DESCRIPTION


# Problem

Env vars like `KAPACITOR_KUBERNETES_..` previously worked but currently do not.

# Solution

Since the Kubernetes config section can be both a single section or a list of sections we have added support for implict 0 indexes in the env var names. This new behavior must be explicitly enabled for each configuration section that needs it. Currently on the kubernetes section needs this change. 