### PR TITLE
Fix Kafka configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ alert will auto-recover.
 - [#1842](https://github.com/influxdata/kapacitor/pull/1842): Add alert inhibitors that allow an alert to supress events from other matching alerts.
 - [#1776](https://github.com/influxdata/kapacitor/issues/1776): Fix bug where you could not delete a topic handler with the same name as its topic.
 - [#1905](https://github.com/influxdata/kapacitor/pull/1905): Adjust PagerDuty v2 service-test names and capture detailed error messages.
+- [#1913](https://github.com/influxdata/kapacitor/pull/1913): Fix Kafka configuration.
 
 ## v1.4.1 [2018-03-13]
 

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -457,13 +457,13 @@ default-retention-policy = ""
   brokers = []
   # Timeout on network operations with the brokers.
   # If 0 a default of 10s will be used.
-  timeout = 10s
+  timeout = "10s"
   # BatchSize is the number of messages that are batched before being sent to Kafka
   # If 0 a default of 100 will be used.
   batch-size = 100
   # BatchTimeout is the maximum amount of time to wait before flushing an incomplete batch.
   # If 0 a default of 1s will be used.
-  batch-timeout = 1s
+  batch-timeout = "1s"
   # Use SSL enables ssl communication.
   # Must be true for the other ssl options to take effect.
   use-ssl = false

--- a/server/config.go
+++ b/server/config.go
@@ -150,6 +150,7 @@ func NewConfig() *Config {
 
 	c.Alerta = alerta.NewConfig()
 	c.HipChat = hipchat.NewConfig()
+	c.Kafka = kafka.Configs{kafka.NewConfig()}
 	c.MQTT = mqtt.Configs{mqtt.NewConfig()}
 	c.OpsGenie = opsgenie.NewConfig()
 	c.OpsGenie2 = opsgenie2.NewConfig()

--- a/services/kafka/config.go
+++ b/services/kafka/config.go
@@ -45,9 +45,7 @@ type Config struct {
 }
 
 func NewConfig() Config {
-	return Config{
-		Enabled: false,
-	}
+	return Config{}
 }
 
 func (c Config) Validate() error {

--- a/services/kafka/config.go
+++ b/services/kafka/config.go
@@ -44,6 +44,12 @@ type Config struct {
 	InsecureSkipVerify bool `toml:"insecure-skip-verify" override:"insecure-skip-verify"`
 }
 
+func NewConfig() Config {
+	return Config{
+		Enabled: false,
+	}
+}
+
 func (c Config) Validate() error {
 	if !c.Enabled {
 		return nil


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

### The Problem
- Kafka was not being returned among the sections of the config in Kapacitor 1.5 out of the box.
- Two of the default Kafka config's duration values were missing quotes and caused errors when used as-is.

### The Solution
- Add a function to Kafka config to generate a new config, and make sure server generates that new config on startup.
- Properly quote the two durations in the default Kafka config.

