### PR TITLE
fix: .Details should be avaliable inside AlertTemplates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2351](https://github.com/influxdata/kapacitor/pull/2351): Upgraded github.com/gorhill/cronexpr, thanks @wuguanyu!
 ### Bugfixes
 - [#2201](https://github.com/influxdata/kapacitor/pull/2201): Added missing err check of a buf scanner, thanks @johncming!
+- [#2395](http://github.com/influxdata/kapacitor/pull/2395): Added missing .Details to AlertTemplate.
 
 ## v1.5.6 [2020-07-17]
 

--- a/alert/types.go
+++ b/alert/types.go
@@ -42,6 +42,7 @@ func (e Event) TemplateData() TemplateData {
 		Level:    e.State.Level.String(),
 		Time:     e.State.Time,
 		Duration: e.State.Duration,
+		Details:  e.State.Details,
 		Name:     e.Data.Name,
 		TaskName: e.Data.TaskName,
 		Group:    e.Data.Group,
@@ -105,6 +106,9 @@ type TemplateData struct {
 
 	// Duration of the event
 	Duration time.Duration
+
+	// Details
+	Details string
 
 	// Measurement name
 	Name string

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -10561,6 +10561,7 @@ stream
 		.info(lambda: "count" > 6.0)
 		.warn(lambda: "count" > 7.0)
 		.crit(lambda: "count" > 8.0)
+		.details('{{ "here" }}/{{ .Name }}')
 		.snmpTrap('1.1.1')
 			.data('1.1.1.2', 'c', '1')
 			.data('1.1.1.2', 's', 'SNMP ALERT')
@@ -10569,6 +10570,7 @@ stream
 			.data('1.1.2.3', 'i', '10')
 			.data('1.1.2.3', 'n', '')
 			.data('1.1.2.3', 't', '20000')
+			.data('1.1.2.3', 's', '{{ .Details }}')
 `
 
 	expTraps := []interface{}{
@@ -10634,6 +10636,11 @@ stream
 						Oid:   "1.1.2.3",
 						Value: "20000",
 						Type:  "TimeTicks",
+					},
+					{
+						Oid:   "1.1.2.3",
+						Value: "here/cpu",
+						Type:  "OctetString",
 					},
 				},
 			},


### PR DESCRIPTION
This adds .Details to AlertTemplates, where it should have been.