### PR TITLE
added k8sautoscale NewConfig invocation

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -157,6 +157,7 @@ func NewConfig() *Config {
 	c.Telegram = telegram.NewConfig()
 	c.VictorOps = victorops.NewConfig()
 
+	c.Kubernetes = []k8s.Config{k8s.NewConfig()}
 	c.Reporting = reporting.NewConfig()
 	c.Stats = stats.NewConfig()
 	c.UDF = udf.NewConfig()


### PR DESCRIPTION
## What was changed.

Added a line to create a `k8s.NewConfig` for the Kubernetes settings.  

## Related Issues

* #1608 

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
