### PR TITLE
Replay service: stop running tasks when a replay is deleted

### DIFF
--- a/services/replay/service.go
+++ b/services/replay/service.go
@@ -806,7 +806,19 @@ func (s *Service) handleDeleteReplay(w http.ResponseWriter, req *http.Request) {
 		httpd.HttpError(w, err.Error(), true, http.StatusBadRequest)
 		return
 	}
-	//TODO: Cancel running replays
+
+	// Cancel running replays
+	replay, err := s.replays.Get(id)
+	if err == nil {
+		tm := s.TaskMasterLookup.Get(replay.ID)
+		if tm != nil {
+			for _, b := range tm.BatchCollectors(replay.TaskID) {
+				b.Close()
+			}
+			tm.StopTasks()
+		}
+	}
+
 	s.replays.Delete(id)
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
A proof-of-concept fix for #1895. Tested with query replays against simple tasks (a single httpOut or httpPost node).

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)