### PR TITLE
Expose pprof without auth when enabled for httpd

### DIFF
--- a/services/httpd/httpdtest/server.go
+++ b/services/httpd/httpdtest/server.go
@@ -21,6 +21,7 @@ func NewServer(verbose bool) *Server {
 	s := &Server{
 		Handler: httpd.NewHandler(
 			false,
+			false,
 			verbose,
 			verbose,
 			false,

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -60,6 +60,7 @@ func NewService(c Config, hostname string, l *log.Logger, li logging.Interface) 
 		shutdownTimeout: time.Duration(c.ShutdownTimeout),
 		Handler: NewHandler(
 			c.AuthEnabled,
+			c.PprofEnabled,
 			c.LogEnabled,
 			c.WriteTracing,
 			c.GZIP,


### PR DESCRIPTION
Fixes https://github.com/influxdata/kapacitor/issues/1517

By default pprof routes are exposed independent of their configuration in the kapacitor config. If authentication was enabled, this would block pprof routes.

This PR introduces a bypass based on the `pprof-enabled` section of the configuration. Now, if both `pprof-enabled` and `auth-enabled` are true, the `pprof` routes will be exposed.