### PR TITLE
Fix package flag in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ If you want to generate code run:
 If you want to build packages run:
 
 ```bash
-./build.py --packages
+./build.py --package
 ```
 
 There are many more options available see


### PR DESCRIPTION
This PR simply just changes the `package` flag to the correct one in CONTRIBUTING.md as seen in

https://github.com/influxdata/kapacitor/blob/master/build.py#L987