### PR TITLE
Set stop time based off query bounds if query is grouped by time

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -316,7 +316,7 @@ func (n *QueryNode) doQuery(in edge.Edge) error {
 				}
 				for _, bch := range batches {
 					// Set stop time based off query bounds
-					if bch.Begin().Time().IsZero() || !n.query.IsGroupedByTime() {
+					if bch.Begin().Time().IsZero() || n.query.IsGroupedByTime() {
 						bch.Begin().SetTime(stop)
 					}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [?] Tests pass (couldn't run the tests locally for some reason)
- [ ] CHANGELOG.md updated (Should I do this)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fixes #1765. When the batches were grouped by time, the time on the BatchPoint was only being updated every hour (?).

Not quite sure if this is the correct part of the code to fix though as I don't completely grasp the complexities of either Go not Kapacitor. However it does now produce correct output every time the groupBy is being called (that is whatever is set to the `every` on the TICKScript).

@nathanielc can you confirm? 