### PR TITLE
Bootstrap main diagnostic

### DIFF
--- a/cmd/kapacitord/main.go
+++ b/cmd/kapacitord/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/influxdata/kapacitor/cmd/kapacitord/help"
 	"github.com/influxdata/kapacitor/cmd/kapacitord/run"
+	"github.com/influxdata/kapacitor/services/diagnostic"
 )
 
 type Diagnostic run.Diagnostic
@@ -56,6 +57,7 @@ type Main struct {
 // NewMain return a new instance of Main.
 func NewMain() *Main {
 	return &Main{
+		Diag:   diagnostic.BootstrapMainHandler(),
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
@@ -77,7 +79,7 @@ func (m *Main) Run(args ...string) error {
 		cmd.Branch = branch
 
 		err := cmd.Run(args...)
-		// Use logger from cmd since it may have special config now.
+		// Use diagnostic from cmd since it may have special config now.
 		if cmd.Diag != nil {
 			m.Diag = cmd.Diag
 		}

--- a/cmd/kapacitord/run/command.go
+++ b/cmd/kapacitord/run/command.go
@@ -103,7 +103,9 @@ func (cmd *Command) Run(args ...string) error {
 
 	// Initialize Logging Services
 	cmd.diagService = diagnostic.NewService(config.Logging, cmd.Stdout, cmd.Stderr)
-	cmd.diagService.Open()
+	if err := cmd.diagService.Open(); err != nil {
+		return fmt.Errorf("failed to opend diagnostic service: %v", err)
+	}
 
 	// Initialize cmd diagnostic
 	cmd.Diag = cmd.diagService.NewCmdHandler()

--- a/services/diagnostic/service.go
+++ b/services/diagnostic/service.go
@@ -40,6 +40,14 @@ func NewService(c Config, stdout, stderr io.Writer) *Service {
 	}
 }
 
+func BootstrapMainHandler() *CmdHandler {
+	s := NewService(NewConfig(), nil, os.Stderr)
+	// Should never error
+	_ = s.Open()
+
+	return s.NewCmdHandler()
+}
+
 func (s *Service) SetLogLevelFromName(lvl string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Previously if an error was encountered with `cmd.Run`, the diagnostic would be nil and so when `m.Diag.Error` was called it would panic.

This PR now returns an error to the main function.