### PR TITLE
Fix VictorOps data being a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Bugfixes
+
+- [#1250](https://github.com/influxdata/kapacitor/issues/1250): Fix VictorOps "data" field being a string instead of actual JSON.
+
 ## v1.4.0-rc1 [2017-11-09]
 
 ### Features

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -269,6 +269,11 @@ default-retention-policy = ""
   # without explicitly marking them in the TICKscript.
   # The routing key can still be overridden.
   global = false
+  # Use JSON for the "data" field
+  # New installations will want to set this to true as it makes
+  # the data that triggered the alert available within VictorOps.
+  # The default is "false" for backwards compatibility reasons.
+  # json-data = false
 
 [pagerduty]
   # Configure PagerDuty.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7784,6 +7784,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 						"global":      false,
 						"routing-key": "test",
 						"url":         victorops.DefaultVictorOpsAPIURL,
+						"json-data":   false,
 					},
 					Redacted: []string{
 						"api-key",
@@ -7798,6 +7799,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 					"global":      false,
 					"routing-key": "test",
 					"url":         victorops.DefaultVictorOpsAPIURL,
+					"json-data":   false,
 				},
 				Redacted: []string{
 					"api-key",
@@ -7807,8 +7809,9 @@ func TestServer_UpdateConfig(t *testing.T) {
 				{
 					updateAction: client.ConfigUpdateAction{
 						Set: map[string]interface{}{
-							"api-key": "",
-							"global":  true,
+							"api-key":   "",
+							"global":    true,
+							"json-data": true,
 						},
 					},
 					expSection: client.ConfigSection{
@@ -7821,6 +7824,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 								"global":      true,
 								"routing-key": "test",
 								"url":         victorops.DefaultVictorOpsAPIURL,
+								"json-data":   true,
 							},
 							Redacted: []string{
 								"api-key",
@@ -7835,6 +7839,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 							"global":      true,
 							"routing-key": "test",
 							"url":         victorops.DefaultVictorOpsAPIURL,
+							"json-data":   true,
 						},
 						Redacted: []string{
 							"api-key",

--- a/services/victorops/config.go
+++ b/services/victorops/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	URL string `toml:"url" override:"url"`
 	// Whether every alert should automatically go to VictorOps.
 	Global bool `toml:"global" override:"global"`
+	// JSONData indicates that the VictorOps "data" field should contain JSON and not a string.
+	JSONData bool `toml:"json-data" override:"json-data"`
 }
 
 func NewConfig() Config {

--- a/services/victorops/service.go
+++ b/services/victorops/service.go
@@ -142,11 +142,15 @@ func (s *Service) preparePost(routingKey, messageType, message, entityID string,
 	voData["timestamp"] = t.Unix()
 	voData["monitoring_tool"] = "kapacitor"
 
-	b, err := json.Marshal(details)
-	if err != nil {
-		return "", nil, err
+	if c.JSONData {
+		voData["data"] = details
+	} else {
+		b, err := json.Marshal(details)
+		if err != nil {
+			return "", nil, err
+		}
+		voData["data"] = string(b)
 	}
-	voData["data"] = string(b)
 
 	if routingKey == "" {
 		routingKey = c.RoutingKey
@@ -155,7 +159,7 @@ func (s *Service) preparePost(routingKey, messageType, message, entityID string,
 	// Post data to VO
 	var post bytes.Buffer
 	enc := json.NewEncoder(&post)
-	err = enc.Encode(voData)
+	err := enc.Encode(voData)
 	if err != nil {
 		return "", nil, err
 	}

--- a/services/victorops/victoropstest/victoropstest.go
+++ b/services/victorops/victoropstest/victoropstest.go
@@ -49,10 +49,10 @@ type Request struct {
 	PostData PostData
 }
 type PostData struct {
-	MessageType    string `json:"message_type"`
-	EntityID       string `json:"entity_id"`
-	StateMessage   string `json:"state_message"`
-	Timestamp      int    `json:"timestamp"`
-	MonitoringTool string `json:"monitoring_tool"`
-	Data           string `json:"data"`
+	MessageType    string      `json:"message_type"`
+	EntityID       string      `json:"entity_id"`
+	StateMessage   string      `json:"state_message"`
+	Timestamp      int         `json:"timestamp"`
+	MonitoringTool string      `json:"monitoring_tool"`
+	Data           interface{} `json:"data"`
 }


### PR DESCRIPTION
Fixes #1250
In order to enable using JSON data add `json-data = true` to the `[victorops]` configuration section.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
