### PR TITLE
Add templating for MQTT topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#2154](https://github.com/influxdata/kapacitor/pull/2154): Add ability to skip ssl verification with an alert post node. Thanks @itsHabib!
+- [#2202](https://github.com/influxdata/kapacitor/pull/2202): Add templating for MQTT topics.
 
 ### Bugfixes
 

--- a/alert.go
+++ b/alert.go
@@ -453,7 +453,10 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 			QoS:        mqtt.QoSLevel(m.Qos),
 			Retained:   m.Retained,
 		}
-		h := et.tm.MQTTService.Handler(c, ctx...)
+		h, err := et.tm.MQTTService.Handler(c, ctx...)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create MQTT handler")
+		}
 		an.handlers = append(an.handlers, h)
 	}
 	// Parse level expressions

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -91,7 +91,7 @@ type Service struct {
 		Handler(kafka.HandlerConfig, ...keyvalue.T) (alert.Handler, error)
 	}
 	MQTTService interface {
-		Handler(mqtt.HandlerConfig, ...keyvalue.T) alert.Handler
+		Handler(mqtt.HandlerConfig, ...keyvalue.T) (alert.Handler, error)
 	}
 	OpsGenieService interface {
 		Handler(opsgenie.HandlerConfig, ...keyvalue.T) alert.Handler
@@ -825,7 +825,10 @@ func (s *Service) createHandlerFromSpec(spec HandlerSpec) (handler, error) {
 		if err != nil {
 			return handler{}, err
 		}
-		h = s.MQTTService.Handler(c, ctx...)
+		h, err = s.MQTTService.Handler(c, ctx...)
+		if err != nil {
+			return handler{}, err
+		}
 		h = newExternalHandler(h)
 	case "opsgenie":
 		c := opsgenie.HandlerConfig{}

--- a/task_master.go
+++ b/task_master.go
@@ -119,7 +119,7 @@ type TaskMaster struct {
 		Handler(smtp.HandlerConfig, ...keyvalue.T) alert.Handler
 	}
 	MQTTService interface {
-		Handler(mqtt.HandlerConfig, ...keyvalue.T) alert.Handler
+		Handler(mqtt.HandlerConfig, ...keyvalue.T) (alert.Handler, error)
 	}
 
 	OpsGenieService interface {


### PR DESCRIPTION
This adds the ability to use templates when specifying the MQTT
topic. This is much more useful than static topics since you
can create topics like this:

switches/{{ index .Tags "agent_host" }}/ports/{{ index .Tags "port_num" }}

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
