### PR TITLE
Fixes to handle Pipeline/AST alert nodes and number types

### DIFF
--- a/pipeline/json.go
+++ b/pipeline/json.go
@@ -481,6 +481,10 @@ func isChainNode(node Node) (chainnodeAlias, bool) {
 	if ok {
 		return &alert.AlertNodeData.chainnode, true
 	}
+	shift, ok := node.(*ShiftNode)
+	if ok {
+		return &shift.chainnode, true
+	}
 	return nil, false
 }
 

--- a/pipeline/json.go
+++ b/pipeline/json.go
@@ -300,7 +300,7 @@ func (p *Pipeline) unmarshalNode(data []byte, typ TypeOf, parents []Node) (Node,
 			return nil, fmt.Errorf("expected one parent for node %d but found %d", typ.ID, len(parents))
 		}
 		parent := parents[0]
-		chainParent, ok := parent.(chainnodeAlias)
+		chainParent, ok := isChainNode(parent)
 		if !ok {
 			return nil, fmt.Errorf("parent node is not a chain node but is %T", parent)
 		}
@@ -324,7 +324,7 @@ func (p *Pipeline) unmarshalNode(data []byte, typ TypeOf, parents []Node) (Node,
 			return nil, fmt.Errorf("expected more than one parent for node %d but received %d", typ.ID, len(parents))
 		}
 		parent := parents[0]
-		chainParent, ok := parent.(chainnodeAlias)
+		chainParent, ok := isChainNode(parent)
 		if !ok {
 			return nil, fmt.Errorf("parent node is not a chain node but is %T", parent)
 		}
@@ -339,7 +339,7 @@ func (p *Pipeline) unmarshalNode(data []byte, typ TypeOf, parents []Node) (Node,
 			return nil, fmt.Errorf("expected one parent for node %d but found %d", typ.ID, len(parents))
 		}
 		parent := parents[0]
-		chainParent, ok := parent.(chainnodeAlias)
+		chainParent, ok := isChainNode(parent)
 		if !ok {
 			return nil, fmt.Errorf("parent node is not a chain node but is %T", parent)
 		}
@@ -434,7 +434,7 @@ func unmarshalTopBottom(data []byte, parents []Node, typ TypeOf) (Node, error) {
 		return nil, fmt.Errorf("expected one parent for node %d but found %d", typ.ID, len(parents))
 	}
 	parent := parents[0]
-	chainParent, ok := parent.(chainnodeAlias)
+	chainParent, ok := isChainNode(parent)
 	if !ok {
 		return nil, fmt.Errorf("parent node is not a chain node but is %T", parent)
 	}
@@ -470,6 +470,18 @@ func unmarshalUDF(data []byte, parents []Node, typ TypeOf) (Node, error) {
 	parent.linkChild(child)
 	err := json.Unmarshal(data, child)
 	return child, err
+}
+
+func isChainNode(node Node) (chainnodeAlias, bool) {
+	a, ok := node.(chainnodeAlias)
+	if ok {
+		return a, ok
+	}
+	alert, ok := node.(*AlertNode)
+	if ok {
+		return &alert.AlertNodeData.chainnode, true
+	}
+	return nil, false
 }
 
 // chainnodeAlias is used to check for the presence of a chain node

--- a/tick/ast/json.go
+++ b/tick/ast/json.go
@@ -105,7 +105,11 @@ func (j JSONNode) Int64(field string) (int64, error) {
 
 	num, ok := n.(int64)
 	if !ok {
-		return 0, fmt.Errorf("field %s is not an integer value but is %T", field, n)
+		flt, ok := n.(float64)
+		if !ok {
+			return 0, fmt.Errorf("field %s is not an integer value but is %T", field, n)
+		}
+		num = int64(flt)
 	}
 	return num, nil
 }
@@ -119,7 +123,11 @@ func (j JSONNode) Float64(field string) (float64, error) {
 
 	num, ok := n.(float64)
 	if !ok {
-		return 0, fmt.Errorf("field %s is not a floating point value but is %T", field, n)
+		integer, ok := n.(int64)
+		if !ok {
+			return 0, fmt.Errorf("field %s is not a floating point value but is %T", field, n)
+		}
+		num = float64(integer)
 	}
 	return num, nil
 }

--- a/tick/ast/node.go
+++ b/tick/ast/node.go
@@ -194,16 +194,25 @@ func (n *NumberNode) unmarshal(props JSONNode) error {
 	if n.IsInt, err = props.Bool("isint"); err != nil {
 		return err
 	}
+	if n.IsInt {
+		if n.Int64, err = props.Int64("int64"); err != nil {
+			return err
+		}
+		base, err := props.Int64("base")
+		if err != nil {
+			return err
+		}
+		if base == 0 {
+			return fmt.Errorf("integer base cannot be zero")
+		}
+		n.Base = int(base)
+	}
 
 	if n.IsFloat, err = props.Bool("isfloat"); err != nil {
 		return err
 	}
-
-	if n.Float64, err = props.Float64("float64"); err != nil {
-		return err
-	}
-
-	if n.Int64, err = props.Int64("int64"); err != nil {
+	if n.IsFloat {
+		n.Float64, err = props.Float64("float64")
 		return err
 	}
 


### PR DESCRIPTION
Found some bugs while testing various autogenerated tickscripts from chronograf.