### PR TITLE
Fix oddly generated TOML for mqtt & httppost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
 - [#1710](https://github.com/influxdata/kapacitor/issues/1710): Idle Barrier is dropping all messages when source has clock offset
+- [#1719](https://github.com/influxdata/kapacitor/pull/1719): Fix oddly generated TOML for mqtt & httppost
 
 ## v1.4.0-rc3 [2017-12-04]
 

--- a/server/config.go
+++ b/server/config.go
@@ -144,11 +144,11 @@ func NewConfig() *Config {
 
 	c.Alerta = alerta.NewConfig()
 	c.HipChat = hipchat.NewConfig()
-	c.MQTT = mqtt.Configs{}
+	c.MQTT = mqtt.Configs{mqtt.NewConfig()}
 	c.OpsGenie = opsgenie.NewConfig()
 	c.PagerDuty = pagerduty.NewConfig()
 	c.Pushover = pushover.NewConfig()
-	c.HTTPPost = httppost.Configs{}
+	c.HTTPPost = httppost.Configs{httppost.NewConfig()}
 	c.SMTP = smtp.NewConfig()
 	c.Sensu = sensu.NewConfig()
 	c.Slack = slack.NewConfig()

--- a/server/server_helper_test.go
+++ b/server/server_helper_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/influxdata/kapacitor/client/v1"
 	"github.com/influxdata/kapacitor/server"
 	"github.com/influxdata/kapacitor/services/diagnostic"
+	"github.com/influxdata/kapacitor/services/mqtt"
 	"github.com/influxdata/wlog"
 )
 
@@ -220,6 +221,7 @@ func (s *Server) Stats() (stats, error) {
 // NewConfig returns the default config with temporary paths.
 func NewConfig() *server.Config {
 	c := server.NewConfig()
+	c.MQTT = mqtt.Configs{}
 	c.Reporting.Enabled = false
 	c.Replay.Dir = MustTempDir()
 	c.Storage.BoltDBPath = filepath.Join(MustTempDir(), "bolt.db")

--- a/services/httppost/config.go
+++ b/services/httppost/config.go
@@ -41,6 +41,13 @@ type Config struct {
 	RowTemplateFile   string            `toml:"row-template-file" override:"row-template-file"`
 }
 
+func NewConfig() Config {
+	return Config{
+		Endpoint: "example",
+		URL:      "http://example.com",
+	}
+}
+
 // Validate ensures that all configurations options are valid. The Endpoint,
 // and URL parameters must be set to be considered valid.
 func (c Config) Validate() error {

--- a/services/mqtt/config.go
+++ b/services/mqtt/config.go
@@ -41,7 +41,10 @@ func (c *Config) SetNewClientF(fn func(c Config) (Client, error)) {
 }
 
 func NewConfig() Config {
-	return Config{}
+	return Config{
+		Enabled: false,
+		Name:    "default",
+	}
 }
 
 func (c Config) Validate() error {


### PR DESCRIPTION
Previously `kapacitord config` generated TOML that looked like

```toml
httppost = []
mtqq = []
...
```

rather than

```toml
[[httppost]]
  ...

[[mqtt]]
  ...
```

this was due to `server.NewConfig` returning an empty slice of `Config`s
for httppost and mqtt.

###### Required for all non-trivial PRs
- [ ] Tests pass
- [ ] CHANGELOG.md updated
