### PR TITLE
chore: remove 386 darwin support and add arm64 darwin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       build:
             docker:
                   - image: nathanielc/docker-client
-            parallelism: 2
+            parallelism: 3
             working_directory: ~/kapacitor
             steps:
                   - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [#2441](https://github.com/influxdata/kapacitor/pull/2441): Preallocate GroupIDs for increased performance by reducing allocations.
 - [#2456](https://github.com/influxdata/kapacitor/pull/2456): Gzip data by default that is sent to influxdb.
 - [#2454](https://github.com/influxdata/kapacitor/pull/2454): Add PrimaryProperty and SecondaryProperty methods to BigPanda AlertNode.
-- [#2461](https://github.com/influxdata/kapacitor/pull/2461): BREAKING: we are forced to remove support for 386 builds as go doesn't support them anymore.
+- [#2462](https://github.com/influxdata/kapacitor/pull/2462): BREAKING: we are forced to remove support for 386/darwin builds as go doesn't support them anymore.  We also added arm64/darwin builds.
 
 ## v1.5.7 [2020-10-27]
 

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -1,0 +1,58 @@
+FROM 32bit/ubuntu:16.04
+
+# This dockerfile capabable  of the the minumum required
+# to run the tests and nothing else.
+
+MAINTAINER support@influxdb.com
+
+RUN apt-get -qq update && apt-get -qq install -y \
+    wget \
+    unzip \
+    git \
+    mercurial \
+    build-essential \
+    autoconf \
+    automake \
+    libtool \
+    python \
+    python-setuptools \
+    python3 \
+    python3-setuptools \
+    zip \
+    curl
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+# Install protobuf3 protoc binary
+
+# Install protobuf3 protoc binary
+ENV PROTO_VERSION 3.11.1
+RUN wget -q https://github.com/google/protobuf/releases/download/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_32.zip\
+    && unzip -j protoc-${PROTO_VERSION}-linux-x86_32.zip bin/protoc -d /bin \
+    rm protoc-${PROTO_VERSION}-linux-x86_64.zip
+
+# Install protobuf3 python library
+RUN wget -q https://github.com/google/protobuf/releases/download/v${PROTO_VERSION}/protobuf-python-${PROTO_VERSION}.tar.gz \
+    && tar -xf protobuf-python-${PROTO_VERSION}.tar.gz \
+    && cd /protobuf-${PROTO_VERSION}/python \
+    && python2 setup.py install \
+    && python3 setup.py install \
+    && rm -rf /protobuf-${PROTO_VERSION} protobuf-python-${PROTO_VERSION}.tar.gz
+
+# Install go
+ENV GOPATH /root/go
+ENV GO_VERSION 1.15.5
+ENV GO_ARCH 386
+RUN wget -q https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
+   tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \
+   rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV PROJECT_DIR $GOPATH/src/github.com/influxdata/kapacitor
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p $PROJECT_DIR
+WORKDIR $PROJECT_DIR
+
+VOLUME $PROJECT_DIR
+
+ENTRYPOINT [ "/root/go/src/github.com/influxdata/kapacitor/build.py" ]

--- a/build.py
+++ b/build.py
@@ -92,9 +92,9 @@ targets = {
 }
 
 supported_builds = {
-    'darwin': [ "amd64" ],
-    'linux': [ "amd64", "armhf", "arm64", "armel", "static_amd64" ],
-    'windows': [ "amd64" ]
+    'darwin': [ "amd64", "arm64" ],
+    'linux': [ "amd64", "i386", "armhf", "arm64", "armel", "static_i386", "static_amd64" ],
+    'windows': [ "amd64", "i386" ]
 }
 
 supported_packages = {
@@ -382,6 +382,8 @@ def get_system_arch():
     arch = os.uname()[4]
     if arch == "x86_64":
         arch = "amd64"
+    elif arch == "386":
+        arch = "i386"
     elif arch == "aarch64":
         arch = "arm64"
     elif 'arm' in arch:
@@ -529,7 +531,9 @@ def build(version=None,
 
         # Handle variations in architecture output
         fullarch = arch
-        if arch == "aarch64" or arch == "arm64":
+        if arch == "i386" or arch == "i686":
+            arch = "386"
+        elif arch == "aarch64" or arch == "arm64":
             arch = "arm64"
         elif "arm" in arch:
             arch = "arm"
@@ -909,7 +913,7 @@ if __name__ == '__main__':
                         type=str,
                         help='Name to use for package name (when package is specified)')
     parser.add_argument('--arch',
-                        metavar='<amd64|armhf|arm64|armel|all>',
+                        metavar='<amd64|i386|armhf|arm64|armel|all>',
                         type=str,
                         default=get_system_arch(),
                         help='Target architecture for build output')

--- a/test.sh
+++ b/test.sh
@@ -43,7 +43,7 @@ then
 fi
 
 # Update this value if you add a new test environment.
-ENV_COUNT=2
+ENV_COUNT=3
 
 # Default return code 0
 rc=0
@@ -116,6 +116,11 @@ case $ENVIRONMENT_INDEX in
         # 64 bit race tests
         GORACE="halt_on_error=1"
         run_test_docker Dockerfile_build_ubuntu64 test_64bit_race --test --generate $no_uncommitted_arg --race
+        rc=$?
+        ;;
+    2)
+        # 32 bit tests
+        run_test_docker Dockerfile_build_ubuntu32 test_32bit --test --generate $no_uncommitted_arg --arch=i386
         rc=$?
         ;;
     "count")


### PR DESCRIPTION
Go no longer supports darwin 386 support, so we must remove 386 darwin support.
We also added darwin arm64 support.
