### PR TITLE
Fix 404 link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ kapacitord config
 # Getting Started
 
 This README gives you a high level overview of what Kapacitor is and what its like to use it. As well as some details of how it works.
-To get started using Kapacitor see [this guide](https://docs.influxdata.com/kapacitor/latest/introduction/getting_started/). After you finish the getting started exercise you can check out the [TICKscripts](https://github.com/influxdata/kapacitor/tree/master/examples/telegraf) for different Telegraf plugins.
+To get started using Kapacitor see [this guide](https://docs.influxdata.com/kapacitor/latest/introduction/getting-started/). After you finish the getting started exercise you can check out the [TICKscripts](https://github.com/influxdata/kapacitor/tree/master/examples/telegraf) for different Telegraf plugins.
 
 # Basic Example
 
@@ -78,5 +78,3 @@ kapacitor define \
 # Start the task
 kapacitor enable cpu_alert
 ```
-
-For more complete examples see the [documentation](https://docs.influxdata.com/kapacitor/latest/examples/).


### PR DESCRIPTION
- Getting started has moved to `https://docs.influxdata.com/kapacitor/latest/introduction/getting-started/`
- More examples have already been removed from the [documentation](https://docs.influxdata.com/kapacitor/latest/examples/).

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
