### PR TITLE
Fix pagerduty2 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ alert will auto-recover.
 - [#1795](https://github.com/influxdata/kapacitor/pull/1795): Support PagerDuty API v2
 - [#1842](https://github.com/influxdata/kapacitor/pull/1842): Add alert inhibitors that allow an alert to supress events from other matching alerts.
 - [#1776](https://github.com/influxdata/kapacitor/issues/1776): Fix bug where you could not delete a topic handler with the same name as its topic.
+- [#1905](https://github.com/influxdata/kapacitor/pull/1905): Adjust PagerDuty v2 service-test names and capture detailed error messages.
 
 ## v1.4.1 [2018-03-13]
 

--- a/alert.go
+++ b/alert.go
@@ -209,7 +209,7 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 
 	for _, pd := range n.PagerDuty2Handlers {
 		c := pagerduty2.HandlerConfig{
-			ServiceKey: pd.ServiceKey,
+			RoutingKey: pd.ServiceKey,
 		}
 		h := et.tm.PagerDuty2Service.Handler(c, ctx...)
 		an.handlers = append(an.handlers, h)

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -9295,7 +9295,7 @@ stream
 		c := pagerduty2.NewConfig()
 		c.Enabled = true
 		c.URL = ts.URL
-		c.ServiceKey = "service_key"
+		c.RoutingKey = "service_key"
 		pd := pagerduty2.NewService(c, diagService.NewPagerDuty2Handler())
 		pd.HTTPDService = tm.HTTPDService
 		tm.PagerDuty2Service = pd

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7442,7 +7442,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 		{
 			section: "pagerduty2",
 			setDefaults: func(c *server.Config) {
-				c.PagerDuty2.ServiceKey = "secret"
+				c.PagerDuty2.RoutingKey = "secret"
 			},
 			expDefaultSection: client.ConfigSection{
 				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/config/pagerduty2"},
@@ -7451,11 +7451,11 @@ func TestServer_UpdateConfig(t *testing.T) {
 					Options: map[string]interface{}{
 						"enabled":     false,
 						"global":      false,
-						"service-key": true,
+						"routing-key": true,
 						"url":         pagerduty2.DefaultPagerDuty2APIURL,
 					},
 					Redacted: []string{
-						"service-key",
+						"routing-key",
 					},
 				}},
 			},
@@ -7464,18 +7464,18 @@ func TestServer_UpdateConfig(t *testing.T) {
 				Options: map[string]interface{}{
 					"enabled":     false,
 					"global":      false,
-					"service-key": true,
+					"routing-key": true,
 					"url":         pagerduty2.DefaultPagerDuty2APIURL,
 				},
 				Redacted: []string{
-					"service-key",
+					"routing-key",
 				},
 			},
 			updates: []updateAction{
 				{
 					updateAction: client.ConfigUpdateAction{
 						Set: map[string]interface{}{
-							"service-key": "",
+							"routing-key": "",
 							"enabled":     true,
 						},
 					},
@@ -7486,11 +7486,11 @@ func TestServer_UpdateConfig(t *testing.T) {
 							Options: map[string]interface{}{
 								"enabled":     true,
 								"global":      false,
-								"service-key": false,
+								"routing-key": false,
 								"url":         pagerduty2.DefaultPagerDuty2APIURL,
 							},
 							Redacted: []string{
-								"service-key",
+								"routing-key",
 							},
 						}},
 					},
@@ -7499,11 +7499,11 @@ func TestServer_UpdateConfig(t *testing.T) {
 						Options: map[string]interface{}{
 							"enabled":     true,
 							"global":      false,
-							"service-key": false,
+							"routing-key": false,
 							"url":         pagerduty2.DefaultPagerDuty2APIURL,
 						},
 						Redacted: []string{
-							"service-key",
+							"routing-key",
 						},
 					},
 				},
@@ -8779,9 +8779,9 @@ func TestServer_ListServiceTests(t *testing.T) {
 				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/service-tests/pagerduty2"},
 				Name: "pagerduty2",
 				Options: client.ServiceTestOptions{
-					"incident-key": "testIncidentKey",
-					"description":  "test pagerduty2 message",
-					"level":        "CRITICAL",
+					"alert_id":    "testAlertID",
+					"description": "test pagerduty2 message",
+					"level":       "CRITICAL",
 					"event_data": map[string]interface{}{
 						"Fields": map[string]interface{}{},
 						"Result": map[string]interface{}{
@@ -9855,7 +9855,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 			handler: client.TopicHandler{
 				Kind: "pagerduty2",
 				Options: map[string]interface{}{
-					"service-key": "service_key",
+					"routing-key": "rkey",
 				},
 			},
 			setup: func(c *server.Config, ha *client.TopicHandler) (context.Context, error) {
@@ -9898,7 +9898,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 							},
 							Timestamp: "1970-01-01T00:00:00.000000000Z",
 						},
-						RoutingKey: "service_key",
+						RoutingKey: "rkey",
 					},
 				}}
 

--- a/services/pagerduty2/config.go
+++ b/services/pagerduty2/config.go
@@ -15,8 +15,8 @@ type Config struct {
 	Enabled bool `toml:"enabled" override:"enabled"`
 	// The PagerDuty API URL, should not need to be changed.
 	URL string `toml:"url" override:"url"`
-	// The PagerDuty service key.
-	ServiceKey string `toml:"service-key" override:"service-key,redact"`
+	// The PagerDuty routing key, this is associated with an Event v2 API integration service.
+	RoutingKey string `toml:"routing-key" override:"routing-key,redact"`
 	// Whether every alert should automatically go to PagerDuty
 	Global bool `toml:"global" override:"global"`
 }


### PR DESCRIPTION
* Adds logic to understand pagerduty error response in full.
* Renames confusing test option.
* Renames ServiceKey to RoutingKey to match v2 API name.