### PR TITLE
Fix unmarshaling of AST node lists

### DIFF
--- a/tick/ast/json.go
+++ b/tick/ast/json.go
@@ -226,7 +226,7 @@ func (j JSONNode) NodeList(field string) ([]Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	list, ok := l.([]map[string]interface{})
+	list, ok := l.([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("field %s is not a list of values but is %T", field, l)
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Lists were incorrectly being unmarshaled into a map
