### PR TITLE
Pre-commit hook `go vet` correction

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -7,7 +7,7 @@ if [ $fmtcount -gt 0 ]; then
 fi
 
 # Due to the way composites work, vet will fail for some of our tests so we ignore it
-vetcount=`go tool vet --composites=false $(go list ./... | grep -v '/vendor/' | sed 's~github.com/influxdata/kapacitor~.~' | grep -v '^\.$') 2>&1  | wc -l`
+vetcount=`go vet --composites=false $(go list ./... | grep -v '/vendor/' | sed 's~github.com/influxdata/kapacitor~.~' | grep -v '^\.$') 2>&1  | wc -l`
 if [ $vetcount -gt 0 ]; then
     echo "Some files aren't passing vet heuristics, please run 'go vet ./...' to see the errors it flags and correct your source code before committing"
     exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 ### Bugfixes
-
+- [#2286](https://github.com/influxdata/kapacitor/pull/2286): Corrected issue with `go vet` invocation in .hooks/pre-commit which would cause the hook to fail.
 ## v1.5.4 [2020-01-16]
 
 ### Features


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Go has deprecated invoking the `vet` tool through the `go tool` command, which flags an error in the pre-commit hook. This is a slight correction to use the `go vet` invocation instead.
