### PR TITLE
Add BarrierNode to emit BarrierMessage periodically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## unreleased
+## Unreleased
+- [#1566](https://github.com/influxdata/kapacitor/pull/1566): Add BarrierNode to emit BarrierMessage periodically
 
 ### Features
 

--- a/barrier.go
+++ b/barrier.go
@@ -8,19 +8,14 @@ import (
 	"sync/atomic"
 
 	"github.com/influxdata/kapacitor/edge"
+	"github.com/influxdata/kapacitor/models"
 	"github.com/influxdata/kapacitor/pipeline"
 )
 
 type BarrierNode struct {
 	node
-	b *pipeline.BarrierNode
-
-	idle   time.Duration
-	period time.Duration
-	lastT  atomic.Value
-	timer  *time.Timer
-	ticker *time.Ticker
-	wg     sync.WaitGroup
+	b              *pipeline.BarrierNode
+	barrierStopper map[models.GroupID]func()
 }
 
 // Create a new  BarrierNode, which emits a barrier if data traffic has been idle for the configured amount of time.
@@ -29,107 +24,249 @@ func newBarrierNode(et *ExecutingTask, n *pipeline.BarrierNode, d NodeDiagnostic
 		return nil, errors.New("barrier node must have either a non zero idle or a non zero period")
 	}
 	bn := &BarrierNode{
-		b:      n,
-		node:   node{Node: n, et: et, diag: d},
-		idle:   n.Idle,
-		period: n.Period,
+		node:           node{Node: n, et: et, diag: d},
+		b:              n,
+		barrierStopper: map[models.GroupID]func(){},
 	}
 	bn.node.runF = bn.runBarrierEmitter
 	return bn, nil
 }
 
 func (n *BarrierNode) runBarrierEmitter([]byte) error {
-	n.lastT.Store(time.Time{})
-	stopC := make(chan bool, 1)
-	n.wg.Add(1)
-
-	if n.idle > 0 {
-		n.timer = time.NewTimer(n.idle)
-		defer func() {
-			stopC <- true
-			n.timer.Stop()
-			n.wg.Wait()
-		}()
-		go n.idleHandler(stopC)
-	}
-	if n.period > 0 {
-		n.ticker = time.NewTicker(n.period)
-		defer func() {
-			stopC <- true
-			n.ticker.Stop()
-			n.wg.Wait()
-		}()
-		go n.periodicEmitter(stopC)
-	}
-
-	consumer := edge.NewConsumerWithReceiver(n.ins[0], n)
+	defer n.stopBarrierEmitter()
+	consumer := edge.NewGroupedConsumer(n.ins[0], n)
+	n.statMap.Set(statCardinalityGauge, consumer.CardinalityVar())
 	return consumer.Consume()
 }
 
-func (n *BarrierNode) BeginBatch(m edge.BeginBatchMessage) error {
-	return edge.Forward(n.outs, m)
-}
-func (n *BarrierNode) BatchPoint(m edge.BatchPointMessage) error {
-	if !m.Time().Before(n.lastT.Load().(time.Time)) {
-		n.resetTimer()
-		return edge.Forward(n.outs, m)
+func (n *BarrierNode) stopBarrierEmitter() {
+	for _, stopF := range n.barrierStopper {
+		stopF()
 	}
-	return nil
-}
-func (n *BarrierNode) EndBatch(m edge.EndBatchMessage) error {
-	return edge.Forward(n.outs, m)
-}
-func (n *BarrierNode) Barrier(m edge.BarrierMessage) error {
-	if !m.Time().Before(n.lastT.Load().(time.Time)) {
-		n.resetTimer()
-		return edge.Forward(n.outs, m)
-	}
-	return nil
-}
-func (n *BarrierNode) DeleteGroup(m edge.DeleteGroupMessage) error {
-	return edge.Forward(n.outs, m)
 }
 
-func (n *BarrierNode) Point(m edge.PointMessage) error {
-	if !m.Time().Before(n.lastT.Load().(time.Time)) {
-		n.resetTimer()
-		return edge.Forward(n.outs, m)
+func (n *BarrierNode) NewGroup(group edge.GroupInfo, first edge.PointMeta) (edge.Receiver, error) {
+	r, stopF, err := n.newBarrier(group, first)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	n.barrierStopper[group.ID] = stopF
+	return edge.NewReceiverFromForwardReceiverWithStats(
+		n.outs,
+		edge.NewTimedForwardReceiver(n.timer, r),
+	), nil
 }
 
-func (n *BarrierNode) resetTimer() {
+func (n *BarrierNode) newBarrier(group edge.GroupInfo, first edge.PointMeta) (edge.ForwardReceiver, func(), error) {
+	switch {
+	case n.b.Idle != 0:
+		idleBarrier := newIdleBarrier(
+			first.Name(),
+			group,
+			n.b.Idle,
+			n.outs,
+		)
+		return idleBarrier, idleBarrier.Stop, nil
+	case n.b.Period != 0:
+		periodicBarrier := newPeriodicBarrier(
+			first.Name(),
+			group,
+			n.b.Period,
+			n.outs,
+		)
+		return periodicBarrier, periodicBarrier.Stop, nil
+	default:
+		return nil, nil, errors.New("unreachable code, barrier node should have non-zero idle or non-zero period")
+	}
+}
+
+type idleBarrier struct {
+	name  string
+	group edge.GroupInfo
+
+	idle  time.Duration
+	lastT atomic.Value
+	timer *time.Timer
+	wg    sync.WaitGroup
+	outs  []edge.StatsEdge
+	stopC chan bool
+}
+
+func newIdleBarrier(name string, group edge.GroupInfo, idle time.Duration, outs []edge.StatsEdge) *idleBarrier {
+	r := &idleBarrier{
+		name:  name,
+		group: group,
+		idle:  idle,
+		lastT: atomic.Value{},
+		timer: time.NewTimer(idle),
+		wg:    sync.WaitGroup{},
+		outs:  outs,
+		stopC: make(chan bool, 1),
+	}
+
+	r.Init()
+
+	return r
+}
+
+func (n *idleBarrier) Init() {
+	n.lastT.Store(time.Time{})
+	n.wg.Add(1)
+
+	go n.idleHandler()
+}
+
+func (n *idleBarrier) Stop() {
+	n.stopC <- true
+	n.timer.Stop()
+	n.wg.Wait()
+}
+
+func (n *idleBarrier) BeginBatch(m edge.BeginBatchMessage) (edge.Message, error) {
+	return m, nil
+}
+func (n *idleBarrier) BatchPoint(m edge.BatchPointMessage) (edge.Message, error) {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		n.resetTimer()
+		return m, nil
+	}
+	return nil, nil
+}
+func (n *idleBarrier) EndBatch(m edge.EndBatchMessage) (edge.Message, error) {
+	return m, nil
+}
+func (n *idleBarrier) Barrier(m edge.BarrierMessage) (edge.Message, error) {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		n.resetTimer()
+		return m, nil
+	}
+	return nil, nil
+}
+func (n *idleBarrier) DeleteGroup(m edge.DeleteGroupMessage) (edge.Message, error) {
+	if m.GroupID() == n.group.ID {
+		n.Stop()
+	}
+	return m, nil
+}
+
+func (n *idleBarrier) Point(m edge.PointMessage) (edge.Message, error) {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		n.resetTimer()
+		return m, nil
+	}
+	return nil, nil
+}
+
+func (n *idleBarrier) resetTimer() {
 	if n.idle > 0 {
 		n.timer.Reset(n.idle)
 	}
 }
 
-func (n *BarrierNode) emitBarrier() error {
+func (n *idleBarrier) emitBarrier() error {
 	nowT := time.Now()
 	n.lastT.Store(nowT)
-	return edge.Forward(n.outs, edge.NewBarrierMessage(nowT))
+	return edge.Forward(n.outs, edge.NewBarrierMessage(n.group, nowT))
 }
 
-func (n *BarrierNode) idleHandler(stopC <-chan bool) {
+func (n *idleBarrier) idleHandler() {
 	defer n.wg.Done()
 	for {
 		select {
 		case <-n.timer.C:
 			n.emitBarrier()
 			n.resetTimer()
-		case <-stopC:
+		case <-n.stopC:
 			return
 		}
 	}
 }
 
-func (n *BarrierNode) periodicEmitter(stopC <-chan bool) {
+type periodicBarrier struct {
+	name  string
+	group edge.GroupInfo
+
+	lastT  atomic.Value
+	ticker *time.Ticker
+	wg     sync.WaitGroup
+	outs   []edge.StatsEdge
+	stopC  chan bool
+}
+
+func newPeriodicBarrier(name string, group edge.GroupInfo, period time.Duration, outs []edge.StatsEdge) *periodicBarrier {
+	r := &periodicBarrier{
+		name:   name,
+		group:  group,
+		lastT:  atomic.Value{},
+		ticker: time.NewTicker(period),
+		wg:     sync.WaitGroup{},
+		outs:   outs,
+		stopC:  make(chan bool, 1),
+	}
+
+	r.Init()
+
+	return r
+}
+
+func (n *periodicBarrier) Init() {
+	n.lastT.Store(time.Time{})
+	n.wg.Add(1)
+
+	go n.periodicEmitter()
+}
+
+func (n *periodicBarrier) Stop() {
+	n.stopC <- true
+	n.ticker.Stop()
+	n.wg.Wait()
+}
+
+func (n *periodicBarrier) BeginBatch(m edge.BeginBatchMessage) (edge.Message, error) {
+	return m, nil
+}
+func (n *periodicBarrier) BatchPoint(m edge.BatchPointMessage) (edge.Message, error) {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		return m, nil
+	}
+	return nil, nil
+}
+func (n *periodicBarrier) EndBatch(m edge.EndBatchMessage) (edge.Message, error) {
+	return m, nil
+}
+func (n *periodicBarrier) Barrier(m edge.BarrierMessage) (edge.Message, error) {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		return m, nil
+	}
+	return nil, nil
+}
+func (n *periodicBarrier) DeleteGroup(m edge.DeleteGroupMessage) (edge.Message, error) {
+	if m.GroupID() == n.group.ID {
+		n.Stop()
+	}
+	return m, nil
+}
+
+func (n *periodicBarrier) Point(m edge.PointMessage) (edge.Message, error) {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		return m, nil
+	}
+	return nil, nil
+}
+
+func (n *periodicBarrier) emitBarrier() error {
+	nowT := time.Now()
+	n.lastT.Store(nowT)
+	return edge.Forward(n.outs, edge.NewBarrierMessage(n.group, nowT))
+}
+
+func (n *periodicBarrier) periodicEmitter() {
 	defer n.wg.Done()
 	for {
 		select {
 		case <-n.ticker.C:
 			n.emitBarrier()
-		case <-stopC:
+		case <-n.stopC:
 			return
 		}
 	}

--- a/barrier.go
+++ b/barrier.go
@@ -89,7 +89,7 @@ type idleBarrier struct {
 	timer *time.Timer
 	wg    sync.WaitGroup
 	outs  []edge.StatsEdge
-	stopC chan interface{}
+	stopC chan struct{}
 }
 
 func newIdleBarrier(name string, group edge.GroupInfo, idle time.Duration, outs []edge.StatsEdge) *idleBarrier {
@@ -101,7 +101,7 @@ func newIdleBarrier(name string, group edge.GroupInfo, idle time.Duration, outs 
 		timer: time.NewTimer(idle),
 		wg:    sync.WaitGroup{},
 		outs:  outs,
-		stopC: make(chan interface{}, 1),
+		stopC: make(chan struct{}, 1),
 	}
 
 	r.Init()

--- a/barrier.go
+++ b/barrier.go
@@ -161,7 +161,7 @@ func (n *idleBarrier) resetTimer() {
 }
 
 func (n *idleBarrier) emitBarrier() error {
-	nowT := time.Now()
+	nowT := time.Now().UTC()
 	n.lastT.Store(nowT)
 	return edge.Forward(n.outs, edge.NewBarrierMessage(n.group, nowT))
 }
@@ -259,7 +259,7 @@ func (n *periodicBarrier) Point(m edge.PointMessage) (edge.Message, error) {
 }
 
 func (n *periodicBarrier) emitBarrier() error {
-	nowT := time.Now()
+	nowT := time.Now().UTC()
 	n.lastT.Store(nowT)
 	return edge.Forward(n.outs, edge.NewBarrierMessage(n.group, nowT))
 }

--- a/barrier.go
+++ b/barrier.go
@@ -89,7 +89,7 @@ type idleBarrier struct {
 	timer *time.Timer
 	wg    sync.WaitGroup
 	outs  []edge.StatsEdge
-	stopC chan bool
+	stopC chan interface{}
 }
 
 func newIdleBarrier(name string, group edge.GroupInfo, idle time.Duration, outs []edge.StatsEdge) *idleBarrier {
@@ -101,7 +101,7 @@ func newIdleBarrier(name string, group edge.GroupInfo, idle time.Duration, outs 
 		timer: time.NewTimer(idle),
 		wg:    sync.WaitGroup{},
 		outs:  outs,
-		stopC: make(chan bool, 1),
+		stopC: make(chan interface{}, 1),
 	}
 
 	r.Init()
@@ -117,7 +117,7 @@ func (n *idleBarrier) Init() {
 }
 
 func (n *idleBarrier) Stop() {
-	n.stopC <- true
+	close(n.stopC)
 	n.timer.Stop()
 	n.wg.Wait()
 }
@@ -158,9 +158,7 @@ func (n *idleBarrier) Point(m edge.PointMessage) (edge.Message, error) {
 }
 
 func (n *idleBarrier) resetTimer() {
-	if n.idle > 0 {
-		n.timer.Reset(n.idle)
-	}
+	n.timer.Reset(n.idle)
 }
 
 func (n *idleBarrier) emitBarrier() error {

--- a/barrier.go
+++ b/barrier.go
@@ -158,6 +158,7 @@ func (n *idleBarrier) Point(m edge.PointMessage) (edge.Message, error) {
 }
 
 func (n *idleBarrier) resetTimer() {
+	n.timer.Stop()
 	n.timer.Reset(n.idle)
 }
 

--- a/barrier.go
+++ b/barrier.go
@@ -1,0 +1,136 @@
+package kapacitor
+
+import (
+	"errors"
+	"time"
+
+	"sync"
+	"sync/atomic"
+
+	"github.com/influxdata/kapacitor/edge"
+	"github.com/influxdata/kapacitor/pipeline"
+)
+
+type BarrierNode struct {
+	node
+	b *pipeline.BarrierNode
+
+	idle   time.Duration
+	period time.Duration
+	lastT  atomic.Value
+	timer  *time.Timer
+	ticker *time.Ticker
+	wg     sync.WaitGroup
+}
+
+// Create a new  BarrierNode, which emits a barrier if data traffic has been idle for the configured amount of time.
+func newBarrierNode(et *ExecutingTask, n *pipeline.BarrierNode, d NodeDiagnostic) (*BarrierNode, error) {
+	if n.Idle == 0 && n.Period == 0 {
+		return nil, errors.New("barrier node must have either a non zero idle or a non zero period")
+	}
+	bn := &BarrierNode{
+		b:      n,
+		node:   node{Node: n, et: et, diag: d},
+		idle:   n.Idle,
+		period: n.Period,
+	}
+	bn.node.runF = bn.runBarrierEmitter
+	return bn, nil
+}
+
+func (n *BarrierNode) runBarrierEmitter([]byte) error {
+	n.lastT.Store(time.Time{})
+	stopC := make(chan bool, 1)
+	n.wg.Add(1)
+
+	if n.idle > 0 {
+		n.timer = time.NewTimer(n.idle)
+		defer func() {
+			stopC <- true
+			n.timer.Stop()
+			n.wg.Wait()
+		}()
+		go n.idleHandler(stopC)
+	}
+	if n.period > 0 {
+		n.ticker = time.NewTicker(n.period)
+		defer func() {
+			stopC <- true
+			n.ticker.Stop()
+			n.wg.Wait()
+		}()
+		go n.periodicEmitter(stopC)
+	}
+
+	consumer := edge.NewConsumerWithReceiver(n.ins[0], n)
+	return consumer.Consume()
+}
+
+func (n *BarrierNode) BeginBatch(m edge.BeginBatchMessage) error {
+	return edge.Forward(n.outs, m)
+}
+func (n *BarrierNode) BatchPoint(m edge.BatchPointMessage) error {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		n.resetTimer()
+		return edge.Forward(n.outs, m)
+	}
+	return nil
+}
+func (n *BarrierNode) EndBatch(m edge.EndBatchMessage) error {
+	return edge.Forward(n.outs, m)
+}
+func (n *BarrierNode) Barrier(m edge.BarrierMessage) error {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		n.resetTimer()
+		return edge.Forward(n.outs, m)
+	}
+	return nil
+}
+func (n *BarrierNode) DeleteGroup(m edge.DeleteGroupMessage) error {
+	return edge.Forward(n.outs, m)
+}
+
+func (n *BarrierNode) Point(m edge.PointMessage) error {
+	if !m.Time().Before(n.lastT.Load().(time.Time)) {
+		n.resetTimer()
+		return edge.Forward(n.outs, m)
+	}
+	return nil
+}
+
+func (n *BarrierNode) resetTimer() {
+	if n.idle > 0 {
+		n.timer.Reset(n.idle)
+	}
+}
+
+func (n *BarrierNode) emitBarrier() error {
+	nowT := time.Now()
+	n.lastT.Store(nowT)
+	return edge.Forward(n.outs, edge.NewBarrierMessage(nowT))
+}
+
+func (n *BarrierNode) idleHandler(stopC <-chan bool) {
+	defer n.wg.Done()
+	for {
+		select {
+		case <-n.timer.C:
+			n.emitBarrier()
+			n.resetTimer()
+		case <-stopC:
+			return
+		}
+	}
+}
+
+func (n *BarrierNode) periodicEmitter(stopC <-chan bool) {
+	defer n.wg.Done()
+	for {
+		select {
+		case <-n.ticker.C:
+			n.emitBarrier()
+		case <-stopC:
+			return
+		}
+	}
+}

--- a/edge/grouped.go
+++ b/edge/grouped.go
@@ -108,13 +108,11 @@ func (c *groupedConsumer) Point(p PointMessage) error {
 }
 
 func (c *groupedConsumer) Barrier(b BarrierMessage) error {
-	// Barriers messages apply to all gorups
-	for _, r := range c.groups {
-		if err := r.Barrier(b); err != nil {
-			return err
-		}
+	r, err := c.getOrCreateGroup(b.GroupInfo(), b)
+	if err != nil {
+		return err
 	}
-	return nil
+	return r.Barrier(b)
 }
 
 func (c *groupedConsumer) DeleteGroup(d DeleteGroupMessage) error {

--- a/edge/messages.go
+++ b/edge/messages.go
@@ -876,15 +876,21 @@ func (l BatchPointMessages) Swap(i int, j int)      { l[i], l[j] = l[j], l[i] }
 type BarrierMessage interface {
 	Message
 	ShallowCopy() BarrierMessage
-	TimeSetter
+	GroupInfoer
+	NameGetter
+	DimensionGetter
+	TagGetter
+	TimeGetter
 }
 type barrierMessage struct {
-	time time.Time
+	group GroupInfo
+	time  time.Time
 }
 
-func NewBarrierMessage(time time.Time) BarrierMessage {
+func NewBarrierMessage(group GroupInfo, time time.Time) BarrierMessage {
 	return &barrierMessage{
-		time: time,
+		group: group,
+		time:  time,
 	}
 }
 
@@ -894,14 +900,29 @@ func (b *barrierMessage) ShallowCopy() BarrierMessage {
 	return c
 }
 
+func (*barrierMessage) Name() string {
+	return "barrier"
+}
+
+func (*barrierMessage) Dimensions() models.Dimensions {
+	return models.Dimensions{}
+}
+
+func (*barrierMessage) Tags() models.Tags {
+	return models.Tags{}
+}
+
 func (*barrierMessage) Type() MessageType {
 	return Barrier
 }
+func (b *barrierMessage) GroupID() models.GroupID {
+	return b.group.ID
+}
+func (b *barrierMessage) GroupInfo() GroupInfo {
+	return b.group
+}
 func (b *barrierMessage) Time() time.Time {
 	return b.time
-}
-func (b *barrierMessage) SetTime(time time.Time) {
-	b.time = time
 }
 
 type DeleteGroupMessage interface {

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -1513,7 +1513,7 @@ stream
 		}
 	}()
 
-	// TODO: may have to update if groupedconsumer adds default group or some support for when there are no messages
+	// groupedconsumers do not run any logic until at least one message is seen
 	data := make([]edge.PointMessage, len(testValues))
 	for i, testValue := range testValues {
 		data[i] = edge.NewPointMessage(
@@ -1924,7 +1924,7 @@ stream
 		}
 	}()
 
-	// TODO: may have to update if groupedconsumer adds default group or some support for when there are no messages
+	// groupedconsumers do not run any logic until at least one message is seen
 	data := make([]edge.PointMessage, len(testValues))
 	for i, testValue := range testValues {
 		data[i] = edge.NewPointMessage(

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -20,6 +20,8 @@ import (
 	"text/template"
 	"time"
 
+	"math/rand"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/influxdata/influxdb/client"
@@ -29,6 +31,7 @@ import (
 	"github.com/influxdata/kapacitor/clock"
 	"github.com/influxdata/kapacitor/command"
 	"github.com/influxdata/kapacitor/command/commandtest"
+	"github.com/influxdata/kapacitor/edge"
 	"github.com/influxdata/kapacitor/keyvalue"
 	"github.com/influxdata/kapacitor/models"
 	alertservice "github.com/influxdata/kapacitor/services/alert"
@@ -1457,6 +1460,826 @@ stream
 	}
 
 	testStreamerWithOutput(t, "TestStream_Window_FillPeriod_Aligned", script, 21*time.Second, er, false, nil)
+}
+
+func TestStream_Barrier_Idle_No_Data(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC())
+	requestCount := int32(0)
+
+	testValues := make([][]interface{}, 1)
+	for i := 0; i < 1; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+	}))
+	defer ts.Close()
+
+	var script = `
+var period = 14s
+var every = 2s
+var idle = 2s
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().idle(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Idle_No_Data", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// barrier should emit at least 4 times
+		if rc := atomic.LoadInt32(&requestCount); rc != 2 {
+			t.Errorf("got %v exp %v", rc, 2)
+		}
+	}()
+
+	// TODO: may have to update if groupedconsumer adds default group or some support for when there are no messages
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+
+	time.Sleep(5 * time.Second)
+	close(dataChannel)
+}
+
+func TestStream_Barrier_Idle(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC().Add(-22 * time.Second))
+	clock.Set(time.Now().UTC())
+	testValues := make([][]interface{}, 21)
+	for i := 0; i < 21; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+	requestCount := int32(0)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+		rc := atomic.LoadInt32(&requestCount)
+
+		var er models.Result
+		switch rc {
+		case 1:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[0:10],
+					},
+				},
+			}
+		case 2:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[6:20],
+					},
+				},
+			}
+		case 3:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[16:21],
+					},
+				},
+			}
+		}
+		if eq, msg := compareResults(er, result); !eq {
+			t.Errorf("unexpected alert data for request: %d %s", rc, msg)
+		}
+	}))
+	defer ts.Close()
+
+	var script = `
+var period = 14s
+var every = 10s
+var idle = 10s
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().idle(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Idle", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// Force emit should force the last window to emit
+		if rc := atomic.LoadInt32(&requestCount); rc != 3 {
+			t.Errorf("got %v exp %v", rc, 3)
+		}
+	}()
+
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	time.Sleep(11 * time.Second)
+	close(dataChannel)
+}
+
+func TestStream_Barrier_Idle_No_Idle(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC().Add(-22 * time.Second))
+	clock.Set(time.Now().UTC())
+	testValues := make([][]interface{}, 21)
+	for i := 0; i < 21; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+	requestCount := int32(0)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+		rc := atomic.LoadInt32(&requestCount)
+
+		var er models.Result
+		switch rc {
+		case 1:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[0:10],
+					},
+				},
+			}
+		case 2:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[6:20],
+					},
+				},
+			}
+		case 3:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[16:21],
+					},
+				},
+			}
+		}
+		if eq, msg := compareResults(er, result); !eq {
+			t.Errorf("unexpected alert data for request: %d %s", rc, msg)
+		}
+	}))
+	defer ts.Close()
+
+	var script = `
+var period = 14s
+var every = 10s
+var idle = 10s
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().idle(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Idle_No_Idle", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// Force emit should force the last window to emit
+		if rc := atomic.LoadInt32(&requestCount); rc != 2 {
+			t.Errorf("got %v exp %v", rc, 2)
+		}
+	}()
+
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	close(dataChannel)
+}
+
+func TestStream_Barrier_Idle_Replay_After_Idle(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC().Add(-22 * time.Second))
+	clock.Set(time.Now().UTC())
+	testValues := make([][]interface{}, 21)
+	for i := 0; i < 21; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+	requestCount := int32(0)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+		rc := atomic.LoadInt32(&requestCount)
+
+		var er models.Result
+		switch rc {
+		case 1:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[0:10],
+					},
+				},
+			}
+		case 2:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[6:20],
+					},
+				},
+			}
+		case 3:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[16:21],
+					},
+				},
+			}
+		}
+		if eq, msg := compareResults(er, result); !eq {
+			t.Errorf("unexpected alert data for request: %d %s", rc, msg)
+		}
+	}))
+	defer ts.Close()
+
+	var script = `
+var period = 14s
+var every = 10s
+var idle = 10s
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().idle(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Idle", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// Force emit should force the last window to emit
+		if rc := atomic.LoadInt32(&requestCount); rc != 3 {
+			t.Errorf("got %v exp %v", rc, 3)
+		}
+	}()
+
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	time.Sleep(11 * time.Second)
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	close(dataChannel)
+}
+
+func TestStream_Barrier_Period_No_Data(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC())
+	requestCount := int32(0)
+
+	testValues := make([][]interface{}, 1)
+	for i := 0; i < 1; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+	}))
+	defer ts.Close()
+
+	// NOTE: using a slightly higher than 2s idle because timer was going off within a few ms of window period 50% of
+	// the time
+	var script = `
+var period = 14s
+var every = 2s
+var idle = 2100ms
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().period(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Period_No_Data", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// barrier should emit at least 4 times
+		if rc := atomic.LoadInt32(&requestCount); rc != 2 {
+			t.Errorf("got %v exp %v", rc, 2)
+		}
+	}()
+
+	// TODO: may have to update if groupedconsumer adds default group or some support for when there are no messages
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+
+	time.Sleep(5 * time.Second)
+	close(dataChannel)
+}
+
+func TestStream_Barrier_Period(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC().Add(-22 * time.Second))
+	clock.Set(time.Now().UTC())
+	testValues := make([][]interface{}, 21)
+	for i := 0; i < 21; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+	requestCount := int32(0)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+		rc := atomic.LoadInt32(&requestCount)
+
+		var er models.Result
+		switch rc {
+		case 1:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[0:10],
+					},
+				},
+			}
+		case 2:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[6:20],
+					},
+				},
+			}
+		case 3:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[16:21],
+					},
+				},
+			}
+		}
+		if eq, msg := compareResults(er, result); !eq {
+			t.Errorf("unexpected alert data for request: %d %s", rc, msg)
+		}
+	}))
+	defer ts.Close()
+
+	var script = `
+var period = 14s
+var every = 10s
+var idle = 10s
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().period(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Period", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// Force emit should force the last window to emit
+		if rc := atomic.LoadInt32(&requestCount); rc != 3 {
+			t.Errorf("got %v exp %v", rc, 3)
+		}
+	}()
+
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	time.Sleep(11 * time.Second)
+	close(dataChannel)
+}
+
+func TestStream_Barrier_Period_No_Idle(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC().Add(-22 * time.Second))
+	clock.Set(time.Now().UTC())
+	testValues := make([][]interface{}, 21)
+	for i := 0; i < 21; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+	requestCount := int32(0)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+		rc := atomic.LoadInt32(&requestCount)
+
+		var er models.Result
+		switch rc {
+		case 1:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[0:10],
+					},
+				},
+			}
+		case 2:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[6:20],
+					},
+				},
+			}
+		case 3:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[16:21],
+					},
+				},
+			}
+		}
+		if eq, msg := compareResults(er, result); !eq {
+			t.Errorf("unexpected alert data for request: %d %s", rc, msg)
+		}
+	}))
+	defer ts.Close()
+
+	var script = `
+var period = 14s
+var every = 10s
+var idle = 10s
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().period(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Period_No_Idle", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// Force emit should force the last window to emit
+		if rc := atomic.LoadInt32(&requestCount); rc != 2 {
+			t.Errorf("got %v exp %v", rc, 2)
+		}
+	}()
+
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	close(dataChannel)
+}
+
+func TestStream_Barrier_Period_Replay_After_Idle(t *testing.T) {
+	// Set up clock to current time - 22 seconds since we're going to send 21 data points
+	clock := clock.New(time.Now().UTC().Add(-22 * time.Second))
+	clock.Set(time.Now().UTC())
+	testValues := make([][]interface{}, 21)
+	for i := 0; i < 21; i++ {
+		testValues[i] = []interface{}{
+			clock.Zero().Add(time.Duration(i) * time.Second),
+			rand.Float64(),
+		}
+	}
+	requestCount := int32(0)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result := models.Result{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		atomic.AddInt32(&requestCount, 1)
+		rc := atomic.LoadInt32(&requestCount)
+
+		var er models.Result
+		switch rc {
+		case 1:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[0:10],
+					},
+				},
+			}
+		case 2:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[6:20],
+					},
+				},
+			}
+		case 3:
+			er = models.Result{
+				Series: models.Rows{
+					{
+						Name:    "cpu",
+						Columns: []string{"time", "value"},
+						Values:  testValues[16:21],
+					},
+				},
+			}
+		}
+		if eq, msg := compareResults(er, result); !eq {
+			t.Errorf("unexpected alert data for request: %d %s", rc, msg)
+		}
+	}))
+	defer ts.Close()
+
+	var script = `
+var period = 14s
+var every = 10s
+var idle = 10s
+stream
+	|from()
+		.database('dbname')
+		.retentionPolicy('rpname')
+		.measurement('cpu')
+	|barrier().period(idle)
+	|window()
+		.period(period)
+		.every(every)
+	|httpPost('` + ts.URL + `')
+`
+
+	dataChannel := make(chan edge.PointMessage)
+	cleanupTest := testStreamerWithInputChannel(t, "TestStream_Barrier_Period", script, dataChannel, clock, nil)
+	defer func() {
+		cleanupTest()
+
+		// Force emit should force the last window to emit
+		if rc := atomic.LoadInt32(&requestCount); rc != 3 {
+			t.Errorf("got %v exp %v", rc, 3)
+		}
+	}()
+
+	data := make([]edge.PointMessage, len(testValues))
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	time.Sleep(11 * time.Second)
+	for i, testValue := range testValues {
+		data[i] = edge.NewPointMessage(
+			"cpu",
+			"dbname",
+			"rpname",
+			models.Dimensions{},
+			models.Fields{"value": testValue[1]},
+			models.Tags{},
+			testValue[0].(time.Time),
+		)
+	}
+	for _, point := range data {
+		dataChannel <- point
+	}
+	close(dataChannel)
 }
 
 func TestStream_Aggregate_Changing_Type(t *testing.T) {
@@ -11317,6 +12140,68 @@ func fastForwardTask(
 		return err
 	}
 	return nil
+}
+
+func testStreamerWithInputChannel(
+	t *testing.T,
+	name,
+	script string,
+	points <-chan edge.PointMessage,
+	clck clock.Clock,
+	tmInit func(tm *kapacitor.TaskMaster),
+) (cleanup func()) {
+	if testing.Verbose() {
+		wlog.SetLevel(wlog.DEBUG)
+	} else {
+		wlog.SetLevel(wlog.OFF)
+	}
+
+	// Create a new execution env
+	tm, err := createTaskMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tmInit != nil {
+		tmInit(tm)
+	}
+	tm.Open()
+
+	//Create the task
+	task, err := tm.NewTask(name, script, kapacitor.StreamTask, dbrps, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Start the task
+	et, err := tm.StartTask(task)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Replay data from channel to exectutor
+	stream, err := tm.Stream(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayErr := kapacitor.ReplayStreamFromChan(clck, points, stream, false)
+
+	// Return cleanup function to caller to execute after data has all been sent
+	cleanup = func() {
+		// Wait till the replay has finished
+		if err := <-replayErr; err != nil {
+			t.Error(err)
+		}
+		tm.Drain()
+		et.StopStats()
+		// Wait till the task is finished
+		if err := et.Wait(); err != nil {
+			t.Error(err)
+		}
+
+		t.Log(string(et.Task.Dot()))
+		return
+	}
+	return
 }
 
 func testStreamerNoOutput(

--- a/pipeline/barrier.go
+++ b/pipeline/barrier.go
@@ -1,0 +1,57 @@
+package pipeline
+
+import (
+	"errors"
+	"time"
+)
+
+// A BarrierNode will emit a barrier with the current time, according to the system
+// clock.  Since the BarrierNode emits based on system time, it allows pipelines to be
+// forced in the absence of data traffic.  The barrier emitted will be based on either
+// idle time since the last received message or on a periodic timer based on the system
+// clock.  Any messages received after an emitted barrier that is older than the last
+// emitted barrier will be dropped.
+//
+// Example:
+//    stream
+//        |barrier().idle(5s)
+//        |window()
+//            .period(10s)
+//            .every(5s)
+//        |top('value', 10)
+//        //Post the top 10 results over the last 10s updated every 5s.
+//        |httpPost('http://example.com/api/top10')
+//
+type BarrierNode struct {
+	chainnode
+
+	// Emit barrier based on idle time since the last received message.
+	// Must be greater than zero.
+	Idle time.Duration
+
+	// Emit barrier based on periodic timer.  The timer is based on system
+	// clock rather than message time.
+	// Must be greater than zero.
+	Period time.Duration
+}
+
+func newBarrierNode(wants EdgeType) *BarrierNode {
+	return &BarrierNode{
+		chainnode: newBasicChainNode("barrier", wants, wants),
+	}
+}
+
+// tick:ignore
+func (b *BarrierNode) validate() error {
+	if b.Idle != 0 && b.Period != 0 {
+		return errors.New("cannot specify both idle and period")
+	}
+	if b.Period == 0 && b.Idle <= 0 {
+		return errors.New("idle must be greater than zero")
+	}
+	if b.Period <= 0 && b.Idle == 0 {
+		return errors.New("period must be greater than zero")
+	}
+
+	return nil
+}

--- a/pipeline/barrier.go
+++ b/pipeline/barrier.go
@@ -18,7 +18,7 @@ import (
 //        |window()
 //            .period(10s)
 //            .every(5s)
-//        |top('value', 10)
+//        |top(10, 'value')
 //        //Post the top 10 results over the last 10s updated every 5s.
 //        |httpPost('http://example.com/api/top10')
 //

--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -417,6 +417,15 @@ func (n *chainnode) Window() *WindowNode {
 	return w
 }
 
+// Create a new Barrier node that emits a BarrierMessage periodically
+//
+// One BarrierMessage will be emitted every period duration
+func (n *chainnode) Barrier() *BarrierNode {
+	b := newBarrierNode(n.provides)
+	n.linkChild(b)
+	return b
+}
+
 // Create a new node that samples the incoming points or batches.
 //
 // One point will be emitted every count or duration specified.

--- a/pipeline/tick/ast.go
+++ b/pipeline/tick/ast.go
@@ -88,6 +88,8 @@ func (a *AST) Create(n pipeline.Node, parents []ast.Node) (ast.Node, error) {
 		return NewJoin(parents).Build(node)
 	case *pipeline.AlertNode:
 		return NewAlert(parents).Build(node)
+	case *pipeline.BarrierNode:
+		return NewBarrierNode(parents).Build(node)
 	case *pipeline.CombineNode:
 		return NewCombine(parents).Build(node)
 	case *pipeline.DefaultNode:

--- a/pipeline/tick/barrier.go
+++ b/pipeline/tick/barrier.go
@@ -1,0 +1,28 @@
+package tick
+
+import (
+	"github.com/influxdata/kapacitor/pipeline"
+	"github.com/influxdata/kapacitor/tick/ast"
+)
+
+// BarrierNode converts the window pipeline node into the TICKScript AST
+type BarrierNode struct {
+	Function
+}
+
+// NewBarrierNode creates a Barrier function builder
+func NewBarrierNode(parents []ast.Node) *BarrierNode {
+	return &BarrierNode{
+		Function{
+			Parents: parents,
+		},
+	}
+}
+
+// Build creates a window ast.Node
+func (n *BarrierNode) Build(b *pipeline.BarrierNode) (ast.Node, error) {
+	n.Pipe("barrier").
+		Dot("idle", b.Idle).
+		Dot("period", b.Period)
+	return n.prev, n.err
+}

--- a/pipeline/window.go
+++ b/pipeline/window.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/influxdata/influxdb/influxql"
@@ -15,9 +14,9 @@ import (
 // The `every` property of `window` defines the frequency at which the window
 // is emitted to the next node in the pipeline.
 //
-//The `align` property of `window` defines how to align the window edges.
-//(By default, the edges are defined relative to the first data point the `window`
-//node receives.)
+// The `align` property of `window` defines how to align the window edges.
+// (By default, the edges are defined relative to the first data point the `window`
+// node receives.)
 //
 // Example:
 //    stream
@@ -26,7 +25,7 @@ import (
 //            .every(5m)
 //        |httpOut('recent')
 //
-// his example emits the last `10 minute` period  every `5 minutes` to the pipeline's `httpOut` node.
+// This example emits the last `10 minute` period  every `5 minutes` to the pipeline's `httpOut` node.
 // Because `every` is less than `period`, each time the window is emitted it contains `5 minutes` of
 // new data and `5 minutes` of the previous period's data.
 //
@@ -139,7 +138,7 @@ func (w *WindowNode) validate() error {
 		return errors.New("can only align windows based off time, not count")
 	}
 	if w.PeriodCount != 0 && w.EveryCount <= 0 {
-		return fmt.Errorf("everyCount must be greater than zero")
+		return errors.New("everyCount must be greater than zero")
 	}
 	return nil
 }

--- a/pipeline/window.go
+++ b/pipeline/window.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/influxdata/influxdb/influxql"

--- a/task.go
+++ b/task.go
@@ -513,6 +513,8 @@ func (et *ExecutingTask) createNode(p pipeline.Node, d NodeDiagnostic) (n Node, 
 		n, err = newStateCountNode(et, t, d)
 	case *pipeline.SideloadNode:
 		n, err = newSideloadNode(et, t, d)
+	case *pipeline.BarrierNode:
+		n, err = newBarrierNode(et, t, d)
 	default:
 		return nil, fmt.Errorf("unknown pipeline node type %T", p)
 	}


### PR DESCRIPTION
Adding a BarrierNode to emit a BarrierMessage on intervals that are driven by the clock rather than by message timestamps.

Addresses portion of #1304 wherein "silent periods" need to be handled by minimum throughput detection pipelines.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
