### PR TITLE
make idle barrier time relative to messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Bugfixes
+
+- [#1710](https://github.com/influxdata/kapacitor/issues/1710): Idle Barrier is dropping all messages when source has clock offset
+
 ## v1.4.0-rc3 [2017-12-04]
 
 ### Bugfixes

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -1507,7 +1507,6 @@ stream
 	defer func() {
 		cleanupTest()
 
-		// barrier should emit at least 4 times
 		if rc := atomic.LoadInt32(&requestCount); rc != 2 {
 			t.Errorf("got %v exp %v", rc, 2)
 		}


### PR DESCRIPTION
addresses #1710

By having barrier time be based on last (point | barrier) time + idle,
the desired behavior of idle barrier for handling no data (silence)
scenarios works even when the data source clock is offset from the
kapacitor host clock.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
