### PR TITLE
Fix deadlock in load service if task has error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bugfixes
 
+- [#1827](https://github.com/influxdata/kapacitor/pull/1827): Fix deadlock in load service when task has an error.
+
 
 ## v1.4.0 [2017-12-08]
 

--- a/services/task_store/util.go
+++ b/services/task_store/util.go
@@ -75,6 +75,9 @@ func taskTypeFromProgram(n *ast.ProgramNode) client.TaskType {
 						tts = append(tts, ident)
 					}
 					break ChainLoop
+				default:
+					// Something went wrong, break out of loop.
+					break ChainLoop
 				}
 			}
 		}


### PR DESCRIPTION
Updated from #1741 