### PR TITLE
fix(servicenow): use recommended event API

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -521,13 +521,14 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 
 	for _, s := range n.ServiceNowHandlers {
 		c := servicenow.HandlerConfig{
-			URL:        s.URL,
-			Source:     s.Source,
-			Node:       s.Node,
-			Type:       s.Type,
-			Resource:   s.Resource,
-			MetricName: s.MetricName,
-			MessageKey: s.MessageKey,
+			URL:            s.URL,
+			Source:         s.Source,
+			Node:           s.Node,
+			Type:           s.Type,
+			Resource:       s.Resource,
+			MetricName:     s.MetricName,
+			MessageKey:     s.MessageKey,
+			AdditionalInfo: s.AdditionalInfoMap,
 		}
 		h := et.tm.ServiceNowService.Handler(c, ctx...)
 		an.handlers = append(an.handlers, h)

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -512,8 +512,8 @@ default-retention-policy = ""
 [servicenow]
   # Configure ServiceNow.
   enabled = false
-  # The ServiceNow URL for target table. Replace instance with actual hostname.
-  url = "https://instance.service-now.com/api/now/v1/table/em_alert"
+  # The ServiceNow events web service URL. Replace instance with actual hostname.
+  url = "https://instance.service-now.com/api/global/em/jsonv2"
   # Default source identification.
   source = "Kapacitor"
   # Username for HTTP BASIC authentication

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -10296,7 +10296,7 @@ stream
 
 		c := servicenow.NewConfig()
 		c.Enabled = true
-		c.URL = ts.URL
+		c.URL = ts.URL + "/api/global/em/jsonv2"
 		c.Source = "Kapacitor"
 		sl := servicenow.NewService(c, diagService.NewServiceNowHandler())
 		tm.ServiceNowService = sl
@@ -10306,25 +10306,33 @@ stream
 
 	exp := []interface{}{
 		servicenowtest.Request{
-			URL: "/",
-			Alert: servicenow.Alert{
-				Source:      "Kapacitor",
-				Node:        "serverA",
-				Type:        "CPU",       // literal since there is no tag for this in the testdata
-				Resource:    "CPU-Total", // literal since there is no tag for this in the testdata
-				MetricName:  "idle",
-				MessageKey:  "Alert: kapacitor/cpu/serverA",
-				Severity:    "1",
-				Description: "kapacitor/cpu/serverA is CRITICAL",
+			URL: "/api/global/em/jsonv2",
+			Alerts: servicenow.Events{
+				Records: []servicenow.Event{
+					{
+						Source:      "Kapacitor",
+						Node:        "serverA",
+						Type:        "CPU",       // literal since there is no tag for this in the testdata
+						Resource:    "CPU-Total", // literal since there is no tag for this in the testdata
+						MetricName:  "idle",
+						MessageKey:  "Alert: kapacitor/cpu/serverA",
+						Severity:    "1",
+						Description: "kapacitor/cpu/serverA is CRITICAL",
+					},
+				},
 			},
 		},
 		servicenowtest.Request{
-			URL: "/",
-			Alert: servicenow.Alert{
-				Source:      "Kapacitor",
-				MessageKey:  "kapacitor/cpu/serverA",
-				Severity:    "1",
-				Description: "kapacitor/cpu/serverA is CRITICAL",
+			URL: "/api/global/em/jsonv2",
+			Alerts: servicenow.Events{
+				Records: []servicenow.Event{
+					{
+						Source:      "Kapacitor",
+						MessageKey:  "kapacitor/cpu/serverA",
+						Severity:    "1",
+						Description: "kapacitor/cpu/serverA is CRITICAL",
+					},
+				},
 			},
 		},
 	}

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -10291,6 +10291,8 @@ stream
 			.resource('CPU-Total')
 			.metricName('{{ index .Tags "type" }}')
 			.messageKey('Alert: {{ .ID }}')
+			.additionalInfo('link', 'http://push/alert?id={{ .ID }}')
+			.additionalInfo('ticks', 666)
 `
 	tmInit := func(tm *kapacitor.TaskMaster) {
 
@@ -10310,14 +10312,15 @@ stream
 			Alerts: servicenow.Events{
 				Records: []servicenow.Event{
 					{
-						Source:      "Kapacitor",
-						Node:        "serverA",
-						Type:        "CPU",       // literal since there is no tag for this in the testdata
-						Resource:    "CPU-Total", // literal since there is no tag for this in the testdata
-						MetricName:  "idle",
-						MessageKey:  "Alert: kapacitor/cpu/serverA",
-						Severity:    "1",
-						Description: "kapacitor/cpu/serverA is CRITICAL",
+						Source:         "Kapacitor",
+						Node:           "serverA",
+						Type:           "CPU",       // literal since there is no tag for this in the testdata
+						Resource:       "CPU-Total", // literal since there is no tag for this in the testdata
+						MetricName:     "idle",
+						MessageKey:     "Alert: kapacitor/cpu/serverA",
+						Severity:       "1",
+						Description:    "kapacitor/cpu/serverA is CRITICAL",
+						AdditionalInfo: "{\"link\":\"http://push/alert?id=kapacitor/cpu/serverA\",\"ticks\":\"666\"}",
 					},
 				},
 			},

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -2130,7 +2130,7 @@ type TeamsHandler struct {
 // Example:
 //    [serviceNow]
 //      enabled = true
-//      url = "https://instance.service-now.com/api/now/v1/table/em_alert"
+//      url = "https://instance.service-now.com/api/global/em/jsonv2"
 //
 // In order to not post a message every alert interval
 // use AlertNode.StateChangesOnly so that only events
@@ -2148,7 +2148,7 @@ type TeamsHandler struct {
 // Example:
 //    [serviceNow]
 //      enabled = true
-//      url = "https://instance.service-now.com/api/now/v1/table/em_alert"
+//      url = "https://instance.service-now.com/api/global/em/jsonv2"
 //      global = true
 //      state-changes-only = true
 //

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -2199,5 +2199,19 @@ type ServiceNowHandler struct {
 	MetricName string `json:"metric_name"`
 
 	// Message key.
-	MessageKey string `json:"messageKey"`
+	MessageKey string `json:"message_key"`
+
+	// Addition info.
+	// tick:ignore
+	AdditionalInfoMap map[string]interface{} `tick:"AdditionalInfo" json:"additional_info"`
+}
+
+// AdditionalInfo adds key values pairs to the request.
+// tick:property
+func (s *ServiceNowHandler) AdditionalInfo(key string, value interface{}) *ServiceNowHandler {
+	if s.AdditionalInfoMap == nil {
+		s.AdditionalInfoMap = make(map[string]interface{})
+	}
+	s.AdditionalInfoMap[key] = value
+	return s
 }

--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -165,6 +165,16 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 			Dot("resource", h.Resource).
 			Dot("metricName", h.MetricName).
 			Dot("messageKey", h.MessageKey)
+
+		// Use stable key order
+		keys := make([]string, 0, len(h.AdditionalInfoMap))
+		for k := range h.AdditionalInfoMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.Dot("additionalInfo", k, h.AdditionalInfoMap[k])
+		}
 	}
 
 	for _, h := range a.SlackHandlers {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7737,7 +7737,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 		{
 			section: "servicenow",
 			setDefaults: func(c *server.Config) {
-				c.ServiceNow.URL = "https://instance.service-now.com/api/now/v1/table/em_alert"
+				c.ServiceNow.URL = "https://instance.service-now.com/api/global/em/jsonv2"
 				c.ServiceNow.Source = "Kapacitor"
 				c.ServiceNow.Username = ""
 				c.ServiceNow.Password = ""
@@ -7750,7 +7750,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 						"enabled":            false,
 						"global":             false,
 						"state-changes-only": false,
-						"url":                "https://instance.service-now.com/api/now/v1/table/em_alert",
+						"url":                "https://instance.service-now.com/api/global/em/jsonv2",
 						"source":             "Kapacitor",
 						"username":           "",
 						"password":           false,
@@ -7766,7 +7766,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 					"enabled":            false,
 					"global":             false,
 					"state-changes-only": false,
-					"url":                "https://instance.service-now.com/api/now/v1/table/em_alert",
+					"url":                "https://instance.service-now.com/api/global/em/jsonv2",
 					"source":             "Kapacitor",
 					"username":           "",
 					"password":           false,
@@ -7780,7 +7780,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 					updateAction: client.ConfigUpdateAction{
 						Set: map[string]interface{}{
 							"enabled":  true,
-							"url":      "https://dev12345.service-now.com/api/now/v1/table/em_alert",
+							"url":      "https://dev12345.service-now.com/api/global/em/jsonv2",
 							"username": "dev",
 							"password": "12345",
 						},
@@ -7793,7 +7793,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 								"enabled":            true,
 								"global":             false,
 								"state-changes-only": false,
-								"url":                "https://dev12345.service-now.com/api/now/v1/table/em_alert",
+								"url":                "https://dev12345.service-now.com/api/global/em/jsonv2",
 								"source":             "Kapacitor",
 								"username":           "dev",
 								"password":           true,
@@ -7809,7 +7809,7 @@ func TestServer_UpdateConfig(t *testing.T) {
 							"enabled":            true,
 							"global":             false,
 							"state-changes-only": false,
-							"url":                "https://dev12345.service-now.com/api/now/v1/table/em_alert",
+							"url":                "https://dev12345.service-now.com/api/global/em/jsonv2",
 							"source":             "Kapacitor",
 							"username":           "dev",
 							"password":           true,
@@ -10449,7 +10449,7 @@ func TestServer_AlertHandlers(t *testing.T) {
 				ctxt := context.WithValue(context.Background(), "server", ts)
 
 				c.ServiceNow.Enabled = true
-				c.ServiceNow.URL = ts.URL
+				c.ServiceNow.URL = ts.URL + "/api/global/em/jsonv2"
 				c.ServiceNow.Source = "Kapacitor"
 				return ctxt, nil
 			},
@@ -10457,12 +10457,16 @@ func TestServer_AlertHandlers(t *testing.T) {
 				ts := ctxt.Value("server").(*servicenowtest.Server)
 				ts.Close()
 				exp := []servicenowtest.Request{{
-					URL: "/",
-					Alert: servicenow.Alert{
-						Source:      "Kapacitor",
-						Severity:    "1",
-						Description: "message",
-						MessageKey:  "id",
+					URL: "/api/global/em/jsonv2",
+					Alerts: servicenow.Events{
+						Records: []servicenow.Event{
+							{
+								Source:      "Kapacitor",
+								Severity:    "1",
+								Description: "message",
+								MessageKey:  "id",
+							},
+						},
 					},
 				}}
 				got := ts.Requests()

--- a/services/servicenow/config.go
+++ b/services/servicenow/config.go
@@ -9,7 +9,7 @@ import (
 type Config struct {
 	// Whether ServiceNow integration is enabled.
 	Enabled bool `toml:"enabled" override:"enabled"`
-	// ServiceNow alerts API URL.
+	// ServiceNow events API URL.
 	URL string `toml:"url" override:"url"`
 	// Event source.
 	Source string `toml:"source" override:"source"`
@@ -25,12 +25,14 @@ type Config struct {
 }
 
 func NewConfig() Config {
-	return Config{}
+	return Config{
+		URL: "https://instance.service-now.com/api/global/em/jsonv2", // dummy default
+	}
 }
 
 func (c Config) Validate() error {
 	if c.Enabled && c.URL == "" {
-		return errors.New("must specify Alerts URL")
+		return errors.New("must specify events URL")
 	}
 	if _, err := url.Parse(c.URL); err != nil {
 		return errors.Wrapf(err, "invalid url %q", c.URL)

--- a/services/servicenow/servicenowtest/servicenowtest.go
+++ b/services/servicenow/servicenowtest/servicenowtest.go
@@ -24,11 +24,10 @@ func NewServer() *Server {
 			URL: r.URL.String(),
 		}
 		dec := json.NewDecoder(r.Body)
-		dec.Decode(&pr.Alert)
+		dec.Decode(&pr.Alerts)
 		s.mu.Lock()
 		s.requests = append(s.requests, pr)
 		s.mu.Unlock()
-		w.WriteHeader(http.StatusCreated)
 	}))
 	s.ts = ts
 	s.URL = ts.URL
@@ -50,6 +49,6 @@ func (s *Server) Close() {
 }
 
 type Request struct {
-	URL   string
-	Alert servicenow.Alert
+	URL    string
+	Alerts servicenow.Events
 }


### PR DESCRIPTION
Closes #2428 
Implements [#202](https://github.com/influxdata/feature-requests/issues/202)

* changes _ServiceNow_ event handler to use _ServiceNow_ Event API instead of Table API.

Default value of ServiceNow URL has changed:
```
[servicenow]
  # Configure ServiceNow.
  enabled = false
  # The ServiceNow events web service URL. Replace instance with actual hostname.
  url = "https://instance.service-now.com/api/global/em/jsonv2"
  ...
```

* adds support for `additional_info` elements in Event structure as requsted in FR [#202](https://github.com/influxdata/feature-requests/issues/202):

1. new handler property is introduced

| handler option | event field |
| --- |  --- |
| `additionalInfo` | entry in `additional_info` map |
  
2. `additional_info` is  a key-value pairs map and allows user to specify multiple entries. String values can be templates.
TICKscript example:
```
stream
  |from()
    .measurement('cpu')
  |alert()
    .crit(lambda: "usage_user" > 90)
    .message('Hey, check your CPU')
    .serviceNow()
        .additionalInfo('link', 'http://push/alert?id={{ .ID }}')
        .additionalInfo('ticks', 666)
```



###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._

Manually tested against dev SN account:

![image](https://user-images.githubusercontent.com/42931850/98843493-57da3f00-244b-11eb-8bcf-150a65681113.png)

Additional Info in the event detail:

![image](https://user-images.githubusercontent.com/42931850/98951284-587dde80-24fa-11eb-9732-45752a00527e.png)

