### PR TITLE
Added https-private-key as a separated parameter for httpd service

### DIFF
--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	PprofEnabled     bool          `toml:"pprof-enabled"`
 	HttpsEnabled     bool          `toml:"https-enabled"`
 	HttpsCertificate string        `toml:"https-certificate"`
+	HttpsPrivateKey  string        `toml:"https-private-key"`
 	ShutdownTimeout  toml.Duration `toml:"shutdown-timeout"`
 	SharedSecret     string        `toml:"shared-secret"`
 
@@ -35,6 +36,7 @@ func NewConfig() Config {
 		BindAddress:      ":9092",
 		LogEnabled:       true,
 		HttpsCertificate: "/etc/ssl/kapacitor.pem",
+		HttpsPrivateKey:  "/etc/ssl/kapacitor.key",
 		ShutdownTimeout:  DefaultShutdownTimeout,
 		GZIP:             true,
 	}

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -20,6 +20,7 @@ type Service struct {
 	addr  string
 	https bool
 	cert  string
+	key   string
 	err   chan error
 
 	externalURL string
@@ -56,6 +57,7 @@ func NewService(c Config, hostname string, l *log.Logger, li logging.Interface) 
 		addr:            c.BindAddress,
 		https:           c.HttpsEnabled,
 		cert:            c.HttpsCertificate,
+		key:             c.HttpsPrivateKey,
 		externalURL:     u.String(),
 		err:             make(chan error, 1),
 		shutdownTimeout: time.Duration(c.ShutdownTimeout),
@@ -84,7 +86,7 @@ func (s *Service) Open() error {
 
 	// Open listener.
 	if s.https {
-		cert, err := tls.LoadX509KeyPair(s.cert, s.cert)
+		cert, err := tls.LoadX509KeyPair(s.cert, s.key)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I've updated the httpd service to allow add a separated `https-private-key` parameter.
Usually, the [tls LoadX509KeyPair](https://golang.org/pkg/crypto/tls/#LoadX509KeyPair) use a different file for certificate and private key.

###### Required for all non-trivial PRs
- [x ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [x ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)