### PR TITLE
fix(http): use default transport consitently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## unreleased
 
+### Features
+
+- [#2154](https://github.com/influxdata/kapacitor/pull/2154): Add ability to skip ssl verification with an alert post node. Thanks @itsHabib!
+
+### Bugfixes
+
+- [#2167](https://github.com/influxdata/kapacitor/pull/2167): Use default transport consistently.
+
 ## v1.5.2 [2018-12-12]
 
 ### Features
@@ -12,7 +20,6 @@
 - [#2101](https://github.com/influxdata/kapacitor/issues/2101): Add multiple field support to the change detect node.
 - [#1961](https://github.com/influxdata/kapacitor/pull/1961): Add links to pagerduty2 alerts
 - [#1974](https://github.com/influxdata/kapacitor/issues/1974): Add additional metadata to Sensu alerts.
-- [#2154](https://github.com/influxdata/kapacitor/pull/2154): Add ability to skip ssl verification with an alert post node.
 
 ### Bugfixes
 

--- a/client/v1/client.go
+++ b/client/v1/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/influxql"
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/pkg/errors"
 )
 
@@ -176,12 +177,9 @@ func New(conf Config) (*Client, error) {
 	var tr *http.Transport
 
 	if rt == nil {
-		tr = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: conf.InsecureSkipVerify,
-			},
-		}
+		tr = khttp.NewDefaultTransportWithTLS(&tls.Config{
+			InsecureSkipVerify: conf.InsecureSkipVerify,
+		})
 		if conf.TLSConfig != nil {
 			tr.TLSClientConfig = conf.TLSConfig
 		}

--- a/http/transport.go
+++ b/http/transport.go
@@ -1,0 +1,34 @@
+package http
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// NewDefaultTransport creates a new transport with sane defaults.
+func NewDefaultTransport() *http.Transport {
+	// These defaults are copied from http.DefaultTransport.
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		// Below are changes from http.DefaultTransport
+		MaxIdleConnsPerHost: 100, // increased from 2, services tend to connect to a single host
+	}
+}
+
+// NewDefaultTransportWithTLS creates a new transport with the specified TLS configuration.
+func NewDefaultTransportWithTLS(tlsConfig *tls.Config) *http.Transport {
+	t := NewDefaultTransport()
+	t.TLSClientConfig = tlsConfig
+	return t
+}

--- a/influxdb/client.go
+++ b/influxdb/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	imodels "github.com/influxdata/influxdb/models"
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/pkg/errors"
 )
 
@@ -123,9 +124,7 @@ func NewHTTPClient(conf Config) (*HTTPClient, error) {
 		return nil, errors.Wrap(err, "invalid URLs")
 	}
 	if conf.Transport == nil {
-		conf.Transport = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		}
+		conf.Transport = khttp.NewDefaultTransport()
 	}
 	c := &HTTPClient{
 		config: conf,

--- a/services/alerta/service.go
+++ b/services/alerta/service.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/influxdata/kapacitor/alert"
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/influxdata/kapacitor/keyvalue"
 	"github.com/influxdata/kapacitor/models"
 	"github.com/pkg/errors"
@@ -45,10 +46,7 @@ func NewService(c Config, d Diagnostic) *Service {
 	}
 	s.configValue.Store(c)
 	s.clientValue.Store(&http.Client{
-		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify},
-		},
+		Transport: khttp.NewDefaultTransportWithTLS(&tls.Config{InsecureSkipVerify: c.InsecureSkipVerify}),
 	})
 	return s
 }
@@ -128,10 +126,7 @@ func (s *Service) Update(newConfig []interface{}) error {
 	} else {
 		s.configValue.Store(c)
 		s.clientValue.Store(&http.Client{
-			Transport: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify},
-			},
+			Transport: khttp.NewDefaultTransportWithTLS(&tls.Config{InsecureSkipVerify: c.InsecureSkipVerify}),
 		})
 	}
 

--- a/services/httppost/service.go
+++ b/services/httppost/service.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/influxdata/kapacitor/alert"
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/influxdata/kapacitor/keyvalue"
 	"github.com/pkg/errors"
 )
@@ -329,15 +330,16 @@ func (h *handler) Handle(event alert.Event) {
 		req = req.WithContext(ctx)
 	}
 
-	httpClient := &http.Client{}
-
-	// Skip SSL verification?
+	// Setup HTTP client
+	var tlsConfig *tls.Config
 	if h.skipSSLVerification {
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
 		}
+	}
+
+	httpClient := &http.Client{
+		Transport: khttp.NewDefaultTransportWithTLS(tlsConfig),
 	}
 
 	// Execute the request

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/influxdata/kapacitor/influxdb"
 	"github.com/influxdata/kapacitor/keyvalue"
 	"github.com/influxdata/kapacitor/server/vars"
@@ -501,10 +502,7 @@ func httpConfig(c Config) (influxdb.Config, error) {
 	if err != nil {
 		return influxdb.Config{}, errors.Wrap(err, "invalid TLS options")
 	}
-	tr := &http.Transport{
-		Proxy:           http.ProxyFromEnvironment,
-		TLSClientConfig: tlsConfig,
-	}
+	tr := khttp.NewDefaultTransportWithTLS(tlsConfig)
 	var credentials influxdb.Credentials
 	if c.Username != "" {
 		credentials = influxdb.Credentials{

--- a/services/k8s/client/client.go
+++ b/services/k8s/client/client.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/pkg/errors"
 )
 
@@ -123,10 +124,7 @@ func New(c Config) (Client, error) {
 		config: c,
 		urls:   urls,
 		client: &http.Client{
-			Transport: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: c.TLSConfig,
-			},
+			Transport: khttp.NewDefaultTransportWithTLS(c.TLSConfig),
 		},
 	}, nil
 }
@@ -168,10 +166,7 @@ func (c *httpClient) Update(new Config) error {
 
 	if old.TLSConfig != new.TLSConfig {
 		c.client = &http.Client{
-			Transport: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: new.TLSConfig,
-			},
+			Transport: khttp.NewDefaultTransportWithTLS(new.TLSConfig),
 		}
 	}
 	return nil

--- a/services/slack/service.go
+++ b/services/slack/service.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/influxdata/kapacitor/alert"
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/influxdata/kapacitor/keyvalue"
 	"github.com/influxdata/kapacitor/tlsconfig"
 	"github.com/pkg/errors"
@@ -37,10 +38,7 @@ func NewWorkspace(c Config) (*Workspace, error) {
 	}
 
 	cl := &http.Client{
-		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsConfig,
-		},
+		Transport: khttp.NewDefaultTransportWithTLS(tlsConfig),
 	}
 
 	return &Workspace{
@@ -68,10 +66,7 @@ func (w *Workspace) Update(c Config) error {
 	}
 
 	cl := &http.Client{
-		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsConfig,
-		},
+		Transport: khttp.NewDefaultTransportWithTLS(tlsConfig),
 	}
 
 	w.client = cl

--- a/services/swarm/client/client.go
+++ b/services/swarm/client/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	khttp "github.com/influxdata/kapacitor/http"
 	"github.com/pkg/errors"
 )
 
@@ -52,9 +53,7 @@ func New(c Config) (Client, error) {
 		config: c,
 		urls:   urls,
 		client: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: c.TLSConfig,
-			},
+			Transport: khttp.NewDefaultTransportWithTLS(c.TLSConfig),
 		},
 	}, nil
 }
@@ -92,9 +91,7 @@ func (c *httpClient) Update(new Config) error {
 
 	if old.TLSConfig != new.TLSConfig {
 		c.client = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: new.TLSConfig,
-			},
+			Transport: khttp.NewDefaultTransportWithTLS(new.TLSConfig),
 		}
 	}
 	return nil


### PR DESCRIPTION
The http transport used in most places did not have sane defaults. This change consolidates creation of a new http transport. 

These changes only effect outgoing HTTP connections from Kapacitor, which tend to be low volume. 