### PR TITLE
Use details field from alert node in pagerduty

### DIFF
--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -7828,6 +7828,8 @@ func TestStream_AlertPagerDuty(t *testing.T) {
 	ts := pagerdutytest.NewServer()
 	defer ts.Close()
 
+	defaultDetails := "{&#34;Name&#34;:&#34;cpu&#34;,&#34;TaskName&#34;:&#34;TestStream_Alert&#34;,&#34;Group&#34;:&#34;host=serverA&#34;,&#34;Tags&#34;:{&#34;host&#34;:&#34;serverA&#34;},&#34;ServerInfo&#34;:{&#34;Hostname&#34;:&#34;&#34;,&#34;ClusterID&#34;:&#34;&#34;,&#34;ServerID&#34;:&#34;&#34;},&#34;ID&#34;:&#34;kapacitor/cpu/serverA&#34;,&#34;Fields&#34;:{&#34;count&#34;:10},&#34;Level&#34;:&#34;CRITICAL&#34;,&#34;Time&#34;:&#34;1971-01-01T00:00:10Z&#34;,&#34;Message&#34;:&#34;CRITICAL alert for kapacitor/cpu/serverA&#34;}\n"
+
 	var script = `
 stream
 	|from()
@@ -7872,7 +7874,7 @@ stream
 				Description: "CRITICAL alert for kapacitor/cpu/serverA",
 				Client:      "kapacitor",
 				ClientURL:   kapacitorURL,
-				Details:     `{"series":[{"name":"cpu","tags":{"host":"serverA"},"columns":["time","count"],"values":[["1971-01-01T00:00:10Z",10]]}]}`,
+				Details:     defaultDetails,
 			},
 		},
 		pagerdutytest.Request{
@@ -7883,7 +7885,7 @@ stream
 				Description: "CRITICAL alert for kapacitor/cpu/serverA",
 				Client:      "kapacitor",
 				ClientURL:   kapacitorURL,
-				Details:     `{"series":[{"name":"cpu","tags":{"host":"serverA"},"columns":["time","count"],"values":[["1971-01-01T00:00:10Z",10]]}]}`,
+				Details:     defaultDetails,
 			},
 		},
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7264,6 +7264,7 @@ func TestServer_ListServiceTests(t *testing.T) {
 					"incident-key": "testIncidentKey",
 					"description":  "test pagerduty message",
 					"level":        "CRITICAL",
+					"details":      "",
 				},
 			},
 			{
@@ -8082,7 +8083,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 						Description: "message",
 						Client:      "kapacitor",
 						ClientURL:   kapacitorURL,
-						Details:     resultJSON,
+						Details:     "details",
 					},
 				}}
 				if !reflect.DeepEqual(exp, got) {


### PR DESCRIPTION
Fixes #743 

Previously the details field specified on an alert node was not being used in the pagerduty service. Instead, the results object that generated was being used. This PR now uses the details field specified.

@nathanielc is this all, or is there something I'm missing?

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
