### PR TITLE
RFC: Feature. Allow for overriding OpsGenieV2's alert recovery action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 ### Features
+- [#2301](https://github.com/influxdata/kapacitor/pull/2301): Allow for overriding OpsGenieV2's alert recovery action in tickSCRIPT
 
 ### Bugfixes
 

--- a/alert.go
+++ b/alert.go
@@ -431,6 +431,7 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 		c := opsgenie2.HandlerConfig{
 			TeamsList:      og.TeamsList,
 			RecipientsList: og.RecipientsList,
+			RecoveryAction: og.RecoveryActionString,
 		}
 		h := et.tm.OpsGenie2Service.Handler(c, ctx...)
 		an.handlers = append(an.handlers, h)

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1761,6 +1761,10 @@ type OpsGenie2Handler struct {
 	// OpsGenie2 Recipients.
 	// tick:ignore
 	RecipientsList []string `tick:"Recipients" json:"recipients"`
+
+	// OpsGenie2 recovery_action
+	// tick:ignore
+	RecoveryActionString string `tick:"RecoveryAction" json:"recoveryAction"`
 }
 
 // The list of teams to be alerted. If empty defaults to the teams from the configuration.
@@ -1774,6 +1778,13 @@ func (og *OpsGenie2Handler) Teams(teams ...string) *OpsGenie2Handler {
 // tick:property
 func (og *OpsGenie2Handler) Recipients(recipients ...string) *OpsGenie2Handler {
 	og.RecipientsList = recipients
+	return og
+}
+
+// The action to perform when the alarm recovers. If empty defaults to the recovery_action from the configuration.
+// tick:property
+func (og *OpsGenie2Handler) RecoveryAction(recoveryAction string) *OpsGenie2Handler {
+	og.RecoveryActionString = recoveryAction
 	return og
 }
 

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1764,7 +1764,7 @@ type OpsGenie2Handler struct {
 
 	// OpsGenie2 recovery_action
 	// tick:ignore
-	RecoveryActionString string `tick:"RecoveryAction" json:"recoveryAction"`
+	RecoveryActionString string `tick:"RecoveryAction" json:"recovery_action"`
 }
 
 // The list of teams to be alerted. If empty defaults to the teams from the configuration.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8815,11 +8815,12 @@ func TestServer_ListServiceTests(t *testing.T) {
 				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/service-tests/opsgenie2"},
 				Name: "opsgenie2",
 				Options: client.ServiceTestOptions{
-					"teams":        nil,
-					"recipients":   nil,
-					"message-type": "CRITICAL",
-					"message":      "test opsgenie message",
-					"entity-id":    "testEntityID",
+					"teams":           nil,
+					"recipients":      nil,
+					"message-type":    "CRITICAL",
+					"message":         "test opsgenie message",
+					"entity-id":       "testEntityID",
+					"recovery_action": "notes",
 				},
 			},
 			{

--- a/services/opsgenie2/config.go
+++ b/services/opsgenie2/config.go
@@ -30,7 +30,8 @@ type Config struct {
 
 func NewConfig() Config {
 	return Config{
-		URL: DefaultOpsGenieAPIURL,
+		URL:            DefaultOpsGenieAPIURL,
+		RecoveryAction: DefaultOpsGenieRecoveryAction,
 	}
 }
 

--- a/services/opsgenie2/config.go
+++ b/services/opsgenie2/config.go
@@ -30,8 +30,7 @@ type Config struct {
 
 func NewConfig() Config {
 	return Config{
-		URL:            DefaultOpsGenieAPIURL,
-		RecoveryAction: DefaultOpsGenieRecoveryAction,
+		URL: DefaultOpsGenieAPIURL,
 	}
 }
 

--- a/services/opsgenie2/service.go
+++ b/services/opsgenie2/service.go
@@ -67,21 +67,23 @@ func (s *Service) Global() bool {
 }
 
 type testOptions struct {
-	Teams       []string `json:"teams"`
-	Recipients  []string `json:"recipients"`
-	MessageType string   `json:"message-type"`
-	Message     string   `json:"message"`
-	EntityID    string   `json:"entity-id"`
+	Teams          []string `json:"teams"`
+	Recipients     []string `json:"recipients"`
+	RecoveryAction string   `json:"recovery-action"`
+	MessageType    string   `json:"message-type"`
+	Message        string   `json:"message"`
+	EntityID       string   `json:"entity-id"`
 }
 
 func (s *Service) TestOptions() interface{} {
 	c := s.config()
 	return &testOptions{
-		Teams:       c.Teams,
-		Recipients:  c.Recipients,
-		MessageType: "CRITICAL",
-		Message:     "test opsgenie message",
-		EntityID:    "testEntityID",
+		Teams:          c.Teams,
+		Recipients:     c.Recipients,
+		RecoveryAction: c.RecoveryAction,
+		MessageType:    "CRITICAL",
+		Message:        "test opsgenie message",
+		EntityID:       "testEntityID",
 	}
 }
 
@@ -103,6 +105,7 @@ func (s *Service) Test(options interface{}) error {
 	return s.Alert(
 		o.Teams,
 		o.Recipients,
+		o.RecoveryAction,
 		level,
 		o.Message,
 		o.EntityID,
@@ -111,8 +114,8 @@ func (s *Service) Test(options interface{}) error {
 	)
 }
 
-func (s *Service) Alert(teams []string, recipients []string, level alert.Level, message, entityID string, t time.Time, details models.Result) error {
-	req, err := s.preparePost(teams, recipients, level, message, entityID, t, details)
+func (s *Service) Alert(teams []string, recipients []string, recoveryAction string, level alert.Level, message, entityID string, t time.Time, details models.Result) error {
+	req, err := s.preparePost(teams, recipients, recoveryAction, level, message, entityID, t, details)
 	if err != nil {
 		return errors.Wrap(err, "failed to prepare API request")
 	}
@@ -139,7 +142,7 @@ func (s *Service) Alert(teams []string, recipients []string, level alert.Level, 
 	return nil
 }
 
-func (s *Service) preparePost(teams []string, recipients []string, level alert.Level, message, entityID string, t time.Time, details models.Result) (*http.Request, error) {
+func (s *Service) preparePost(teams []string, recipients []string, recoveryAction string, level alert.Level, message, entityID string, t time.Time, details models.Result) (*http.Request, error) {
 	c := s.config()
 	if !c.Enabled {
 		return nil, errors.New("service is not enabled")
@@ -155,7 +158,18 @@ func (s *Service) preparePost(teams []string, recipients []string, level alert.L
 		if err != nil {
 			return nil, err
 		}
-		recoveryURL.Path = path.Join(recoveryURL.Path, alias, c.RecoveryAction)
+		validRecoveryActions := map[string]bool{
+			"close": true,
+			"notes": true,
+		}
+		if !validRecoveryActions[recoveryAction] { // use parameter
+			if !validRecoveryActions[c.RecoveryAction] { //use global config
+				recoveryAction = DefaultOpsGenieRecoveryAction //use default
+			} else {
+				recoveryAction = c.RecoveryAction
+			}
+		}
+		recoveryURL.Path = path.Join(recoveryURL.Path, alias, recoveryAction)
 		recoveryURL.RawQuery = "identifierType=alias"
 		u = recoveryURL.String()
 		ogData["note"] = message
@@ -251,6 +265,9 @@ type HandlerConfig struct {
 
 	// OpsGenie Recipients.
 	RecipientsList []string `mapstructure:"recipients-list"`
+
+	// OpsGenie RecoveryAction
+	RecoveryAction string `mapstructure:"recovery-action"`
 }
 
 type handler struct {
@@ -271,6 +288,7 @@ func (h *handler) Handle(event alert.Event) {
 	if err := h.s.Alert(
 		h.c.TeamsList,
 		h.c.RecipientsList,
+		h.c.RecoveryAction,
 		event.State.Level,
 		event.State.Message,
 		event.State.ID,

--- a/services/opsgenie2/service.go
+++ b/services/opsgenie2/service.go
@@ -69,7 +69,7 @@ func (s *Service) Global() bool {
 type testOptions struct {
 	Teams          []string `json:"teams"`
 	Recipients     []string `json:"recipients"`
-	RecoveryAction string   `json:"recovery-action"`
+	RecoveryAction string   `json:"recovery_action"`
 	MessageType    string   `json:"message-type"`
 	Message        string   `json:"message"`
 	EntityID       string   `json:"entity-id"`
@@ -267,7 +267,7 @@ type HandlerConfig struct {
 	RecipientsList []string `mapstructure:"recipients-list"`
 
 	// OpsGenie RecoveryAction
-	RecoveryAction string `mapstructure:"recovery-action"`
+	RecoveryAction string `mapstructure:"recovery_action"`
 }
 
 type handler struct {


### PR DESCRIPTION
Allows the addition of the _.RecoveryAction(...)_ method to the chain of the opsGenie2 service. Historically the recovery action was either _close_|_notes_ set in the global config which didn't allow uses cases where specific scripts wanted to deviate from the default behavior.

RFC: I'm not sure I fully grokked the model and pattern for config in kapacitor so would be good to make get some input on this.

TBC: Update documentation

###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [x] Tests pass
- [X] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


