### PR TITLE
Enable docker layer caching in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          reusable: true
           docker_layer_caching: true
       - run:
           name: Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           reusable: true
+          docker_layer_caching: true
       - run:
           name: Tests
           command: |


### PR DESCRIPTION
This is a feature of CircleCI that we are currently demoing. Should speed up docker image building.

https://circleci.com/docs/2.0/docker-layer-caching/