### PR TITLE
Add now built in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     The breaking change is that the Combine and Flatten nodes previously, but erroneously, operated across batch boundaries; this has been fixed.
 - [#1497](https://github.com/influxdata/kapacitor/pull/1497): Add support for Docker Swarm autoscaling services.
 - [#1485](https://github.com/influxdata/kapacitor/issues/1485): Add bools field types to UDFs.
+- [#1549](https://github.com/influxdata/kapacitor/issues/1549): Add stateless now() function to get the current local time.
 - [#1545](https://github.com/influxdata/kapacitor/pull/1545): Add support for timeout, tags and service template in the Alerta AlertNode
 - [#1568](https://github.com/influxdata/kapacitor/issues/1568): Add support for custom HTTP Post bodies via a template system.
 - [#1569](https://github.com/influxdata/kapacitor/issues/1569): Add support for add the HTTP status code as a field when using httpPost

--- a/integrations/data/TestStream_EvalNow.srpl
+++ b/integrations/data/TestStream_EvalNow.srpl
@@ -1,0 +1,3 @@
+dbname
+rpname
+account,owner=ownerA expiration=315533000000000000i 0000000001

--- a/integrations/data/TestStream_LambdaNow.srpl
+++ b/integrations/data/TestStream_LambdaNow.srpl
@@ -1,0 +1,9 @@
+dbname
+rpname
+account,owner=ownerA expiration=315533000000000000i 0000000001
+dbname
+rpname
+account,owner=ownerB expiration=4102440000000000000i 0000000001
+dbname
+rpname
+account,owner=ownerC expiration=656419000000000000i 0000000001

--- a/tick/stateful/functions.go
+++ b/tick/stateful/functions.go
@@ -225,6 +225,7 @@ func init() {
 	statelessFuncs["day"] = day{}
 	statelessFuncs["month"] = month{}
 	statelessFuncs["year"] = year{}
+	statelessFuncs["now"] = now{}
 
 	// Humanize functions
 	statelessFuncs["humanBytes"] = humanBytes{}
@@ -1352,6 +1353,34 @@ func (year) Call(args ...interface{}) (v interface{}, err error) {
 
 func (year) Signature() map[Domain]ast.ValueType {
 	return timeFuncSignature
+}
+
+var nowFuncSignature = map[Domain]ast.ValueType{}
+
+// Initialize Now function signature
+func init() {
+	d := Domain{}
+	nowFuncSignature[d] = ast.TTime
+}
+
+type now struct {
+}
+
+func (now) Reset() {
+}
+
+// Return the current local time.
+func (now) Call(args ...interface{}) (v interface{}, err error) {
+	if len(args) != 0 {
+		return 0, errors.New("now expects exactly zero argument")
+	}
+	v = time.Now()
+
+	return
+}
+
+func (now) Signature() map[Domain]ast.ValueType {
+	return nowFuncSignature
 }
 
 type humanBytes struct {


### PR DESCRIPTION
This pull request adds a stateless function now() that could be used in conjunction with the recently merged function unixNano() to compare fields containing time encoded in nanoseconds with the current time.
Relevant feature request: [Add stateless function now() to get the current local time](https://github.com/influxdata/kapacitor/issues/1549)

###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [X] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

(pull request beginner here, please let me know if I've made a mistake in the process, thanks)