### PR TITLE
fix(package): set rpm user and group to create files with correct owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#2167](https://github.com/influxdata/kapacitor/pull/2167): Use default transport consistently.
 - [#2144](https://github.com/influxdata/kapacitor/issues/2144): Fix deadlock in barrier node when delete is used.
+- [#2186](https://github.com/influxdata/kapacitor/pull/2186): Make RPM create files with correct ownership on install.
 
 ## v1.5.2 [2018-12-12]
 

--- a/build.py
+++ b/build.py
@@ -1,16 +1,15 @@
 #!/usr/bin/python2.7 -u
 
-import sys
-import os
-import subprocess
-import time
-from datetime import datetime
-import shutil
-import tempfile
-import hashlib
-import re
-import logging
 import argparse
+import hashlib
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
 
 ################
 #### Kapacitor Variables
@@ -21,6 +20,8 @@ os.environ["GO15VENDOREXPERIMENT"] = "1"
 
 # PACKAGING VARIABLES
 PACKAGE_NAME = "kapacitor"
+USER = "kapacitor"
+GROUP = "kapacitor"
 INSTALL_ROOT_DIR = "/usr/bin"
 LOG_DIR = "/var/log/kapacitor"
 DATA_DIR = "/var/lib/kapacitor"
@@ -60,6 +61,8 @@ fpm_common_args = "-f -s dir --log error \
  --config-files {} \
  --config-files {} \
  --directories {} \
+ --rpm-attr 755,{},{}:{} \
+ --rpm-attr 755,{},{}:{} \
  --description \"{}\"".format(
         VENDOR,
         PACKAGE_URL,
@@ -76,6 +79,8 @@ fpm_common_args = "-f -s dir --log error \
                          os.path.dirname(SCRIPT_DIR[1:]),
                          os.path.dirname(DEFAULT_CONFIG),
                     ]),
+        USER, GROUP, LOG_DIR,
+        USER, GROUP, DATA_DIR,
         DESCRIPTION)
 
 targets = {

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -31,11 +31,6 @@ if ! id kapacitor >/dev/null 2>&1; then
 fi
 chmod a+rX $BIN_DIR/kapacitor*
 
-mkdir -p $LOG_DIR
-chown -R -L kapacitor:kapacitor $LOG_DIR
-mkdir -p $DATA_DIR
-chown -R -L kapacitor:kapacitor $DATA_DIR
-
 test -f /etc/default/kapacitor || touch /etc/default/kapacitor
 
 # Distribution-specific logic
@@ -49,26 +44,33 @@ if [[ -f /etc/redhat-release ]]; then
         install_init
         # Do not enable service
     fi
-elif [[ -f /etc/debian_version ]]; then
-    # Debian/Ubuntu logic
-    if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
-        install_systemd
-        enable_systemd
-    else
-        # Assuming SysV
-        install_init
-        # Run update-rc.d or fallback to chkconfig if not available
-        if which update-rc.d &>/dev/null; then
-            enable_update_rcd
+else
+    mkdir -p $LOG_DIR
+    chown -R -L kapacitor:kapacitor $LOG_DIR
+    mkdir -p $DATA_DIR
+    chown -R -L kapacitor:kapacitor $DATA_DIR
+
+    if [[ -f /etc/debian_version ]]; then
+        # Debian/Ubuntu logic
+        if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
+            install_systemd
+            enable_systemd
         else
-            enable_chkconfig
+            # Assuming SysV
+            install_init
+            # Run update-rc.d or fallback to chkconfig if not available
+            if which update-rc.d &>/dev/null; then
+                enable_update_rcd
+            else
+                enable_chkconfig
+            fi
         fi
-    fi
-elif [[ -f /etc/os-release ]]; then
-    source /etc/os-release
-    if [[ $ID = "amzn" ]]; then
-        # Amazon Linux logic
-        install_init
-        # Do not enable service
+    elif [[ -f /etc/os-release ]]; then
+        source /etc/os-release
+        if [[ $ID = "amzn" ]]; then
+            # Amazon Linux logic
+            install_init
+            # Do not enable service
+        fi
     fi
 fi


### PR DESCRIPTION

This PR makes rpm create files and directories with the right owner (user and group).  
This makes it possible to avoid changing ownership after install and so breaking verification (`rpm -V ...`).

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
