### PR TITLE
Add variadic options to udf

### DIFF
--- a/pipeline/udf.go
+++ b/pipeline/udf.go
@@ -125,8 +125,10 @@ func (u *UDFNode) Property(name string) interface{} {
 func (u *UDFNode) SetProperty(name string, args ...interface{}) (interface{}, error) {
 	opt, ok := u.options[name]
 	if ok {
-		if got, exp := len(args), len(opt.ValueTypes); got != exp {
-			return nil, fmt.Errorf("unexpected number of args to %s, got %d expected %d", name, got, exp)
+		if !opt.IsVariadic {
+			if got, exp := len(args), len(opt.ValueTypes); got != exp {
+				return nil, fmt.Errorf("unexpected number of args to %s, got %d expected %d", name, got, exp)
+			}
 		}
 		values := make([]*agent.OptionValue, len(args))
 		for i, arg := range args {
@@ -148,7 +150,7 @@ func (u *UDFNode) SetProperty(name string, args ...interface{}) (interface{}, er
 				values[i].Type = agent.ValueType_DURATION
 				values[i].Value = &agent.OptionValue_DurationValue{DurationValue: int64(v)}
 			}
-			if values[i].Type != opt.ValueTypes[i] {
+			if !opt.IsVariadic && values[i].Type != opt.ValueTypes[i] {
 				return nil, fmt.Errorf("unexpected arg to %s, got %v expected %v", name, values[i].Type, opt.ValueTypes[i])
 			}
 		}

--- a/udf/agent/udf.pb.go
+++ b/udf/agent/udf.pb.go
@@ -126,6 +126,7 @@ func (m *InfoResponse) GetOptions() map[string]*OptionInfo {
 
 type OptionInfo struct {
 	ValueTypes []ValueType `protobuf:"varint,1,rep,name=valueTypes,enum=agent.ValueType" json:"valueTypes,omitempty"`
+	IsVariadic bool        `protobuf:"varint,2,opt,name=isVariadic" json:"isVariadic,omitempty"`
 }
 
 func (m *OptionInfo) Reset()                    { *m = OptionInfo{} }

--- a/udf/agent/udf.proto
+++ b/udf/agent/udf.proto
@@ -63,6 +63,7 @@ enum ValueType {
 
 message OptionInfo {
     repeated ValueType valueTypes = 1;
+    bool isVariadic               = 2;
 }
 
 // Request that the process initialize itself with the provided options.


### PR DESCRIPTION
- [+] Rebased/mergable
- [+] Tests pass
- [-] CHANGELOG.md updated
- [-] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated

Want to use lists in UDF method calls. As lists contain unknown amount of items and are passed not as a single list argument, but as X arguments, where X is list's length, it is currently impossible to add UDF method which works with lists of undefined length. To allow this, I've edited ``agent.OptionInfo`` struct to have a ``IsVariadic`` bool value. If it is set to true, one can pass any amount of values of any type into UDF method.