### PR TITLE
Fix panic with MQTT toml configuration generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfixes
 
 - [#1250](https://github.com/influxdata/kapacitor/issues/1250): Fix VictorOps "data" field being a string instead of actual JSON.
+- [#1697](https://github.com/influxdata/kapacitor/issues/1697): Fix panic with MQTT toml configuration generation.
 
 ## v1.4.0-rc1 [2017-11-09]
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6948,11 +6948,14 @@ func TestServer_UpdateConfig(t *testing.T) {
 		{
 			section: "mqtt",
 			setDefaults: func(c *server.Config) {
-				c.MQTT = mqtt.Configs{mqtt.Config{
-					Name:       "default",
-					URL:        "tcp://mqtt.example.com:1883",
-					NewClientF: mqtttest.NewClient,
-				}}
+				cfg := &mqtt.Config{
+					Name: "default",
+					URL:  "tcp://mqtt.example.com:1883",
+				}
+				cfg.SetNewClientF(mqtttest.NewClient)
+				c.MQTT = mqtt.Configs{
+					*cfg,
+				}
 			},
 			element: "default",
 			expDefaultSection: client.ConfigSection{
@@ -8867,15 +8870,15 @@ func TestServer_AlertHandlers(t *testing.T) {
 			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
 				cc := new(mqtttest.ClientCreator)
 				ctxt := context.WithValue(nil, "clientCreator", cc)
-
-				c.MQTT = mqtt.Configs{
-					mqtt.Config{
-						Enabled:    true,
-						Name:       "test",
-						URL:        "tcp://mqtt.example.com:1883",
-						NewClientF: cc.NewClient,
-					},
+				cfg := &mqtt.Config{
+					Enabled: true,
+					Name:    "test",
+					URL:     "tcp://mqtt.example.com:1883",
 				}
+
+				cfg.SetNewClientF(cc.NewClient)
+
+				c.MQTT = mqtt.Configs{*cfg}
 				return ctxt, nil
 			},
 			result: func(ctxt context.Context) error {

--- a/services/mqtt/config.go
+++ b/services/mqtt/config.go
@@ -29,8 +29,15 @@ type Config struct {
 	Username string `toml:"username" override:"username"`
 	Password string `toml:"password" override:"password,redact"`
 
-	// NewClientF is a function that returns a client for a given config.
-	NewClientF func(c Config) (Client, error) `toml:"-" override:"-"`
+	// newClientF is a function that returns a client for a given config.
+	// It is used exclusively for testing.
+	newClientF func(c Config) (Client, error) `override:"-"`
+}
+
+// SetNewClientF sets the newClientF on a Config.
+// It is used exclusively for testing.
+func (c *Config) SetNewClientF(fn func(c Config) (Client, error)) {
+	c.newClientF = fn
 }
 
 func NewConfig() Config {
@@ -52,8 +59,8 @@ func (c Config) Validate() error {
 // NewClient creates a new client based off this configuration.
 func (c Config) NewClient() (Client, error) {
 	newC := newClient
-	if c.NewClientF != nil {
-		newC = c.NewClientF
+	if c.newClientF != nil {
+		newC = c.newClientF
 	}
 	return newC(c)
 }


### PR DESCRIPTION
Previously, the `NewClientF` being exported was causing the our toml
package to panic.

Fixes https://github.com/influxdata/kapacitor/issues/1697

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
