### PR TITLE
avoid allocation when building group ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2144](https://github.com/influxdata/kapacitor/issues/2144): Fix deadlock in barrier node when delete is used.
 - [#2186](https://github.com/influxdata/kapacitor/pull/2186): Make RPM create files with correct ownership on install.
 - [#2189](https://github.com/influxdata/kapacitor/pull/2189): Delete group stats when a group is deleted
+- [#2207](https://github.com/influxdata/kapacitor/pull/2207): Avoid extra allocation when building GroupID
 
 ## v1.5.2 [2018-12-12]
 

--- a/models/point.go
+++ b/models/point.go
@@ -1,8 +1,8 @@
 package models
 
 import (
-	"bytes"
 	"sort"
+	"strings"
 )
 
 type GroupID string
@@ -86,7 +86,7 @@ func ToGroupID(name string, tags map[string]string, dims Dimensions) GroupID {
 		}
 		return NilGroup
 	}
-	var buf bytes.Buffer
+	var buf strings.Builder
 	if dims.ByName {
 		buf.WriteString(name)
 		// Add delimiter that is not allowed in name.
@@ -101,5 +101,5 @@ func ToGroupID(name string, tags map[string]string, dims Dimensions) GroupID {
 		buf.WriteString(tags[d])
 
 	}
-	return GroupID(buf.Bytes())
+	return GroupID(buf.String())
 }


### PR DESCRIPTION
This change avoids the allocation to build the GroupID, as this is a hot code path this optimization can greatly reduce total allocation thus reducing pressure on garbage collection.