### PR TITLE
Support custom details in pagerduty2 service

### DIFF
--- a/services/pagerduty2/service.go
+++ b/services/pagerduty2/service.go
@@ -204,7 +204,7 @@ func (s *Service) Test(options interface{}) error {
 		o.Links,
 		o.AlertID,
 		o.Description,
-		o.Description,
+		"",
 		o.Level,
 		o.Timestamp,
 		o.Data,

--- a/services/pagerduty2/service.go
+++ b/services/pagerduty2/service.go
@@ -323,10 +323,10 @@ func (s *Service) preparePost(routingKey string, links []LinkTemplate, alertID, 
 
 	ap.Payload.CustomDetails = make(map[string]interface{})
 	if details != "" {
-	  ap.Payload.CustomDetails["result"] = details
-        } else {
-	  ap.Payload.CustomDetails["result"] = data.Result
-        }
+		ap.Payload.CustomDetails["result"] = details
+	} else {
+		ap.Payload.CustomDetails["result"] = data.Result
+	}
 
 	ap.Payload.Class = data.TaskName
 	ap.Payload.Severity = severity


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Resolves https://github.com/influxdata/kapacitor/issues/743 by using details from the tick script when using pagerduty2.