### PR TITLE
udf.agent python 2.7 and 3 compatibility

### DIFF
--- a/udf/agent/py/kapacitor/udf/agent.py
+++ b/udf/agent/py/kapacitor/udf/agent.py
@@ -1,12 +1,17 @@
 # Kapacitor UDF Agent implementation in Python
 #
 # Requires protobuf v3
-#   pip install protobuf==3.0.0b2
+#   pip install protobuf==3.0.0
 
 import sys
-import udf_pb2
+from . import udf_pb2
 from threading import Lock, Thread
-from Queue import Queue
+
+try:
+    from queue import Queue
+except ImportError:
+    from Queue import Queue
+
 import io
 import traceback
 import socket

--- a/udf/agent/py/kapacitor/udf/agent.py
+++ b/udf/agent/py/kapacitor/udf/agent.py
@@ -2,6 +2,7 @@
 #
 # Requires protobuf v3
 #   pip install protobuf==3.0.0
+from __future__ import absolute_import
 
 import sys
 from . import udf_pb2
@@ -70,6 +71,9 @@ class Agent(object):
                 self._out = out.buffer
             else:
                 self._out = out
+        else:
+            self._in = _in
+            self._out = out
 
         self._thread = None
         self.handler = handler

--- a/udf/agent/py/kapacitor/udf/agent.py
+++ b/udf/agent/py/kapacitor/udf/agent.py
@@ -21,6 +21,7 @@ import io
 import traceback
 import socket
 import os
+import struct
 
 import logging
 logger = logging.getLogger()
@@ -176,10 +177,10 @@ def encodeUvarint(writer, value):
     bits = value & varintMask
     value >>= shiftSize
     while value:
-        writer.write(chr(varintMoreMask|bits).encode())
+        writer.write(struct.pack("B", varintMoreMask | bits))
         bits = value & varintMask
         value >>= shiftSize
-    return writer.write(chr(bits).encode())
+    return writer.write(struct.pack("B", bits))
 
 # Decode an unsigned varint, max of 32 bits
 def decodeUvarint32(reader):
@@ -189,7 +190,7 @@ def decodeUvarint32(reader):
         byte = reader.read(1)
         if len(byte) == 0:
             raise EOF
-        b = ord(byte)
+        b = struct.unpack("B", byte)[0]
         result |= ((b & varintMask) << shift)
         if not (b & varintMoreMask):
             result &= mask32uint


### PR DESCRIPTION
This PR is based upon multiple existing PRs. It includes the changes from #1355 and #1750 and also the changed imports from #1799 to keep python 2.7 compatibility (which will [retire soon](https://pythonclock.org/), anyways). Additionally #1750 missed one of the branches in the `if`, also breaking python 2 compatibility.

The size varint prefixing protobuffer messages used to be converted to/from int using `ord` and `char`, which is not their intended purpose and leads to encoding problems under python 3 if the value is bigger than 127. The recommended way to do this in a portable way is using `struct.pack` and `unpack`.

Tested under python 2.7 and 3.6. Fixes #1868. Closes #1355, closes #1750, closes #1799.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)