### PR TITLE
Added ProxyFromEnvironment support to telegram service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
     Load service was added; the service can load tasks/handlers from a directory.
 - [#1606](https://github.com/influxdata/kapacitor/pull/1606): Update Go version to 1.9.1
 - [#1578](https://github.com/influxdata/kapacitor/pull/1578): Add support for exposing logs via the API.
+- [#1592](https://github.com/influxdata/kapacitor/pull/1592): Add ProxyFromEnvironment support for Telegram service.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
     Load service was added; the service can load tasks/handlers from a directory.
 - [#1606](https://github.com/influxdata/kapacitor/pull/1606): Update Go version to 1.9.1
 - [#1578](https://github.com/influxdata/kapacitor/pull/1578): Add support for exposing logs via the API.
-- [#1592](https://github.com/influxdata/kapacitor/pull/1592): Add ProxyFromEnvironment support for Telegram service.
+- [#1592](https://github.com/influxdata/kapacitor/pull/1592): Add ProxyFromEnvironment support for Telegram service. 
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
     Load service was added; the service can load tasks/handlers from a directory.
 - [#1606](https://github.com/influxdata/kapacitor/pull/1606): Update Go version to 1.9.1
 - [#1578](https://github.com/influxdata/kapacitor/pull/1578): Add support for exposing logs via the API.
-- [#1592](https://github.com/influxdata/kapacitor/pull/1592): Add ProxyFromEnvironment support for Telegram service. 
+- [#1592](https://github.com/influxdata/kapacitor/pull/1592): Add ProxyFromEnvironment support for Telegram service.
 
 ### Bugfixes
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/)

In this PR I've added ProxyFromEnvironment support for Telegram service.

I've used #1415 as an example.