### PR TITLE
Allow filling alert details template with HTML fields/tags

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -126,6 +126,9 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 
 			return html.JS(tmpBuffer.String())
 		},
+		"safeHtml": func(v interface{}) html.HTML {
+			return html.HTML(v.(string))
+		},
 	}).Parse(n.Details)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Alerts' details (email body) can currently be enhanced by using HTML tags, however embedding there Field or Tag value (ex. _{{ index .Fields "someField" }}_ ) automatically triggers html escaping on said value (as per [example here](https://golang.org/pkg/html/template/#hdr-Introduction))
While this is a sensible default behavior, it unnecessarily limits Users flexibility when creating HTML-rich email notifications, and from a User's perspective seems counter-intuitive - some email body elements can have HTML and some cannot.

Proposed solution introduces a new function to template function map for encapsulation of given string in a type html/template/HTML [as suggested here](https://golang.org/pkg/html/template/#hdr-Typed_Strings).

Added tests are based on TestStream_AlertEmail.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
