### PR TITLE
depreciate: depreciate ssl 3.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - [#2286](https://github.com/influxdata/kapacitor/pull/2286): Corrected issue with `go vet` invocation in .hooks/pre-commit which would cause the hook to fail.
 
+### Depreciated
+- [#2331](https://github.com/influxdata/kapacitor/pull/2331): Depreciate ssl 3.0 as it is insecure and is removed from newer versions of go.
+
 ## v1.5.5 [2020-04-20]
 
 ### bugfixes

--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 )
@@ -99,6 +100,11 @@ func (c Config) Parse() (out *tls.Config, err error) {
 		out.MaxVersion = version
 	}
 
+	if out != nil && (out.MinVersion == tls.VersionSSL30 || out.MaxVersion == tls.VersionSSL30) {
+		_, _ = fmt.Fprintln(os.Stderr, "WARNING: SSL 3.0 is depreciated and support for it will be removed soon")
+		return out, nil
+	}
+
 	return out, nil
 }
 
@@ -144,7 +150,7 @@ func unknownCipher(name string) error {
 }
 
 var versionsMap = map[string]uint16{
-	"SSL3.0": tls.VersionSSL30,
+	"SSL3.0": tls.VersionSSL30, // DEPRECIATED!!
 	"TLS1.0": tls.VersionTLS10,
 	"1.0":    tls.VersionTLS10,
 	"TLS1.1": tls.VersionTLS11,


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

I didn't use a formal logger because I didn't want to re-architect the objects for a change that will be short lived (we intend to remove ssl 3.0 support in the next version).

We have to do this, if we want to be able to continue upgrading to newer versions of go.

Closes https://github.com/influxdata/kapacitor/issues/2321