### PR TITLE
fix: add barrier handling to flatten

### DIFF
--- a/edge/consumer.go
+++ b/edge/consumer.go
@@ -54,8 +54,7 @@ func (ec *consumer) Consume() error {
 				return err
 			}
 		case BufferedBatchMessage:
-			err := receiveBufferedBatch(ec.r, m)
-			if err != nil {
+			if err := receiveBufferedBatch(ec.r, m); err != nil {
 				return err
 			}
 		case PointMessage:

--- a/group_by.go
+++ b/group_by.go
@@ -77,7 +77,9 @@ func (n *GroupByNode) BeginBatch(begin edge.BeginBatchMessage) error {
 	n.timer.Start()
 	defer n.timer.Stop()
 
-	n.emit(begin.Time())
+	if err := n.emit(begin.Time()); err != nil {
+		return err
+	}
 
 	n.begin = begin
 	n.dimensions = begin.Dimensions()

--- a/integrations/helpers_test.go
+++ b/integrations/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/kapacitor"
 	"github.com/influxdata/kapacitor/alert"
 	"github.com/influxdata/kapacitor/influxdb"
@@ -112,8 +113,8 @@ func compareResultsIgnoreSeriesOrder(exp, got models.Result) (bool, string) {
 		if !reflect.DeepEqual(exp.Series[i].Columns, got.Series[j].Columns) {
 			return false, fmt.Sprintf("unexpected series columns: i: %d \nexp %v \ngot %v", i, exp.Series[i].Columns, got.Series[j].Columns)
 		}
-		if !reflect.DeepEqual(exp.Series[i].Values, got.Series[j].Values) {
-			return false, fmt.Sprintf("unexpected series values: i: %d \nexp %v \ngot %v", i, exp.Series[i].Values, got.Series[j].Values)
+		if !cmp.Equal(exp.Series[i].Values, got.Series[j].Values) {
+			return false, fmt.Sprintf("unexpected series values: i: %d \n %s", i, cmp.Diff(exp.Series[i].Values, got.Series[j].Values))
 		}
 	}
 	return true, ""


### PR DESCRIPTION
This adds barrier handling to flatten, so that barriers actually cause flatten to emit its points.

Unfortunately, because of the timing stuff here, its quite hard to test this in an automated way.  I've tested it manually, and will think about how to test these in a more automated way with the PR for join's barrier handling.