### PR TITLE
Systemd ability to reload kapacitor configuration

### DIFF
--- a/scripts/kapacitor.service
+++ b/scripts/kapacitor.service
@@ -11,6 +11,7 @@ Group=kapacitor
 LimitNOFILE=65536
 EnvironmentFile=-/etc/default/kapacitor
 ExecStart=/usr/bin/kapacitord -config /etc/kapacitor/kapacitor.conf $KAPACITOR_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
 


### PR DESCRIPTION
Previously you can not use service reload `systemctl reload  kapacitor` as ExecReload was skipped