### PR TITLE
Alerta support for timeout, tags and service template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     The breaking change is that the Combine and Flatten nodes previously, but erroneously, operated across batch boundaries; this has been fixed.
 - [#1497](https://github.com/influxdata/kapacitor/pull/1497): Add support for Docker Swarm autoscaling services.
 - [#1485](https://github.com/influxdata/kapacitor/issues/1485): Add bools field types to UDFs.
+- [#1545](https://github.com/influxdata/kapacitor/pull/1545): Add support for timeout, tags and service template in the Alerta AlertNode
 
 ### Bugfixes
 

--- a/alert.go
+++ b/alert.go
@@ -319,6 +319,9 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, l *log.Logger) (an *
 		if len(a.Service) != 0 {
 			c.Service = a.Service
 		}
+		if a.Timeout != 0 {
+			c.Timeout = a.Timeout
+		}
 		h, err := et.tm.AlertaService.Handler(c, l)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create Alerta handler")

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -7616,6 +7616,7 @@ stream
 		.alerta()
 			.token('testtoken1234567')
 			.environment('production')
+			.timeout(1h)
 		.alerta()
 			.token('anothertesttoken')
 			.resource('resource: {{ index .Tags "host" }}')
@@ -7624,7 +7625,7 @@ stream
 			.origin('override')
 			.group('{{ .ID }}')
 			.value('{{ index .Fields "count" }}')
-			.services('serviceA', 'serviceB')
+			.services('serviceA', 'serviceB', '{{ .Name }}')
 `
 	tmInit := func(tm *kapacitor.TaskMaster) {
 		c := alerta.NewConfig()
@@ -7648,6 +7649,7 @@ stream
 				Text:        "kapacitor/cpu/serverA is CRITICAL @1971-01-01 00:00:10 +0000 UTC",
 				Origin:      "Kapacitor",
 				Service:     []string{"cpu"},
+				Timeout:     3600,
 			},
 		},
 		alertatest.Request{
@@ -7660,8 +7662,9 @@ stream
 				Environment: "serverA",
 				Text:        "kapacitor/cpu/serverA is CRITICAL @1971-01-01 00:00:10 +0000 UTC",
 				Origin:      "override",
-				Service:     []string{"serviceA", "serviceB"},
+				Service:     []string{"serviceA", "serviceB", "cpu"},
 				Value:       "10",
+				Timeout:     86400,
 			},
 		},
 	}

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -945,6 +945,7 @@ type HipChatHandler struct {
 //                 .event('Something went wrong')
 //                 .environment('Development')
 //                 .group('Dev. Servers')
+//                 .timeout(5m)
 //
 // NOTE: Alerta cannot be configured globally because of its required properties.
 // tick:property
@@ -996,6 +997,10 @@ type AlertaHandler struct {
 	// List of effected Services
 	// tick:ignore
 	Service []string `tick:"Services"`
+
+	// Alerta timeout.
+	// Default: 24h
+	Timeout time.Duration
 }
 
 // List of effected services.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5918,6 +5918,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 						"token-prefix": "",
 						"url":          "http://alerta.example.com",
 						"insecure-skip-verify": false,
+						"timeout":              "0s",
 					},
 					Redacted: []string{
 						"token",
@@ -5934,6 +5935,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 					"token-prefix": "",
 					"url":          "http://alerta.example.com",
 					"insecure-skip-verify": false,
+					"timeout":              "0s",
 				},
 				Redacted: []string{
 					"token",
@@ -5943,8 +5945,9 @@ func TestServer_UpdateConfig(t *testing.T) {
 				{
 					updateAction: client.ConfigUpdateAction{
 						Set: map[string]interface{}{
-							"token":  "token",
-							"origin": "kapacitor",
+							"token":   "token",
+							"origin":  "kapacitor",
+							"timeout": "3h",
 						},
 					},
 					expSection: client.ConfigSection{
@@ -5959,6 +5962,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 								"token-prefix": "",
 								"url":          "http://alerta.example.com",
 								"insecure-skip-verify": false,
+								"timeout":              "3h0m0s",
 							},
 							Redacted: []string{
 								"token",
@@ -5975,6 +5979,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 							"token-prefix": "",
 							"url":          "http://alerta.example.com",
 							"insecure-skip-verify": false,
+							"timeout":              "3h0m0s",
 						},
 						Redacted: []string{
 							"token",
@@ -7352,6 +7357,7 @@ func TestServer_ListServiceTests(t *testing.T) {
 						"testServiceA",
 						"testServiceB",
 					},
+					"timeout": "24h0m0s",
 				},
 			},
 			{
@@ -8066,6 +8072,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 					"origin":       "kapacitor",
 					"group":        "test",
 					"environment":  "env",
+					"timeout":      time.Duration(24 * time.Hour),
 				},
 			},
 			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
@@ -8091,6 +8098,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 						Text:        "message",
 						Origin:      "kapacitor",
 						Service:     []string{"alert"},
+						Timeout:     86400,
 					},
 				}}
 				if !reflect.DeepEqual(exp, got) {

--- a/services/alerta/alertatest/alertatest.go
+++ b/services/alerta/alertatest/alertatest.go
@@ -61,4 +61,5 @@ type PostData struct {
 	Origin      string   `json:"origin"`
 	Service     []string `json:"service"`
 	Value       string   `json:"value"`
+	Timeout     int64    `json:"timeout"`
 }

--- a/services/alerta/config.go
+++ b/services/alerta/config.go
@@ -3,6 +3,7 @@ package alerta
 import (
 	"net/url"
 
+	"github.com/influxdata/influxdb/toml"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,8 @@ type Config struct {
 	Environment string `toml:"environment" override:"environment"`
 	// The origin of the alert.
 	Origin string `toml:"origin" override:"origin"`
+	// Optional timeout, can be overridden per alert.
+	Timeout toml.Duration `toml:"timeout" override:"timeout"`
 }
 
 func NewConfig() Config {


### PR DESCRIPTION
Add template support to service field as requested in #1543
Add timeout support as requested in #1264 
Add tags support as requested in #1546 

##### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)