### PR TITLE
Remove reference to WARN log level

### DIFF
--- a/cmd/kapacitord/run/command.go
+++ b/cmd/kapacitord/run/command.go
@@ -252,7 +252,7 @@ run starts the Kapacitor server.
                           Write logs to a file.
 
         -log-level <level>
-                          Sets the log level. One of debug,info,warn,error.
+                          Sets the log level. One of debug,info,error.
 `
 
 // Options represents the command line options that can be parsed.

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -36,7 +36,8 @@ default-retention-policy = ""
     # Can be a path to a file or 'STDOUT', 'STDERR'.
     file = "/var/log/kapacitor/kapacitor.log"
     # Logging level can be one of:
-    # DEBUG, INFO, WARN, ERROR, or OFF
+    # DEBUG, INFO, ERROR
+    # HTTP logging can be disabled in the [http] config section.
     level = "INFO"
 
 [load]


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The `WARN` log level was not being used and removed in the process of adding the logging API features in Kapacitor 1.4.0. Note that it is still possible to set warn thresholds on alert nodes, this only affects Kapacitor internal logging.