### PR TITLE
use kapacitor alert details as opsgenie description text

### DIFF
--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -294,6 +294,9 @@ default-retention-policy = ""
     #     * close -- close the alert
     #
     recovery_action = "notes"
+    # If true then all alerts will use their event details
+    # as OpsGenie alert description.
+    details = false
     # If true then all alerts will be sent to OpsGenie
     # without explicitly marking them in the TICKscript.
     # The team and recipients can still be overridden.
@@ -331,7 +334,7 @@ default-retention-policy = ""
 
 [pagerduty2]
   # Configure PagerDuty API v2.
-  enabled = false 
+  enabled = false
   # Your PagerDuty Routing Key.
   routing-key = ""
   # The PagerDuty API v2 URL should not need to be changed.

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -9418,6 +9418,7 @@ stream
 	tmInit := func(tm *kapacitor.TaskMaster) {
 		c := opsgenie2.NewConfig()
 		c.Enabled = true
+		c.Details = false
 		c.URL = ts.URL
 		c.APIKey = "api_key"
 		og := opsgenie2.NewService(c, diagService.NewOpsGenie2Handler())
@@ -9505,6 +9506,7 @@ stream
 	tmInit := func(tm *kapacitor.TaskMaster) {
 		c := opsgenie2.NewConfig()
 		c.Enabled = true
+		c.Details = false
 		c.URL = ts.URL
 		c.RecoveryAction = "notes"
 		c.APIKey = "api_key"

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1821,6 +1821,7 @@ func (og *OpsGenieHandler) Recipients(recipients ...string) *OpsGenieHandler {
 //      enabled = true
 //      api-key = "xxxxx"
 //      recipients = ["johndoe"]
+//      details = false
 //      global = true
 //
 // Example:
@@ -1852,6 +1853,10 @@ type OpsGenie2Handler struct {
 	// OpsGenie2 recovery_action
 	// tick:ignore
 	RecoveryActionString string `tick:"RecoveryAction" json:"recovery_action"`
+
+	// OpsGenie2 details
+	// tick:ignore
+	IsDetails bool `tick:"Details" json:"details"`
 }
 
 // The list of teams to be alerted. If empty defaults to the teams from the configuration.
@@ -1872,6 +1877,13 @@ func (og *OpsGenie2Handler) Recipients(recipients ...string) *OpsGenie2Handler {
 // tick:property
 func (og *OpsGenie2Handler) RecoveryAction(recoveryAction string) *OpsGenie2Handler {
 	og.RecoveryActionString = recoveryAction
+	return og
+}
+
+// The action to perform when the alarm recovers. If empty defaults to the recovery_action from the configuration.
+// tick:property
+func (og *OpsGenie2Handler) Details() *OpsGenie2Handler {
+	og.IsDetails = true
 	return og
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7360,6 +7360,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 						"api-key":         false,
 						"enabled":         false,
 						"global":          false,
+						"details":         false,
 						"recipients":      nil,
 						"teams":           nil,
 						"url":             "http://opsgenie2.example.com",
@@ -7376,6 +7377,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 					"api-key":         false,
 					"enabled":         false,
 					"global":          false,
+					"details":         false,
 					"recipients":      nil,
 					"teams":           nil,
 					"url":             "http://opsgenie2.example.com",
@@ -7402,6 +7404,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 								"api-key":         true,
 								"enabled":         false,
 								"global":          true,
+								"details":         false,
 								"recipients":      nil,
 								"teams":           []interface{}{"teamA", "teamB"},
 								"url":             "http://opsgenie2.example.com",
@@ -7418,6 +7421,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 							"api-key":         true,
 							"enabled":         false,
 							"global":          true,
+							"details":         false,
 							"recipients":      nil,
 							"teams":           []interface{}{"teamA", "teamB"},
 							"url":             "http://opsgenie2.example.com",
@@ -10044,6 +10048,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 				ctxt := context.WithValue(nil, "server", ts)
 
 				c.OpsGenie2.Enabled = true
+				c.OpsGenie2.Details = false
 				c.OpsGenie2.URL = ts.URL
 				c.OpsGenie2.RecoveryAction = "notes"
 				c.OpsGenie2.APIKey = "api_key"

--- a/services/opsgenie2/config.go
+++ b/services/opsgenie2/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	RecoveryAction string `toml:"recovery_action" override:"recovery_action"`
 	// Whether every alert should automatically go to OpsGenie.
 	Global bool `toml:"global" override:"global"`
+	// Whether to use event details as OpsGenie alert description.
+	Details bool `toml:"details" override:"details"`
 }
 
 func NewConfig() Config {

--- a/services/opsgenie2/service.go
+++ b/services/opsgenie2/service.go
@@ -110,12 +110,13 @@ func (s *Service) Test(options interface{}) error {
 		o.Message,
 		o.EntityID,
 		time.Now(),
+		"",
 		models.Result{},
 	)
 }
 
-func (s *Service) Alert(teams []string, recipients []string, recoveryAction string, level alert.Level, message, entityID string, t time.Time, details models.Result) error {
-	req, err := s.preparePost(teams, recipients, recoveryAction, level, message, entityID, t, details)
+func (s *Service) Alert(teams []string, recipients []string, recoveryAction string, level alert.Level, message, entityID string, t time.Time, eventDetails string, details models.Result) error {
+	req, err := s.preparePost(teams, recipients, recoveryAction, level, message, entityID, t, eventDetails, details)
 	if err != nil {
 		return errors.Wrap(err, "failed to prepare API request")
 	}
@@ -142,7 +143,7 @@ func (s *Service) Alert(teams []string, recipients []string, recoveryAction stri
 	return nil
 }
 
-func (s *Service) preparePost(teams []string, recipients []string, recoveryAction string, level alert.Level, message, entityID string, t time.Time, details models.Result) (*http.Request, error) {
+func (s *Service) preparePost(teams []string, recipients []string, recoveryAction string, level alert.Level, message, entityID string, t time.Time, eventDetails string, details models.Result) (*http.Request, error) {
 	c := s.config()
 	if !c.Enabled {
 		return nil, errors.New("service is not enabled")
@@ -190,12 +191,17 @@ func (s *Service) preparePost(teams []string, recipients []string, recoveryActio
 		ogData["note"] = ""
 		ogData["priority"] = priority
 
-		// Encode details as description
-		b, err := json.Marshal(details)
-		if err != nil {
-			return nil, err
+		// Use event details as description if available
+		if len(eventDetails) > 0 {
+			ogData["description"] = eventDetails
+		} else {
+			// Otherwise encode details as description
+			b, err := json.Marshal(details)
+			if err != nil {
+				return nil, err
+			}
+			ogData["description"] = string(b)
 		}
-		ogData["description"] = string(b)
 
 		//Extra Fields (can be used for filtering)
 		ogDetails := make(map[string]string)
@@ -293,6 +299,7 @@ func (h *handler) Handle(event alert.Event) {
 		event.State.Message,
 		event.State.ID,
 		event.State.Time,
+		event.State.Details,
 		event.Data.Result,
 	); err != nil {
 		h.diag.Error("failed to send event to OpsGenie", err)

--- a/services/opsgenie2/service.go
+++ b/services/opsgenie2/service.go
@@ -192,7 +192,7 @@ func (s *Service) preparePost(teams []string, recipients []string, recoveryActio
 		ogData["priority"] = priority
 
 		// Use event details as description if available
-		if len(eventDetails) > 0 {
+		if c.Details && len(eventDetails) > 0 {
 			ogData["description"] = eventDetails
 		} else {
 			// Otherwise encode details as description


### PR DESCRIPTION
This is a _breaking_ change in the OpsGenie plugin behaviour of Kapacitor. The modification will use alert/event state details as description when opening OpsGenie alerts instead. This allows much more descriptive alerts in OpsGenie. Alert details in OpsGenie are still filled with the same key/values as before.

The current behaviour of simply encoding the event details as description is imho not very useful as a value for an OpsGenie alert description, Kapacitor alert details can provide much more information and are more in line with OpsGenie alert descriptions.

Would such a change make sense, or is it too breaking in current behaviour?

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)