### PR TITLE
fix(edge): delete group stats when a group is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2167](https://github.com/influxdata/kapacitor/pull/2167): Use default transport consistently.
 - [#2144](https://github.com/influxdata/kapacitor/issues/2144): Fix deadlock in barrier node when delete is used.
 - [#2186](https://github.com/influxdata/kapacitor/pull/2186): Make RPM create files with correct ownership on install.
+- [#2189](https://github.com/influxdata/kapacitor/pull/2189): Delete group stats when a group is deleted
 
 ## v1.5.2 [2018-12-12]
 


### PR DESCRIPTION
The delete messages were not honored in the Stats edge implementation. As such high cardinality tasks would collect stats on groups indefinitely. 

With this change the stats edge checks for delete messages and deletes its stats for the deleted group.