### PR TITLE
 Add delete support to barrier node 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#2095](https://github.com/influxdata/kapacitor/issues/2095): Add barrier node support to join node.
+- [#1157](https://github.com/influxdata/kapacitor/issues/1157): Add ability to expire groups using the barrier node.
 
 ### Bugfixes
 

--- a/barrier.go
+++ b/barrier.go
@@ -63,16 +63,20 @@ func (n *BarrierNode) newBarrier(group edge.GroupInfo, first edge.PointMeta) (ed
 		idleBarrier := newIdleBarrier(
 			first.Name(),
 			group,
+			n.ins[0],
 			n.b.Idle,
 			n.outs,
+			n.b.Delete,
 		)
 		return idleBarrier, idleBarrier.Stop, nil
 	case n.b.Period != 0:
 		periodicBarrier := newPeriodicBarrier(
 			first.Name(),
 			group,
+			n.ins[0],
 			n.b.Period,
 			n.outs,
+			n.b.Delete,
 		)
 		return periodicBarrier, periodicBarrier.Stop, nil
 	default:
@@ -83,7 +87,9 @@ func (n *BarrierNode) newBarrier(group edge.GroupInfo, first edge.PointMeta) (ed
 type idleBarrier struct {
 	name  string
 	group edge.GroupInfo
+	in    edge.Edge
 
+	del          bool
 	idle         time.Duration
 	lastPointT   atomic.Value
 	lastBarrierT atomic.Value
@@ -93,10 +99,11 @@ type idleBarrier struct {
 	resetTimerC  chan struct{}
 }
 
-func newIdleBarrier(name string, group edge.GroupInfo, idle time.Duration, outs []edge.StatsEdge) *idleBarrier {
+func newIdleBarrier(name string, group edge.GroupInfo, in edge.Edge, idle time.Duration, outs []edge.StatsEdge, del bool) *idleBarrier {
 	r := &idleBarrier{
 		name:         name,
 		group:        group,
+		in:           in,
 		idle:         idle,
 		lastPointT:   atomic.Value{},
 		lastBarrierT: atomic.Value{},
@@ -104,6 +111,7 @@ func newIdleBarrier(name string, group edge.GroupInfo, idle time.Duration, outs 
 		outs:         outs,
 		stopC:        make(chan struct{}),
 		resetTimerC:  make(chan struct{}),
+		del:          del,
 	}
 
 	r.Init()
@@ -120,8 +128,12 @@ func (n *idleBarrier) Init() {
 }
 
 func (n *idleBarrier) Stop() {
-	close(n.stopC)
-	n.wg.Wait()
+	select {
+	case <-n.stopC:
+	default:
+		close(n.stopC)
+		n.wg.Wait()
+	}
 }
 
 func (n *idleBarrier) BeginBatch(m edge.BeginBatchMessage) (edge.Message, error) {
@@ -172,7 +184,15 @@ func (n *idleBarrier) emitBarrier() error {
 	newT := n.lastPointT.Load().(time.Time).Add(n.idle)
 	n.lastPointT.Store(newT)
 	n.lastBarrierT.Store(newT)
-	return edge.Forward(n.outs, edge.NewBarrierMessage(n.group, newT))
+
+	err := edge.Forward(n.outs, edge.NewBarrierMessage(n.group, newT))
+	if err != nil {
+		return err
+	}
+	if n.del {
+		return n.in.Collect(edge.NewDeleteGroupMessage(n.group.ID))
+	}
+	return nil
 }
 
 func (n *idleBarrier) idleHandler() {
@@ -198,7 +218,9 @@ func (n *idleBarrier) idleHandler() {
 type periodicBarrier struct {
 	name  string
 	group edge.GroupInfo
+	in    edge.Edge
 
+	del    bool
 	lastT  atomic.Value
 	ticker *time.Ticker
 	wg     sync.WaitGroup
@@ -206,15 +228,17 @@ type periodicBarrier struct {
 	stopC  chan struct{}
 }
 
-func newPeriodicBarrier(name string, group edge.GroupInfo, period time.Duration, outs []edge.StatsEdge) *periodicBarrier {
+func newPeriodicBarrier(name string, group edge.GroupInfo, in edge.Edge, period time.Duration, outs []edge.StatsEdge, del bool) *periodicBarrier {
 	r := &periodicBarrier{
 		name:   name,
 		group:  group,
+		in:     in,
 		lastT:  atomic.Value{},
 		ticker: time.NewTicker(period),
 		wg:     sync.WaitGroup{},
 		outs:   outs,
 		stopC:  make(chan struct{}),
+		del:    del,
 	}
 
 	r.Init()
@@ -230,9 +254,13 @@ func (n *periodicBarrier) Init() {
 }
 
 func (n *periodicBarrier) Stop() {
-	close(n.stopC)
-	n.ticker.Stop()
-	n.wg.Wait()
+	select {
+	case <-n.stopC:
+	default:
+		close(n.stopC)
+		n.ticker.Stop()
+		n.wg.Wait()
+	}
 }
 
 func (n *periodicBarrier) BeginBatch(m edge.BeginBatchMessage) (edge.Message, error) {
@@ -271,7 +299,15 @@ func (n *periodicBarrier) Point(m edge.PointMessage) (edge.Message, error) {
 func (n *periodicBarrier) emitBarrier() error {
 	nowT := time.Now().UTC()
 	n.lastT.Store(nowT)
-	return edge.Forward(n.outs, edge.NewBarrierMessage(n.group, nowT))
+	err := edge.Forward(n.outs, edge.NewBarrierMessage(n.group, nowT))
+	if err != nil {
+		return err
+	}
+	if n.del {
+		// Send DeleteGroupMessage into self
+		return n.in.Collect(edge.NewDeleteGroupMessage(n.group.ID))
+	}
+	return nil
 }
 
 func (n *periodicBarrier) periodicEmitter() {

--- a/edge/consumer.go
+++ b/edge/consumer.go
@@ -66,6 +66,10 @@ func (ec *consumer) Consume() error {
 			if err := ec.r.Barrier(m); err != nil {
 				return err
 			}
+		case DeleteGroupMessage:
+			if err := ec.r.DeleteGroup(m); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unexpected message of type %T", msg)
 		}

--- a/pipeline/barrier_test.go
+++ b/pipeline/barrier_test.go
@@ -9,6 +9,7 @@ func TestBarrierNode_MarshalJSON(t *testing.T) {
 	type fields struct {
 		Period time.Duration
 		Idle   time.Duration
+		Delete bool
 	}
 	tests := []struct {
 		name    string
@@ -21,8 +22,9 @@ func TestBarrierNode_MarshalJSON(t *testing.T) {
 			fields: fields{
 				Period: time.Hour,
 				Idle:   time.Minute,
+				Delete: true,
 			},
-			want: `{"typeOf":"barrier","id":"0","period":"1h","idle":"1m"}`,
+			want: `{"typeOf":"barrier","id":"0","delete":true,"period":"1h","idle":"1m"}`,
 		},
 		{
 			name: "only period ",
@@ -37,6 +39,7 @@ func TestBarrierNode_MarshalJSON(t *testing.T) {
 			b := newBarrierNode(StreamEdge)
 			b.Period = tt.fields.Period
 			b.Idle = tt.fields.Idle
+			b.Delete = tt.fields.Delete
 			MarshalTestHelper(t, b, tt.wantErr, tt.want)
 		})
 	}

--- a/pipeline/tick/barrier.go
+++ b/pipeline/tick/barrier.go
@@ -23,6 +23,7 @@ func NewBarrierNode(parents []ast.Node) *BarrierNode {
 func (n *BarrierNode) Build(b *pipeline.BarrierNode) (ast.Node, error) {
 	n.Pipe("barrier").
 		Dot("idle", b.Idle).
-		Dot("period", b.Period)
+		Dot("period", b.Period).
+		Dot("delete", b.Delete)
 	return n.prev, n.err
 }

--- a/pipeline/tick/barrier_test.go
+++ b/pipeline/tick/barrier_test.go
@@ -11,6 +11,7 @@ func TestBarrierNode(t *testing.T) {
 	type args struct {
 		idle   time.Duration
 		period time.Duration
+		del    bool
 	}
 	tests := []struct {
 		name string
@@ -39,6 +40,17 @@ func TestBarrierNode(t *testing.T) {
         .period(1s)
 `,
 		},
+		{
+			name: "barrier with delete",
+			args: args{
+				del: true,
+			},
+			want: `stream
+    |from()
+    |barrier()
+        .delete(TRUE)
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -48,6 +60,7 @@ func TestBarrierNode(t *testing.T) {
 			b := stream.From().Barrier()
 			b.Idle = tt.args.idle
 			b.Period = tt.args.period
+			b.Delete = tt.args.del
 
 			got, err := PipelineTick(pipe)
 			if err != nil {


### PR DESCRIPTION
Fixes #1157 

It is now possible to use the barrier node to delete/expire old groupds.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
