### PR TITLE
Update RPM specific packaging to match RPM naming convention

### DIFF
--- a/build.py
+++ b/build.py
@@ -772,9 +772,10 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                                 outfile = new_outfile
                             else:
                                 if package_type == 'rpm':
-                                    # rpm's convert any dashes to underscores
-                                    package_version = package_version.replace("-", "_")
-                                new_outfile = outfile.replace("{}-{}".format(package_version, package_iteration), package_version)
+                                    # rpm naming convention requires us to include the package_iteration value
+                                    new_outfile = outfile
+                                else:
+                                    new_outfile = outfile.replace("{}-{}".format(package_version, package_iteration), package_version)
                                 os.rename(outfile, new_outfile)
                                 outfile = new_outfile
                             outfiles.append(os.path.join(os.getcwd(), outfile))


### PR DESCRIPTION
fix: Update RPM specific packaging to match RPM naming convention

RPM naming convention says that:
 1. We should use dashes not underscores in the package filename
 2. We should include a package version (iteration) in the package name

This change removes the code which swapped underscores for dashes in the RPM specific code. 
It also moves the code which removes the package_iteration in to an else block and adds an rpm specific work around to not do that.  This was done so that non-rpm builds are not affected by this change.

Fixes: #95

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


