### PR TITLE
feat: add fields to BigPanda alert

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -493,7 +493,9 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 
 	for _, s := range n.BigPandaHandlers {
 		c := bigpanda.HandlerConfig{
-			AppKey: s.AppKey,
+			AppKey:            s.AppKey,
+			PrimaryProperty:   s.PrimaryProperty,
+			SecondaryProperty: s.SecondaryProperty,
 		}
 		h, err := et.tm.BigPandaService.Handler(c, ctx...)
 		if err != nil {

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1637,6 +1637,7 @@ type DiscordHandler struct {
 //      enabled = true
 //      app-key = "my-app-key"
 //      token = "your-api-key"
+//      url = "BigPanda alert webhook url"
 //
 // In order to not post a message every alert interval
 // use AlertNode.StateChangesOnly so that only events
@@ -1654,11 +1655,13 @@ type DiscordHandler struct {
 //      |alert()
 //          .bigPanda()
 //          .appKey('my-application')
+//          .primaryProperty('property1')
+//          .secondaryProperty('property2')
 //
-// send alerts with custom appKey
+// send alerts with custom appKey, primary and secondary property
 //
 // If the 'bigpanda' section in the configuration has the option: global = true
-// then all alerts are sent to BigpPanda without the need to explicitly state it
+// then all alerts are sent to BigPanda without the need to explicitly state it
 // in the TICKscript.
 //
 // Example:
@@ -1690,6 +1693,12 @@ type BigPandaHandler struct {
 	// Application id
 	// If empty uses the default config
 	AppKey string `json:"app-key"`
+
+	// Custom primary BigPanda property
+	PrimaryProperty string `json:"primary-property"`
+
+	// Custom secondary BigPanda property
+	SecondaryProperty string `json:"secondary-property"`
 }
 
 // Send the alert to Telegram.

--- a/services/bigpanda/config.go
+++ b/services/bigpanda/config.go
@@ -26,16 +26,17 @@ type Config struct {
 	// Only applies if global is also set.
 	StateChangesOnly bool `toml:"state-changes-only" override:"state-changes-only"`
 
-	// Whether to skip the tls verification of the alerta host
+	// Whether to skip the tls verification
 	InsecureSkipVerify bool `toml:"insecure-skip-verify" override:"insecure-skip-verify"`
 
-	// BigPanda Alert webhook URL,
-	// https://api.bigpanda.io/data/v2/alerts
+	//BigPanda Alert api URL, if not specified https://api.bigpanda.io/data/v2/alerts is used
 	URL string `toml:"url" override:"url"`
 }
 
 func NewConfig() Config {
-	return Config{}
+	return Config{
+		URL: defaultBigPandaAlertApi,
+	}
 }
 
 func (c Config) Validate() error {

--- a/services/bigpanda/config.go
+++ b/services/bigpanda/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	// Whether BigPanda integration is enabled.
 	Enabled bool `toml:"enabled" override:"enabled"`
 
-	// Whether all alerts should automatically post to Teams.
+	// Whether all alerts should automatically post to BigPanda.
 	Global bool `toml:"global" override:"global"`
 
 	//Each integration must have an App Key in BigPanda to identify it as a unique source.
@@ -29,17 +29,20 @@ type Config struct {
 	// Whether to skip the tls verification of the alerta host
 	InsecureSkipVerify bool `toml:"insecure-skip-verify" override:"insecure-skip-verify"`
 
-	//Optional alert api URL, if not specified https://api.bigpanda.io/data/v2/alerts is used
+	// BigPanda Alert webhook URL,
+	// https://api.bigpanda.io/data/v2/alerts
 	URL string `toml:"url" override:"url"`
 }
 
 func NewConfig() Config {
-	return Config{
-		URL: defaultBigPandaAlertApi,
-	}
+	return Config{}
 }
 
 func (c Config) Validate() error {
+	if c.Enabled && c.URL == "" {
+		return errors.New("must specify the BigPanda webhook URL")
+	}
+
 	if c.Enabled && c.AppKey == "" {
 		return errors.New("must specify BigPanda app-key")
 	}

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -232,16 +232,12 @@ func (s *Service) preparePost(id string, message string, details string, level a
 		bpData["app_key"] = c.AppKey
 	}
 
-	if len(data.Tags) > 0 {
-		for k, v := range data.Tags {
-			bpData[k] = v
-		}
+	for k, v := range data.Tags {
+		bpData[k] = v
 	}
 
-	if len(data.Fields) > 0 {
-		for k, v := range data.Fields {
-			bpData[k] = fmt.Sprintf("%v", v)
-		}
+	for k, v := range data.Fields {
+		bpData[k] = fmt.Sprintf("%v", v)
 	}
 
 	var post bytes.Buffer
@@ -250,12 +246,11 @@ func (s *Service) preparePost(id string, message string, details string, level a
 		return nil, err
 	}
 
-	var bpUrl string
-	if hc.URL != "" {
-		bpUrl = hc.URL
-	} else {
+	bpUrl := hc.URL
+	if bpUrl == "" {
 		bpUrl = c.URL
 	}
+
 	alertUrl, err := url.Parse(bpUrl)
 	if err != nil {
 		return nil, err

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -226,6 +226,12 @@ func (s *Service) preparePost(appKey, id string, message string, details string,
 		}
 	}
 
+	if len(data.Fields) > 0 {
+		for k, v := range data.Fields {
+			bpData[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
 	var post bytes.Buffer
 	enc := json.NewEncoder(&post)
 	if err := enc.Encode(bpData); err != nil {


### PR DESCRIPTION
This PR improves BigPanda alerting:
-  by default BP Alert contains all field values and tags
-  BigPanda primary and secondary property is configurable in tick script or in topic handler

```tick
alert
  .bigPanda()
  .appKey('fc39458f98e91eb0310258c3b725d643')
  .primaryProperty('device')
  .secondaryProperty('sensor_name')
  .topic('bigpanda-topic')
```
or in topic hadler
```yaml
id: bigpanda-cpu-alert
topic: bigpanda-topic
kind: bigpanda
options:
  app-key: '8f5795cada387b9f310f41fc369c88e4'
  primary-property: 'host'
  secondary-property: 'check'
  url: 'http://localhost:8080/data/v2/alerts'
```


###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
