### PR TITLE
Fix a typo in swarm_autoscale pipeline test

### DIFF
--- a/pipeline/tick/swarm_autoscale.go
+++ b/pipeline/tick/swarm_autoscale.go
@@ -23,7 +23,7 @@ func NewSwarmAutoscale(parents []ast.Node) *SwarmAutoscaleNode {
 func (n *SwarmAutoscaleNode) Build(s *pipeline.SwarmAutoscaleNode) (ast.Node, error) {
 	n.Pipe("swarmAutoscale").
 		Dot("cluster", s.Cluster).
-		Dot("servceName", s.ServiceNameTag).
+		Dot("serviceName", s.ServiceNameTag).
 		Dot("serviceNameTag", s.ServiceNameTag).
 		Dot("outputServiceNameTag", s.OutputServiceNameTag).
 		Dot("currentField", s.CurrentField).

--- a/pipeline/tick/swarm_autoscale_test.go
+++ b/pipeline/tick/swarm_autoscale_test.go
@@ -75,7 +75,7 @@ func TestSwarmAutoscale(t *testing.T) {
     |from()
     |swarmAutoscale()
         .cluster('zerg')
-        .servceName('mutalisk')
+        .serviceName('mutalisk')
         .serviceNameTag('mutalisk')
         .outputServiceNameTag('guardian')
         .currentField('hitPoints')


### PR DESCRIPTION
Fix a small typo :smiley: 
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)