### PR TITLE
sysUpTime addition to snmptrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#1500](https://github.com/influxdata/kapacitor/pull/1500): Fix bugs with stopping running UDF agent.
 - [#1470](https://github.com/influxdata/kapacitor/pull/1470): Fix error messages for missing fields which are arguments to functions are not clear
 - [#1516](https://github.com/influxdata/kapacitor/pull/1516): Fix bad PagerDuty test the required server info.
+- [#1581](https://github.com/influxdata/kapacitor/pull/1581): Add SNMP sysUpTime to SNMP Trap service
 
 ## v1.3.3 [2017-08-11]
 

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -8687,6 +8687,11 @@ stream
 				ErrorStatus: snmpgo.NoError,
 				VarBinds: snmptraptest.VarBinds{
 					{
+						Oid:   "1.3.6.1.2.1.1.3.0",
+						Value: "1000",
+						Type:  "TimeTicks",
+					},
+					{
 						Oid:   "1.3.6.1.6.3.1.1.4.1.0",
 						Value: "1.1.1",
 						Type:  "Oid",
@@ -8714,6 +8719,11 @@ stream
 				Type:        snmpgo.SNMPTrapV2,
 				ErrorStatus: snmpgo.NoError,
 				VarBinds: snmptraptest.VarBinds{
+					{
+						Oid:   "1.3.6.1.2.1.1.3.0",
+						Value: "1000",
+						Type:  "TimeTicks",
+					},
 					{
 						Oid:   "1.3.6.1.6.3.1.1.4.1.0",
 						Value: "1.1.2",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8628,6 +8628,11 @@ func TestServer_AlertHandlers(t *testing.T) {
 						ErrorStatus: snmpgo.NoError,
 						VarBinds: snmptraptest.VarBinds{
 							{
+								Oid:   "1.3.6.1.2.1.1.3.0",
+								Value: "1000",
+								Type:  "TimeTicks",
+							},
+							{
 								Oid:   "1.3.6.1.6.3.1.1.4.1.0",
 								Value: "1.1.2",
 								Type:  "Oid",

--- a/services/snmptrap/service.go
+++ b/services/snmptrap/service.go
@@ -138,6 +138,7 @@ func (s *Service) Trap(trapOid string, dataList []Data) error {
 		return errors.Wrapf(err, "invalid trap Oid %q", trapOid)
 	}
 	varBinds := snmpgo.VarBinds{
+		snmpgo.NewVarBind(snmpgo.OidSysUpTime, snmpgo.NewTimeTicks(1000)),
 		snmpgo.NewVarBind(snmpgo.OidSnmpTrap, oid),
 	}
 


### PR DESCRIPTION
Updated snmptrap service to fix https://github.com/influxdata/kapacitor/issues/1541 


###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)