### PR TITLE
Add example of all nodes in load tasks style dir

### DIFF
--- a/examples/nodes/tasks/alert.tick
+++ b/examples/nodes/tasks/alert.tick
@@ -1,0 +1,8 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy(*)
+    |alert()
+        .crit(lambda: "usage_user" > 80)

--- a/examples/nodes/tasks/batch.tick
+++ b/examples/nodes/tasks/batch.tick
@@ -1,0 +1,6 @@
+dbrp "telegraf"."autogen"
+
+batch
+    |query('SELECT mean("usage_user") FROM "telegraf"."autogen"."cpu"')
+        .period(1m)
+        .every(10s)

--- a/examples/nodes/tasks/combine.tick
+++ b/examples/nodes/tasks/combine.tick
@@ -1,0 +1,8 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy(*)
+    |combine(lambda: "cpu" == 'cpu-total', lambda: TRUE)
+        .as('total', 'cpu')

--- a/examples/nodes/tasks/default.tick
+++ b/examples/nodes/tasks/default.tick
@@ -1,0 +1,9 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy(*)
+    |default()
+        .tag('sweet_new_tag', 'this_is')
+        .field('value', 10.9)

--- a/examples/nodes/tasks/delete.tick
+++ b/examples/nodes/tasks/delete.tick
@@ -1,0 +1,9 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy(*)
+    |delete()
+        .tag('cpu')
+        .field('usuage_idle')

--- a/examples/nodes/tasks/eval.tick
+++ b/examples/nodes/tasks/eval.tick
@@ -1,0 +1,7 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+    |eval(lambda: 100.0 - "usage_idle")
+        .as('usage_not_idle')

--- a/examples/nodes/tasks/flatten.tick
+++ b/examples/nodes/tasks/flatten.tick
@@ -1,0 +1,7 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+    |flatten()
+        .on('cpu')

--- a/examples/nodes/tasks/groupby.tick
+++ b/examples/nodes/tasks/groupby.tick
@@ -1,0 +1,6 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('system')
+    |groupBy(*)

--- a/examples/nodes/tasks/handle_loopback.tick
+++ b/examples/nodes/tasks/handle_loopback.tick
@@ -1,0 +1,6 @@
+dbrp "loopback"."autogen"
+
+stream
+    |from()
+        .measurement('system')
+        .groupBy(*)

--- a/examples/nodes/tasks/httpout.tick
+++ b/examples/nodes/tasks/httpout.tick
@@ -1,0 +1,9 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('system')
+    |window()
+        .period(1m)
+        .every(10s)
+    |httpOut('data')

--- a/examples/nodes/tasks/httppost.tick
+++ b/examples/nodes/tasks/httppost.tick
@@ -1,0 +1,9 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('system')
+    |window()
+        .period(1m)
+        .every(10s)
+    |httpPost('http://localhost:8080/example')

--- a/examples/nodes/tasks/influxdbout.tick
+++ b/examples/nodes/tasks/influxdbout.tick
@@ -1,0 +1,13 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('system')
+    |window()
+        .period(1m)
+        .every(10s)
+    |mean('load1')
+        .as('load1')
+    |influxDBOut()
+        .database('mydb')
+        .measurement('derived_system')

--- a/examples/nodes/tasks/join.tick
+++ b/examples/nodes/tasks/join.tick
@@ -1,0 +1,29 @@
+dbrp "telegraf"."autogen"
+
+var cpu = stream
+    |from()
+        .measurement('cpu')
+        .groupBy(*)
+    |window()
+        .period(30s)
+        .every(10s)
+        .align()
+    |mean('usage_user')
+        .as('value')
+
+var mem = stream
+    |from()
+        .measurement('mem')
+        .groupBy(*)
+    |window()
+        .period(30s)
+        .every(10s)
+        .align()
+    |mean('free')
+        .as('value')
+
+cpu
+    |join(mem)
+        .as('cpu', 'mem')
+    |eval(lambda: "cpu.value" / "mem.value")
+        .as('cpu_mem_free_ratio')

--- a/examples/nodes/tasks/log.tick
+++ b/examples/nodes/tasks/log.tick
@@ -1,0 +1,7 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('system')
+        .groupBy(*)
+    |log()

--- a/examples/nodes/tasks/loopback.tick
+++ b/examples/nodes/tasks/loopback.tick
@@ -1,0 +1,9 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('system')
+        .groupBy(*)
+    |kapacitorLoopback()
+        .database('loopback')
+        .retentionPolicy('autogen')

--- a/examples/nodes/tasks/sample.tick
+++ b/examples/nodes/tasks/sample.tick
@@ -1,0 +1,7 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy('host')
+    |sample(3)

--- a/examples/nodes/tasks/shift.tick
+++ b/examples/nodes/tasks/shift.tick
@@ -1,0 +1,7 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy('host')
+    |shift(1m)

--- a/examples/nodes/tasks/statecount.tick
+++ b/examples/nodes/tasks/statecount.tick
@@ -1,0 +1,8 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+    |where(lambda: "cpu" == 'cpu-total')
+    |groupBy('host')
+    |stateCount(lambda: "usage_idle" <= 10)

--- a/examples/nodes/tasks/stateduration.tick
+++ b/examples/nodes/tasks/stateduration.tick
@@ -1,0 +1,9 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+    |where(lambda: "cpu" == 'cpu-total')
+    |groupBy('host')
+    |stateDuration(lambda: "usage_idle" <= 10)
+        .unit(1m)

--- a/examples/nodes/tasks/stats.tick
+++ b/examples/nodes/tasks/stats.tick
@@ -1,0 +1,7 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy('host')
+    |stats(30s)

--- a/examples/nodes/tasks/stream.tick
+++ b/examples/nodes/tasks/stream.tick
@@ -1,0 +1,6 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy('host')

--- a/examples/nodes/tasks/union.tick
+++ b/examples/nodes/tasks/union.tick
@@ -1,0 +1,17 @@
+dbrp "telegraf"."autogen"
+
+var cpu = stream
+    |from()
+        .measurement('cpu')
+
+var mem = stream
+    |from()
+        .measurement('mem')
+
+var system = stream
+    |from()
+        .measurement('system')
+
+cpu
+    |union(mem, system)
+        .rename('stats')

--- a/examples/nodes/tasks/where.tick
+++ b/examples/nodes/tasks/where.tick
@@ -1,0 +1,7 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy('host')
+    |where(lambda: "cpu" == 'cpu-total')

--- a/examples/nodes/tasks/window.tick
+++ b/examples/nodes/tasks/window.tick
@@ -1,0 +1,9 @@
+dbrp "telegraf"."autogen"
+
+stream
+    |from()
+        .measurement('cpu')
+        .groupBy('host')
+    |window()
+        .period(1m)
+        .every(1m)


### PR DESCRIPTION
This PR adds simple tickscripts for each node type in kapacitor and will serve as the basis for a burn-in test.
