### PR TITLE
Fix of the Kapacitor crash on windows when starting recording: issues #902, #916

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugfixes
 
+- [#916](https://github.com/influxdata/kapacitor/issues/916): Crash of Kapacitor on Windows x64 when starting a recording
 - [#1400](https://github.com/influxdata/kapacitor/issues/1400): Allow for `.yml` file extensions in `define-topic-handler`
 - [#1402](https://github.com/influxdata/kapacitor/pull/1402): Fix http server error logging.
 - [#1500](https://github.com/influxdata/kapacitor/pull/1500): Fix bugs with stopping running UDF agent.

--- a/server/server_const_test.go
+++ b/server/server_const_test.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+//Platform dependent constants for non-windows
+package server_test
+
+const (
+	ExecutableSuffix    = ""
+	PythonExecutable    = "python2"
+	LogFileExpectedMode = 0604
+	AlertLogPath        = `/var/log/alert.log`
+)

--- a/server/server_const_windows_test.go
+++ b/server/server_const_windows_test.go
@@ -1,0 +1,11 @@
+// +build windows
+
+//Platform dependent constants for tests on windows
+package server_test
+
+const (
+	ExecutableSuffix    = ".exe"
+	PythonExecutable    = "python"
+	LogFileExpectedMode = 0666
+	AlertLogPath        = `c:\alert.log`
+)

--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -247,7 +247,7 @@ func (s *Service) syncRecordingMetadata() error {
 		}
 		dataUrl := url.URL{
 			Scheme: "file",
-			Path:   filepath.Join(s.saveDir, info.Name()),
+			Path:   filepath.ToSlash(filepath.Join(s.saveDir, info.Name())),
 		}
 		recording := Recording{
 			ID:       id,
@@ -578,7 +578,7 @@ func (s *Service) handleDeleteRecording(w http.ResponseWriter, r *http.Request) 
 func (s *Service) dataURLFromID(id, ext string) url.URL {
 	return url.URL{
 		Scheme: "file",
-		Path:   filepath.Join(s.saveDir, id+ext),
+		Path:   filepath.ToSlash(filepath.Join(s.saveDir, id+ext)),
 	}
 }
 
@@ -1637,10 +1637,16 @@ func parseDataSourceURL(rawurl string) (DataSource, error) {
 	}
 	switch u.Scheme {
 	case "file":
-		return fileSource(u.Path), nil
+		return fileSource(getFilePathFromUrl(u)), nil
 	default:
 		return nil, fmt.Errorf("unsupported data source scheme %s", u.Scheme)
 	}
+}
+
+//getFilePathFromUrl restores filesystem path from file URL
+func getFilePathFromUrl(url *url.URL) string {
+	//Host part on windows contains drive, on non windows it is empty
+	return url.Host + filepath.FromSlash(url.Path)
 }
 
 func (s fileSource) Size() (int64, error) {

--- a/tick/cmd/tickdoc/main.go
+++ b/tick/cmd/tickdoc/main.go
@@ -35,7 +35,7 @@ import (
 	"html"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -139,7 +139,7 @@ func main() {
 			weight = w
 		}
 		n.Render(&buf, r, nodes, weight)
-		filename := path.Join(out, snaker.CamelToSnake(name)+".md")
+		filename := filepath.Join(out, snaker.CamelToSnake(name)+".md")
 		log.Println("Writing file:", filename, i)
 		f, err := os.Create(filename)
 		if err != nil {


### PR DESCRIPTION
Fix of the Kapacitor crash on windows during recording: issues #902, #916. Verified on Windows 10 and Ubuntu 17.04

I would mark issue #902 as duplicate of #916 (#916 has more comments)  and update summary of #916 to  Crash of Kapacitor on Windows x64 when starting a recording

I've also fixed server tests to be platform independent.

Recording tests sometimes fail on deletion, server most probably slowly closes handles, I didn't dig into this.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

