### PR TITLE
Stop writing HTTP header for sessions service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [#1547](https://github.com/influxdata/kapacitor/issues/1547): Fix panic on recording replay with HTTPPostHandler.
 - [#1623](https://github.com/influxdata/kapacitor/issues/1623): Fix k8s incluster master api dns resolution
 - [#1630](https://github.com/influxdata/kapacitor/issues/1630): Remove the pidfile after the server has exited.
+- [#1641](https://github.com/influxdata/kapacitor/issues/1641): Logs API writes multiple http headers.
 
 ## v1.3.3 [2017-08-11]
 

--- a/services/diagnostic/api.go
+++ b/services/diagnostic/api.go
@@ -104,13 +104,13 @@ func (s *SessionService) handleSessions(w http.ResponseWriter, r *http.Request) 
 
 	contentType := r.Header.Get("Content-Type")
 
-	session := s.SessionsStore.Create(w, contentType, level, tags)
-	defer s.SessionsStore.Delete(session)
-
 	header := w.Header()
 	header.Add("Transfer-Encoding", "chunked")
 	header.Add("Content-Type", r.Header.Get("Content-Type"))
 	w.WriteHeader(http.StatusOK)
+
+	session := s.SessionsStore.Create(w, contentType, level, tags)
+	defer s.SessionsStore.Delete(session)
 
 	<-r.Context().Done()
 }


### PR DESCRIPTION
Fixes #1641 

Writing headers is handled by the chunked HTTP response writer. Writing
headers manually results in an HTTP error log.
