### PR TITLE
Use Systemd for Amazon Linux 2

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -66,7 +66,10 @@ elif [[ -f /etc/debian_version ]]; then
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
-    if [[ $ID = "amzn" ]]; then
+    if [[ "$NAME" = "Amazon Linux" ]]; then
+        # Amazon Linux 2+ logic
+        install_systemd
+    elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
         # Amazon Linux logic
         install_init
         # Do not enable service

--- a/scripts/post-uninstall.sh
+++ b/scripts/post-uninstall.sh
@@ -62,12 +62,16 @@ elif [[ -f /etc/debian_version ]]; then
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
-    if [[ $ID = "amzn" ]]; then
-        # Amazon Linux logic
-        if [[ "$1" = "0" ]]; then
-            # Kapacitor is no longer installed, remove from init system
-            rm -f /etc/default/kapacitor
+    if [[ "$ID" = "amzn" ]] && [[ "$1" = "0" ]]; then
+        # Kapacitor is no longer installed, remove from init system
+        rm -f /etc/default/kapacitor
 
+        if [[ "$NAME" = "Amazon Linux" ]]; then
+            # Amazon Linux 2+ logic
+            disable_systemd
+            uninstall_systemd
+        elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
+            # Amazon Linux logic
             # Run update-rc.d or fallback to chkconfig if not available
             if which update-rc.d &>/dev/null; then
                 disable_update_rcd


### PR DESCRIPTION
Amazon Linux 2 uses systemd. This PR adds support for Amazon Linux 2 in `kapacitord`'s `post-install.sh` and `post-uninstall.sh` scripts.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
