### PR TITLE
Update build.py to support arm64

### DIFF
--- a/build.py
+++ b/build.py
@@ -388,6 +388,8 @@ def get_system_arch():
         arch = "amd64"
     elif arch == "386":
         arch = "i386"
+    elif arch == "aarch64":
+        arch = "arm64"
     elif 'arm' in arch:
         # Prevent uname from reporting full ARM arch (eg 'armv7l')
         arch = "arm"
@@ -532,20 +534,22 @@ def build(version=None,
             build_command += "CGO_ENABLED=0 "
 
         # Handle variations in architecture output
+        fullarch = arch
         if arch == "i386" or arch == "i686":
             arch = "386"
+        elif arch == "aarch64" or arch == "arm64":
+            arch = "arm64"
         elif "arm" in arch:
             arch = "arm"
         build_command += "GOOS={} GOARCH={} ".format(platform, arch)
 
-        if "arm" in arch:
-            if arch == "armel":
+        if "arm" in fullarch:
+            if fullarch == "armel":
                 build_command += "GOARM=5 "
-            elif arch == "armhf" or arch == "arm":
+            elif fullarch == "armhf" or fullarch == "arm":
                 build_command += "GOARM=6 "
-            elif arch == "arm64":
-                # TODO(rossmcdonald) - Verify this is the correct setting for arm64
-                build_command += "GOARM=7 "
+            elif fullarch == "arm64":
+                # GOARM not used - see https://github.com/golang/go/wiki/GoArm
             else:
                 logging.error("Invalid ARM architecture specified: {}".format(arch))
                 logging.error("Please specify either 'armel', 'armhf', or 'arm64'.")

--- a/build.py
+++ b/build.py
@@ -550,6 +550,7 @@ def build(version=None,
                 build_command += "GOARM=6 "
             elif fullarch == "arm64":
                 # GOARM not used - see https://github.com/golang/go/wiki/GoArm
+                pass
             else:
                 logging.error("Invalid ARM architecture specified: {}".format(arch))
                 logging.error("Please specify either 'armel', 'armhf', or 'arm64'.")


### PR DESCRIPTION
Currently arm64 aka aarch64 results in armhf binaries. Not ARM64 binaries. 
Modern arm chips (like those in TV boxes) does not support armhf instruction set.  exec format error.

The first change will detect aarch64 and set arch to arm64, which is supported.

Cleaned up code  around line 540 to store arch in fullarch for later use in if statement below that sets GOARM. Line 543 would overwrite the value tested in the if statement in 546 and down.
According to this: https://github.com/golang/go/wiki/GoArm GOARM should not be used for arm64

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


