### PR TITLE
Fix various AST to tickscript issues found by more extensive testing

### DIFF
--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -57,7 +57,7 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 	}
 
 	for _, h := range a.HTTPPostHandlers {
-		n.Dot("post", h.URL).
+		n.DotRemoveZeroValue("post", h.URL).
 			Dot("endpoint", h.Endpoint).
 			DotIf("captureResponse", h.CaptureResponseFlag).
 			Dot("timeout", h.Timeout)
@@ -73,7 +73,7 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 	}
 
 	for _, h := range a.TcpHandlers {
-		n.Dot("tcp", h.Address)
+		n.DotRemoveZeroValue("tcp", h.Address)
 	}
 
 	for _, h := range a.EmailHandlers {
@@ -84,11 +84,11 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 	}
 
 	for _, h := range a.ExecHandlers {
-		n.Dot("exec", args(h.Command)...)
+		n.DotRemoveZeroValue("exec", args(h.Command)...)
 	}
 
 	for _, h := range a.LogHandlers {
-		n.Dot("log", h.FilePath)
+		n.DotRemoveZeroValue("log", h.FilePath)
 		if h.Mode != 0 {
 			mode := &ast.NumberNode{
 				IsInt: true,
@@ -114,8 +114,8 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 			Dot("userKey", h.UserKey).
 			Dot("device", h.Device).
 			Dot("title", h.Title).
-			Dot("url", h.URL).
-			Dot("urlTitle", h.URLTitle).
+			Dot("uRL", h.URL).
+			Dot("uRLTitle", h.URLTitle).
 			Dot("sound", h.Sound)
 	}
 
@@ -170,15 +170,14 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 	}
 
 	for _, h := range a.MQTTHandlers {
-		n.Dot("mqtt").
+		n.DotRemoveZeroValue("mqtt", h.Topic).
 			Dot("brokerName", h.BrokerName).
-			Dot("topic", h.Topic).
 			Dot("qos", h.Qos).
-			DotIf("retained", h.Retained)
+			Dot("retained", h.Retained)
 	}
 
 	for _, h := range a.SNMPTrapHandlers {
-		n.Dot("snmpTrap", h.TrapOid)
+		n.DotRemoveZeroValue("snmpTrap", h.TrapOid)
 		for _, d := range h.DataList {
 			n.Dot("data", d.Oid, d.Type, d.Value)
 		}

--- a/pipeline/tick/combine_test.go
+++ b/pipeline/tick/combine_test.go
@@ -12,39 +12,35 @@ func TestCombine(t *testing.T) {
 	combine := from.Combine(&ast.LambdaNode{
 		Expression: &ast.BinaryNode{
 			Operator: ast.TokenAnd,
-			Left: &ast.LambdaNode{
-				Expression: &ast.BinaryNode{
-					Left: &ast.ReferenceNode{
-						Reference: "cpu",
-					},
-					Right: &ast.StringNode{
-						Literal: "cpu-total",
-					},
-					Operator: ast.TokenNotEqual,
+			Left: &ast.BinaryNode{
+				Left: &ast.ReferenceNode{
+					Reference: "cpu",
 				},
+				Right: &ast.StringNode{
+					Literal: "cpu-total",
+				},
+				Operator: ast.TokenNotEqual,
 			},
-			Right: &ast.LambdaNode{
-				Expression: &ast.BinaryNode{
-					Left: &ast.ReferenceNode{
-						Reference: "host",
-					},
-					Right: &ast.RegexNode{
-						Literal: `logger\d+`,
-					},
-					Operator: ast.TokenRegexEqual,
+			Right: &ast.BinaryNode{
+				Left: &ast.ReferenceNode{
+					Reference: "host",
 				},
+				Right: &ast.RegexNode{
+					Literal: `logger\d+`,
+				},
+				Operator: ast.TokenRegexEqual,
 			},
 		},
 	})
-	combine.As("pumpkin", "eggs", "cinnamon", "ginger", "nutmeg", "condensedMilk")
+	combine.As("pumpkin")
 	combine.Delimiter = "cup"
 	combine.Tolerance = time.Hour + 10*time.Minute
 	combine.Max = 1
 
 	want := `stream
     |from()
-    |combine(lambda: lambda: "cpu" != 'cpu-total' AND lambda: "host" =~ /logger\d+/)
-        .as('pumpkin', 'eggs', 'cinnamon', 'ginger', 'nutmeg', 'condensedMilk')
+    |combine(lambda: "cpu" != 'cpu-total' AND "host" =~ /logger\d+/)
+        .as('pumpkin')
         .delimiter('cup')
         .tolerance(70m)
         .max(1)

--- a/pipeline/tick/eval_test.go
+++ b/pipeline/tick/eval_test.go
@@ -11,36 +11,32 @@ func TestEval(t *testing.T) {
 	eval := from.Eval(&ast.LambdaNode{
 		Expression: &ast.BinaryNode{
 			Operator: ast.TokenAnd,
-			Left: &ast.LambdaNode{
-				Expression: &ast.BinaryNode{
-					Left: &ast.ReferenceNode{
-						Reference: "cpu",
-					},
-					Right: &ast.StringNode{
-						Literal: "cpu-total",
-					},
-					Operator: ast.TokenNotEqual,
+			Left: &ast.BinaryNode{
+				Left: &ast.ReferenceNode{
+					Reference: "cpu",
 				},
+				Right: &ast.StringNode{
+					Literal: "cpu-total",
+				},
+				Operator: ast.TokenNotEqual,
 			},
-			Right: &ast.LambdaNode{
-				Expression: &ast.BinaryNode{
-					Left: &ast.ReferenceNode{
-						Reference: "host",
-					},
-					Right: &ast.RegexNode{
-						Literal: `logger\d+`,
-					},
-					Operator: ast.TokenRegexEqual,
+			Right: &ast.BinaryNode{
+				Left: &ast.ReferenceNode{
+					Reference: "host",
 				},
+				Right: &ast.RegexNode{
+					Literal: `logger\d+`,
+				},
+				Operator: ast.TokenRegexEqual,
 			},
 		},
 	})
-	eval.As("multiply", "divide").Tags("cells").Keep("petri", "dish").Quiet()
+	eval.As("cells").Tags("cells").Keep("petri", "dish").Quiet()
 
 	want := `stream
     |from()
-    |eval(lambda: lambda: "cpu" != 'cpu-total' AND lambda: "host" =~ /logger\d+/)
-        .as('multiply', 'divide')
+    |eval(lambda: "cpu" != 'cpu-total' AND "host" =~ /logger\d+/)
+        .as('cells')
         .tags('cells')
         .quiet()
         .keep('petri', 'dish')

--- a/pipeline/tick/from_test.go
+++ b/pipeline/tick/from_test.go
@@ -12,27 +12,23 @@ func TestFrom(t *testing.T) {
 	from.Where(&ast.LambdaNode{
 		Expression: &ast.BinaryNode{
 			Operator: ast.TokenAnd,
-			Left: &ast.LambdaNode{
-				Expression: &ast.BinaryNode{
-					Left: &ast.ReferenceNode{
-						Reference: "cpu",
-					},
-					Right: &ast.StringNode{
-						Literal: "cpu-total",
-					},
-					Operator: ast.TokenNotEqual,
+			Left: &ast.BinaryNode{
+				Left: &ast.ReferenceNode{
+					Reference: "cpu",
 				},
+				Right: &ast.StringNode{
+					Literal: "cpu-total",
+				},
+				Operator: ast.TokenNotEqual,
 			},
-			Right: &ast.LambdaNode{
-				Expression: &ast.BinaryNode{
-					Left: &ast.ReferenceNode{
-						Reference: "host",
-					},
-					Right: &ast.RegexNode{
-						Literal: `logger\d+`,
-					},
-					Operator: ast.TokenRegexEqual,
+			Right: &ast.BinaryNode{
+				Left: &ast.ReferenceNode{
+					Reference: "host",
 				},
+				Right: &ast.RegexNode{
+					Literal: `logger\d+`,
+				},
+				Operator: ast.TokenRegexEqual,
 			},
 		},
 	})
@@ -51,7 +47,7 @@ func TestFrom(t *testing.T) {
         .groupByMeasurement()
         .round(1s)
         .truncate(1s)
-        .where(lambda: lambda: "cpu" != 'cpu-total' AND lambda: "host" =~ /logger\d+/)
+        .where(lambda: "cpu" != 'cpu-total' AND "host" =~ /logger\d+/)
         .groupBy('this', 'that', 'these', 'those')
 `
 	PipelineTickTestHelper(t, pipe, want)

--- a/pipeline/tick/group_by_test.go
+++ b/pipeline/tick/group_by_test.go
@@ -2,19 +2,39 @@ package tick_test
 
 import (
 	"testing"
+
+	"github.com/influxdata/kapacitor/tick/ast"
 )
 
 func TestGroupBy(t *testing.T) {
 	pipe, _, from := StreamFrom()
 	logger := from.Log()
 	logger.Level = "Coxeter"
-	logger.GroupBy("simplex", "cube", "orthoplpex", "demicube").Exclude("4_21", "2_41", "1_42").ByMeasurement()
+	logger.GroupBy("simplex", "cube", "orthoplpex", "demicube").ByMeasurement()
 
 	want := `stream
     |from()
     |log()
         .level('Coxeter')
     |groupBy('simplex', 'cube', 'orthoplpex', 'demicube')
+        .exclude()
+        .byMeasurement()
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
+func TestGroupByStar(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	logger := from.Log()
+	logger.Level = "Coxeter"
+	star := &ast.StarNode{}
+	logger.GroupBy(star).Exclude("4_21", "2_41", "1_42").ByMeasurement()
+
+	want := `stream
+    |from()
+    |log()
+        .level('Coxeter')
+    |groupBy(*)
         .exclude('4_21', '2_41', '1_42')
         .byMeasurement()
 `

--- a/pipeline/tick/http_post_test.go
+++ b/pipeline/tick/http_post_test.go
@@ -5,12 +5,10 @@ import (
 	"time"
 )
 
-func TestHTTPPost(t *testing.T) {
+func TestHTTPPostURL(t *testing.T) {
 	pipe, _, from := StreamFrom()
-	post := from.HttpPost("http://influx1.local:8086/query", "http://influx2.local:8086/query")
+	post := from.HttpPost("http://influx1.local:8086/query")
 	post.
-		Endpoint("endpoint1").
-		Endpoint("endpoint2").
 		Header("Authorization", "Basic GOTO 10").
 		Header("X-Forwarded-For", `10 PRINT "HELLO WORLD"`).
 		CaptureResponse()
@@ -19,12 +17,34 @@ func TestHTTPPost(t *testing.T) {
 
 	want := `stream
     |from()
-    |httpPost('http://influx1.local:8086/query', 'http://influx2.local:8086/query')
+    |httpPost('http://influx1.local:8086/query')
+        .codeField('statusField')
+        .captureResponse()
+        .timeout(10s)
+        .header('Authorization', 'Basic GOTO 10')
+        .header('X-Forwarded-For', '10 PRINT "HELLO WORLD"')
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
+func TestHTTPPostEndpoint(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	post := from.HttpPost()
+	post.
+		Endpoint("endpoint1").
+		Header("Authorization", "Basic GOTO 10").
+		Header("X-Forwarded-For", `10 PRINT "HELLO WORLD"`).
+		CaptureResponse()
+	post.CodeField = "statusField"
+	post.Timeout = 10 * time.Second
+
+	want := `stream
+    |from()
+    |httpPost()
         .codeField('statusField')
         .captureResponse()
         .timeout(10s)
         .endpoint('endpoint1')
-        .endpoint('endpoint2')
         .header('Authorization', 'Basic GOTO 10')
         .header('X-Forwarded-For', '10 PRINT "HELLO WORLD"')
 `

--- a/pipeline/tick/influx.go
+++ b/pipeline/tick/influx.go
@@ -1,6 +1,8 @@
 package tick
 
 import (
+	"strings"
+
 	"github.com/influxdata/kapacitor/pipeline"
 	"github.com/influxdata/kapacitor/tick/ast"
 )
@@ -22,10 +24,18 @@ func NewInfluxQL(parents []ast.Node) *InfluxQLNode {
 // Build creates a InfluxQLNode ast.Node
 func (n *InfluxQLNode) Build(q *pipeline.InfluxQLNode) (ast.Node, error) {
 	args := []interface{}{}
-	if q.Field != "" {
-		args = append(args, q.Field)
+	if strings.ToLower(q.Method) == "bottom" || strings.ToLower(q.Method) == "top" {
+		if len(q.Args) > 0 {
+			args = append(args, q.Args[0])
+			args = append(args, q.Field)
+			args = append(args, q.Args[1:]...)
+		}
+	} else {
+		if q.Field != "" {
+			args = append(args, q.Field)
+		}
+		args = append(args, q.Args...)
 	}
-	args = append(args, q.Args...)
 	n.Pipe(q.Method, args...).
 		Dot("as", q.As).
 		DotIf("usePointTimes", q.PointTimes)

--- a/pipeline/tick/influx_test.go
+++ b/pipeline/tick/influx_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestInfluxQL(t *testing.T) {
+func TestInfluxQLBottom(t *testing.T) {
 	pipe, _, from := StreamFrom()
 	influx := from.Mean("streets").Bottom(5, "rung", "tags")
 	influx.As = "my"
@@ -14,9 +14,34 @@ func TestInfluxQL(t *testing.T) {
     |from()
     |mean('streets')
         .as('mean')
-    |bottom('rung', 5, 'tags')
+    |bottom(5, 'rung', 'tags')
         .as('my')
         .usePointTimes()
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
+func TestInfluxQLTop(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	influx := from.Top(5, "shelf", "tags", "youre_it")
+	influx.As = "brass_ring"
+
+	want := `stream
+    |from()
+    |top(5, 'shelf', 'tags', 'youre_it')
+        .as('brass_ring')
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
+func TestInfluxQLCount(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	from.Count("dracula")
+
+	want := `stream
+    |from()
+    |count('dracula')
+        .as('count')
 `
 	PipelineTickTestHelper(t, pipe, want)
 }

--- a/pipeline/tick/k8s_autoscale_test.go
+++ b/pipeline/tick/k8s_autoscale_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/influxdata/kapacitor/tick/ast"
 )
 
-func TestK8sAutoscale(t *testing.T) {
+func TestK8sAutoscaleResourceName(t *testing.T) {
 	pipe, _, from := StreamFrom()
 	n := from.K8sAutoscale()
 
@@ -15,7 +15,6 @@ func TestK8sAutoscale(t *testing.T) {
 	n.Namespace = "winona_marina"
 	n.Kind = "deployments"
 	n.ResourceName = "east_docks"
-	n.ResourceNameTag = "docks"
 	n.CurrentField = "replicas"
 	n.Max = 10
 	n.Min = 5
@@ -65,6 +64,75 @@ func TestK8sAutoscale(t *testing.T) {
         .namespace('winona_marina')
         .kind('deployments')
         .resourceName('east_docks')
+        .currentField('replicas')
+        .max(10)
+        .min(5)
+        .replicas(lambda: if("greater spire" > 1, "replicas" + 1, "replicas"))
+        .increaseCooldown(1h)
+        .decreaseCooldown(1m)
+        .namespaceTag('lucky_find')
+        .kindTag('deployment')
+        .resourceTag('dock')
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
+func TestK8sAutoscaleResourceNameTag(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	n := from.K8sAutoscale()
+
+	n.Cluster = "marina"
+	n.Namespace = "winona_marina"
+	n.Kind = "deployments"
+	n.ResourceNameTag = "docks"
+	n.CurrentField = "replicas"
+	n.Max = 10
+	n.Min = 5
+	n.IncreaseCooldown = time.Hour
+	n.DecreaseCooldown = time.Minute
+	n.NamespaceTag = "lucky_find"
+	n.KindTag = "deployment"
+	n.ResourceTag = "dock"
+	n.Replicas = &ast.LambdaNode{
+		Expression: &ast.FunctionNode{
+			Type: ast.GlobalFunc,
+			Func: "if",
+			Args: []ast.Node{
+				&ast.BinaryNode{
+					Operator: ast.TokenGreater,
+					Left: &ast.ReferenceNode{
+						Reference: "greater spire",
+					},
+					Right: &ast.NumberNode{
+						IsInt: true,
+						Int64: 1,
+						Base:  10,
+					},
+				},
+				&ast.BinaryNode{
+					Operator: ast.TokenPlus,
+					Left: &ast.ReferenceNode{
+						Reference: "replicas",
+					},
+					Right: &ast.NumberNode{
+						IsInt: true,
+						Int64: 1,
+						Base:  10,
+					},
+				},
+				&ast.ReferenceNode{
+					Reference: "replicas",
+				},
+			},
+		},
+	}
+
+	want := `stream
+    |from()
+    |k8sAutoscale()
+        .cluster('marina')
+        .namespace('winona_marina')
+        .kind('deployments')
         .resourceNameTag('docks')
         .currentField('replicas')
         .max(10)

--- a/pipeline/tick/udf_test.go
+++ b/pipeline/tick/udf_test.go
@@ -9,7 +9,35 @@ import (
 
 func TestUDF(t *testing.T) {
 	pipe, _, from := StreamFrom()
-	udf := pipeline.NewUDF(from, "delorean", agent.EdgeType_STREAM, agent.EdgeType_STREAM, nil)
+	options := map[string]*agent.OptionInfo{
+		"mph": &agent.OptionInfo{
+			ValueTypes: []agent.ValueType{
+				agent.ValueType_INT,
+			},
+		},
+		"gigawatts": &agent.OptionInfo{
+			ValueTypes: []agent.ValueType{
+				agent.ValueType_DOUBLE,
+			},
+		},
+		"nearClockTower": &agent.OptionInfo{
+			ValueTypes: []agent.ValueType{
+				agent.ValueType_BOOL,
+			},
+		},
+		"martySays": &agent.OptionInfo{
+			ValueTypes: []agent.ValueType{
+				agent.ValueType_STRING,
+			},
+		},
+		"future": &agent.OptionInfo{
+			ValueTypes: []agent.ValueType{
+				agent.ValueType_DURATION,
+				agent.ValueType_STRING,
+			},
+		},
+	}
+	udf := pipeline.NewUDF(from, "delorean", agent.EdgeType_STREAM, agent.EdgeType_STREAM, options)
 	udf.Options = []*agent.Option{
 		{
 			Name: "mph",
@@ -83,5 +111,5 @@ func TestUDF(t *testing.T) {
         .martySays('Doc!')
         .future(15778476m, 'years')
 `
-	PipelineTickTestHelper(t, pipe, want)
+	PipelineTickTestHelper(t, pipe, want, udf)
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Several of the generated tickscripts had issues with

1. case (pushover's `uRL` and `uRLTitle`
2. removing nodes when arguments were incorrectly empty string (post, log, tcp, exec)
3. bottom/top were incorrectly generated as the field is the second argument
4. several tests generated incorrect tickscripts.  This had no functional problem, but, we don't want them as examples.