### PR TITLE
K8s incluster api addr fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [#1516](https://github.com/influxdata/kapacitor/pull/1516): Fix bad PagerDuty test the required server info.
 - [#1581](https://github.com/influxdata/kapacitor/pull/1581): Add SNMP sysUpTime to SNMP Trap service
 - [#1547](https://github.com/influxdata/kapacitor/issues/1547): Fix panic on recording replay with HTTPPostHandler.
+- [#1623](https://github.com/influxdata/kapacitor/issues/1623): Fix k8s incluster master api dns resolution
 
 ## v1.3.3 [2017-08-11]
 

--- a/services/k8s/client/client.go
+++ b/services/k8s/client/client.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"sync"
@@ -92,12 +93,22 @@ func NewConfigInCluster() (Config, error) {
 	t.RootCAs = caCertPool
 
 	config := Config{
-		URLs:      []string{"https://kubernetes"},
+		URLs:      []string{GetK8sHost()},
 		Namespace: string(namespaceBytes),
 		Token:     string(tokenBytes),
 		TLSConfig: t,
 	}
 	return config, nil
+}
+
+func GetK8sHost() string {
+	template := "https://%s"
+
+	if k8sHost := os.Getenv("KUBERNETES_SERVICE_HOST"); k8sHost != "" {
+		return fmt.Sprintf(template, k8sHost)
+	}
+
+	return fmt.Sprintf(template, "kubernetes")
 }
 
 func New(c Config) (Client, error) {


### PR DESCRIPTION
Fixed [#1623](https://github.com/influxdata/kapacitor/issues/1623) regarding k8s in-cluster configuration setup and the dns resolution issue to master api server.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

