### PR TITLE
feat: Zenoss event handler

### DIFF
--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -353,6 +353,26 @@ default-retention-policy = ""
   # The URL for the Pushover API.
   url = "https://api.pushover.net/1/messages.json"
 
+[zenoss]
+  # Configure Zenoss.
+  enabled = false
+  # The Zenoss events endpoint URL.
+  url = "https://tenant.zenoss.io:8080/zport/dmd/evconsole_router"
+  # Username for HTTP BASIC authentication
+  # username = ""
+  # Password for HTTP BASIC authentication
+  # password = ""
+  # Action (router name).
+  action = "EventsRouter"
+  # Router method.
+  method = "add_event"
+  # Event type.
+  type = "rpc"
+  # Temporary request transaction ID.
+  tid = 1
+  # Alert level to event severity mapping.
+  severity-map = { OK = "Clear", Info = "Info", Warning = "Warning", Critical = "Critical" }
+
 ##########################################
 # Configure Alert POST request Endpoints
 

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -404,6 +404,10 @@ type AlertNodeData struct {
 	// Send alert to ServiceNow.
 	// tick:ignore
 	ServiceNowHandlers []*ServiceNowHandler `tick:"ServiceNow" json:"serviceNow"`
+
+	// Send alert to Zenoss.
+	// tick:ignore
+	ZenossHandlers []*ZenossHandler `tick:"Zenoss" json:"zenoss"`
 }
 
 func newAlertNode(wants EdgeType) *AlertNode {
@@ -2311,5 +2315,122 @@ func (s *ServiceNowHandler) AdditionalInfo(key string, value interface{}) *Servi
 		s.AdditionalInfoMap = make(map[string]interface{})
 	}
 	s.AdditionalInfoMap[key] = value
+	return s
+}
+
+// Send the alert to Zenoss.
+//
+// Example:
+//    [zenoss]
+//      enabled = true
+//      url = "https://tenant.zenoss.io:8080/zport/dmd/evconsole_router"
+//
+// In order to not post a message every alert interval
+// use AlertNode.StateChangesOnly so that only events
+// where the alert changed state are posted.
+//
+// Example:
+//    stream
+//         |alert()
+//             .zenoss()
+//                 .summary('Alert {{ .ID }}')
+//                 .message('{{ .Message }}')
+//                 .eventClass('/App')
+//
+// If the 'zenoss' section in the configuration has the option: global = true
+// then all alerts are sent to Zenoss without the need to explicitly state it
+// in the TICKscript.
+//
+// Example:
+//    [zenoss]
+//      enabled = true
+//      url = "https://tenant.zenoss.io:8080/zport/dmd/evconsole_router"
+//      global = true
+//      state-changes-only = true
+//
+// Example:
+//    stream
+//         |alert()
+//             .zenoss()
+//                 .summary('Alert {{ .ID }}')
+//                 .message('{{ .Message }}')
+//                 .eventClass('/App')
+//
+// Send alert to Zenoss using default url.
+// tick:property
+func (n *AlertNodeData) Zenoss() *ZenossHandler {
+	zenoss := &ZenossHandler{
+		AlertNodeData: n,
+		Summary:       "{{ .Message }}", // default mapping
+	}
+	n.ZenossHandlers = append(n.ZenossHandlers, zenoss)
+	return zenoss
+}
+
+// tick:embedded:AlertNode.Zenoss
+type ZenossHandler struct {
+	*AlertNodeData `json:"-"`
+
+	// Zenoss API URL to post alerts.
+	// If empty uses the URL from the configuration.
+	URL string `json:"url"`
+
+	// Username for BASIC authentication.
+	// If empty uses username from the configuration.
+	Username string `json:"username"`
+
+	// Password for BASIC authentication.
+	// If empty uses password from the configuration.
+	Password string `json:"password"`
+
+	// Action (router name).
+	// If empty uses value from the configuration.
+	Action string `json:"action"`
+
+	// Router method.
+	// If empty uses value from the configuration.
+	Method string `json:"method"`
+
+	// Event type.
+	// If empty uses value from the configuration.
+	Type string `json:"type"`
+
+	// Temporary transaction ID.
+	// If empty uses value from the configuration.
+	TID int64 `json:"tid"`
+
+	// Summary of the event.
+	Summary string `json:"summary"`
+
+	// Device (typically IP or hostname).
+	Device string `json:"device"`
+
+	// Component related to the event.
+	Component string `json:"component"`
+
+	// Event class key.
+	EventClassKey string `json:"evclasskey"`
+
+	// Event class.
+	EventClass string `json:"evclass"`
+
+	// Message related to the event.
+	Message string `json:"message"`
+
+	// Collector.
+	Collector string `json:"collector"`
+
+	// Custom fields.
+	// tick:ignore
+	CustomFieldsMap map[string]interface{} `tick:"CustomField" json:"customField"`
+}
+
+// CustomField adds a field to event data.
+// tick:property
+func (s *ZenossHandler) CustomField(key string, value interface{}) *ZenossHandler {
+	if s.CustomFieldsMap == nil {
+		s.CustomFieldsMap = make(map[string]interface{})
+	}
+	s.CustomFieldsMap[key] = value
 	return s
 }

--- a/pipeline/alert_test.go
+++ b/pipeline/alert_test.go
@@ -84,7 +84,8 @@ func TestAlertNode_MarshalJSON(t *testing.T) {
     "snmpTrap": null,
     "kafka": null,
     "teams": null,
-    "serviceNow": null
+    "serviceNow": null,
+    "zenoss": null
 }`,
 		},
 	}

--- a/pipeline/json_test.go
+++ b/pipeline/json_test.go
@@ -263,7 +263,8 @@ func TestPipeline_MarshalJSON(t *testing.T) {
             "snmpTrap": null,
             "kafka": null,
             "teams": null,
-            "serviceNow": null
+            "serviceNow": null,
+            "zenoss": null
         },
         {
             "typeOf": "httpOut",

--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -249,5 +249,31 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 		}
 	}
 
+	for _, h := range a.ZenossHandlers {
+		n.Dot("zenoss").
+			Dot("action", h.Action).
+			Dot("method", h.Method).
+			Dot("type", h.Type).
+			Dot("TID", h.TID).
+			// standard event data element fields
+			Dot("summary", h.Summary).
+			Dot("device", h.Device).
+			Dot("component", h.Component).
+			Dot("eventClassKey", h.EventClassKey).
+			Dot("eventClass", h.EventClass).
+			Dot("collector", h.Collector).
+			Dot("message", h.Message)
+
+		// Use stable key order
+		keys := make([]string, 0, len(h.CustomFieldsMap))
+		for k := range h.CustomFieldsMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.Dot("customField", k, h.CustomFieldsMap[k])
+		}
+	}
+
 	return n.prev, n.err
 }

--- a/server/config.go
+++ b/server/config.go
@@ -61,6 +61,7 @@ import (
 	"github.com/influxdata/kapacitor/services/udf"
 	"github.com/influxdata/kapacitor/services/udp"
 	"github.com/influxdata/kapacitor/services/victorops"
+	"github.com/influxdata/kapacitor/services/zenoss"
 	"github.com/influxdata/kapacitor/tlsconfig"
 	"github.com/pkg/errors"
 
@@ -110,6 +111,7 @@ type Config struct {
 	Teams      teams.Config      `toml:"teams" override:"teams"`
 	Telegram   telegram.Config   `toml:"telegram" override:"telegram"`
 	VictorOps  victorops.Config  `toml:"victorops" override:"victorops"`
+	Zenoss     zenoss.Config     `toml:"zenoss" override:"zenoss"`
 
 	// Discovery for scraping
 	Scraper         []scraper.Config          `toml:"scraper" override:"scraper,element-key=name"`
@@ -183,6 +185,7 @@ func NewConfig() *Config {
 	c.SNMPTrap = snmptrap.NewConfig()
 	c.Telegram = telegram.NewConfig()
 	c.VictorOps = victorops.NewConfig()
+	c.Zenoss = zenoss.NewConfig()
 
 	c.Reporting = reporting.NewConfig()
 	c.Stats = stats.NewConfig()
@@ -343,6 +346,9 @@ func (c *Config) Validate() error {
 	}
 	if err := c.VictorOps.Validate(); err != nil {
 		return errors.Wrap(err, "victorops")
+	}
+	if err := c.Zenoss.Validate(); err != nil {
+		return errors.Wrap(err, "zenoss")
 	}
 
 	if err := c.UDF.Validate(); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -74,6 +74,7 @@ import (
 	"github.com/influxdata/kapacitor/services/udf"
 	"github.com/influxdata/kapacitor/services/udp"
 	"github.com/influxdata/kapacitor/services/victorops"
+	"github.com/influxdata/kapacitor/services/zenoss"
 	"github.com/influxdata/kapacitor/uuid"
 	"github.com/influxdata/kapacitor/waiter"
 	"github.com/pkg/errors"
@@ -274,6 +275,7 @@ func New(c *Config, buildInfo BuildInfo, diagService *diagnostic.Service) (*Serv
 	s.appendSensuService()
 	s.appendTalkService()
 	s.appendVictorOpsService()
+	s.appendZenossService()
 
 	// Append alert service
 	s.appendAlertService()
@@ -1033,6 +1035,18 @@ func (s *Server) appendServiceNowService() {
 
 	s.SetDynamicService("servicenow", srv)
 	s.AppendService("servicenow", srv)
+}
+
+func (s *Server) appendZenossService() {
+	c := s.config.Zenoss
+	d := s.DiagService.NewZenossHandler()
+	srv := zenoss.NewService(c, d)
+
+	s.TaskMaster.ZenossService = srv
+	s.AlertService.ZenossService = srv
+
+	s.SetDynamicService("zenoss", srv)
+	s.AppendService("zenoss", srv)
 }
 
 // Err returns an error channel that multiplexes all out of band errors received from all services.

--- a/services/diagnostic/handlers.go
+++ b/services/diagnostic/handlers.go
@@ -43,6 +43,7 @@ import (
 	"github.com/influxdata/kapacitor/services/telegram"
 	"github.com/influxdata/kapacitor/services/udp"
 	"github.com/influxdata/kapacitor/services/victorops"
+	"github.com/influxdata/kapacitor/services/zenoss"
 	"github.com/influxdata/kapacitor/udf"
 	"github.com/influxdata/kapacitor/uuid"
 	plog "github.com/prometheus/common/log"
@@ -1399,5 +1400,22 @@ func (h *ServiceNowHandler) WithContext(ctx ...keyvalue.T) servicenow.Diagnostic
 }
 
 func (h *ServiceNowHandler) Error(msg string, err error) {
+	h.l.Error(msg, Error(err))
+}
+
+// Zenoss handler
+type ZenossHandler struct {
+	l Logger
+}
+
+func (h *ZenossHandler) WithContext(ctx ...keyvalue.T) zenoss.Diagnostic {
+	fields := logFieldsFromContext(ctx)
+
+	return &ZenossHandler{
+		l: h.l.With(fields...),
+	}
+}
+
+func (h *ZenossHandler) Error(msg string, err error) {
 	h.l.Error(msg, Error(err))
 }

--- a/services/diagnostic/service.go
+++ b/services/diagnostic/service.go
@@ -490,3 +490,9 @@ func (s *Service) NewServiceNowHandler() *ServiceNowHandler {
 		l: s.Logger.With(String("service", "serviceNow")),
 	}
 }
+
+func (s *Service) NewZenossHandler() *ZenossHandler {
+	return &ZenossHandler{
+		l: s.Logger.With(String("service", "zenoss")),
+	}
+}

--- a/services/zenoss/config.go
+++ b/services/zenoss/config.go
@@ -1,0 +1,84 @@
+package zenoss
+
+import (
+	"net/url"
+
+	"github.com/influxdata/kapacitor/alert"
+	"github.com/pkg/errors"
+)
+
+type SeverityMap struct {
+	// OK level mapping to severity (number or string)
+	OK interface{} `toml:"OK" json:"ok"`
+	// Info level mapping to severity (number or string)
+	Info interface{} `toml:"Info" json:"info"`
+	// Warning level mapping to severity (number or string)
+	Warning interface{} `toml:"Warning" json:"warning"`
+	// Critical level mapping to severity (number or string)
+	Critical interface{} `toml:"Critical" json:"critical"`
+}
+
+func (s *SeverityMap) ValueFor(level alert.Level) interface{} {
+	var severity interface{}
+	switch level {
+	case alert.OK:
+		severity = s.OK
+	case alert.Info:
+		severity = s.Info
+	case alert.Warning:
+		severity = s.Warning
+	case alert.Critical:
+		severity = s.Critical
+	}
+	return severity
+}
+
+type Config struct {
+	// Whether Zenoss integration is enabled.
+	Enabled bool `toml:"enabled" override:"enabled"`
+	// Zenoss events API URL.
+	URL string `toml:"url" override:"url"`
+	// ServiceNow authentication username.
+	Username string `toml:"username" override:"username"`
+	// ServiceNow authentication password.
+	Password string `toml:"password" override:"password,redact"`
+	// Action (router name).
+	Action string `toml:"action" override:"action"`
+	// Router method.
+	Method string `toml:"method" override:"method"`
+	// Event type.
+	Type string `toml:"type" override:"type"`
+	// Event TID.
+	TID int64 `toml:"tid" override:"tid"`
+	// Level to severity map.
+	SeverityMap SeverityMap `toml:"severity-map" override:"severity-map"`
+	// Whether all alerts should automatically post to ServiceNow.
+	Global bool `toml:"global" override:"global"`
+	// Whether all alerts should automatically use stateChangesOnly mode.
+	// Only applies if global is also set.
+	StateChangesOnly bool `toml:"state-changes-only" override:"state-changes-only"`
+}
+
+func NewConfig() Config {
+	return Config{
+		URL:         "https://tenant.zenoss.io:8080/zport/dmd/evconsole_router",
+		Action:      "EventsRouter",
+		Method:      "add_event",
+		Type:        "rpc",
+		TID:         1,
+		SeverityMap: SeverityMap{OK: "Clear", Info: "Info", Warning: "Warning", Critical: "Critical"},
+	}
+}
+
+func (c Config) Validate() error {
+	if c.Enabled && c.URL == "" {
+		return errors.New("must specify events URL")
+	}
+	if _, err := url.Parse(c.URL); err != nil {
+		return errors.Wrapf(err, "invalid url %q", c.URL)
+	}
+	if c.SeverityMap.OK == nil || c.SeverityMap.Info == nil || c.SeverityMap.Warning == nil || c.SeverityMap.Critical == nil {
+		return errors.New("invalid severity mapping")
+	}
+	return nil
+}

--- a/services/zenoss/service.go
+++ b/services/zenoss/service.go
@@ -1,0 +1,450 @@
+package zenoss
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"net/http"
+	neturl "net/url"
+	"strings"
+	"sync/atomic"
+	text "text/template"
+	"time"
+
+	"github.com/influxdata/kapacitor/alert"
+	"github.com/influxdata/kapacitor/keyvalue"
+	"github.com/pkg/errors"
+)
+
+//const usualCutoff = 100
+
+type Diagnostic interface {
+	WithContext(ctx ...keyvalue.T) Diagnostic
+	Error(msg string, err error)
+}
+
+type Service struct {
+	configValue atomic.Value
+	diag        Diagnostic
+}
+
+func NewService(c Config, d Diagnostic) *Service {
+	s := &Service{
+		diag: d,
+	}
+	s.configValue.Store(c)
+
+	return s
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+
+func (s *Service) Close() error {
+	return nil
+}
+
+func (s *Service) config() Config {
+	return s.configValue.Load().(Config)
+}
+
+func (s *Service) Update(newConfig []interface{}) error {
+	if l := len(newConfig); l != 1 {
+		return fmt.Errorf("expected only one new config object, got %d", l)
+	}
+	if c, ok := newConfig[0].(Config); !ok {
+		return fmt.Errorf("expected config object to be of type %T, got %T", c, newConfig[0])
+	} else {
+		s.configValue.Store(c)
+	}
+
+	return nil
+}
+
+func (s *Service) Global() bool {
+	return s.config().Global
+}
+
+func (s *Service) StateChangesOnly() bool {
+	return s.config().StateChangesOnly
+}
+
+type testOptions struct {
+	Action string `json:"action"`
+	Method string `json:"method"`
+	Type   string `json:"type"`
+	TID    int64  `json:"tid"`
+}
+
+func (s *Service) TestOptions() interface{} {
+	return &testOptions{
+		Action: "EventsRouter",
+		Method: "add_event",
+		Type:   "rpc",
+		TID:    1,
+	}
+}
+
+func (s *Service) Test(options interface{}) error {
+	o, ok := options.(*testOptions)
+	if !ok {
+		return fmt.Errorf("unexpected options type %T", options)
+	}
+	c := s.config()
+	hc := &HandlerConfig{
+		Action: o.Action,
+		Method: o.Method,
+		Type:   o.Type,
+		TID:    o.TID,
+	}
+	data := &alert.EventData{
+		Fields: map[string]interface{}{},
+		Tags:   map[string]string{},
+	}
+	state := &alert.EventState{
+		ID:      "ID 001",
+		Level:   alert.OK,
+		Message: "test message",
+	}
+
+	return s.Alert(c.URL, state, data, hc)
+}
+
+func (s *Service) Alert(url string, state *alert.EventState, data *alert.EventData, hc *HandlerConfig) error {
+	postUrl, postBody, err := s.preparePost(url, state, data, hc)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", postUrl, postBody)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	c := s.config()
+	if c.Username != "" && c.Password != "" {
+		req.SetBasicAuth(c.Username, c.Password)
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		type response struct {
+			Error string `json:"error"`
+		}
+		r := &response{Error: fmt.Sprintf("failed to understand Zenoss response. code: %d content: %s", resp.StatusCode, string(body))}
+		b := bytes.NewReader(body)
+		dec := json.NewDecoder(b)
+		dec.Decode(r)
+
+		return errors.New(r.Error)
+	}
+
+	return nil
+}
+
+// EventData represents Zenoss event data. All fields should be present in JSON.
+type EventData struct {
+	Summary    string      `json:"summary"`
+	Device     string      `json:"device"`
+	Component  string      `json:"component"`
+	Severity   interface{} `json:"severity"`
+	EvClassKey string      `json:"evclasskey"`
+	EvClass    string      `json:"evclass"`
+	Collector  string      `json:"collector,omitempty"`
+	Message    string      `json:"message,omitempty"`
+}
+
+// Event is a structure representing Zenoss event.
+type Event struct {
+	Action string                   `json:"action"`
+	Method string                   `json:"method"`
+	Data   []map[string]interface{} `json:"data"`
+	Type   string                   `json:"type"`
+	TID    int64                    `json:"tid"`
+}
+
+func (s *Service) preparePost(url string, state *alert.EventState, data *alert.EventData, hc *HandlerConfig) (string, io.Reader, error) {
+	c := s.config()
+	if !c.Enabled {
+		return "", nil, errors.New("service is not enabled")
+	}
+
+	if url == "" {
+		url = c.URL
+	}
+	u, err := neturl.Parse(url)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// fallback to config values for handler options not set
+	action := hc.Action
+	if action == "" {
+		action = c.Action
+	}
+	method := hc.Method
+	if method == "" {
+		method = c.Method
+	}
+	typ := hc.Type
+	if typ == "" {
+		typ = c.Type
+	}
+	tid := hc.TID
+	if tid == 0 {
+		tid = c.TID
+	}
+
+	cutoff := func(text string, max int) string {
+		return text[:int(math.Min(float64(max), float64(len(text))))]
+	}
+
+	// resolve templates for event standard data fields
+	var buffer bytes.Buffer
+	info := struct {
+		Name        string
+		TaskName    string
+		ID          string
+		Message     string
+		Details     string
+		Time        time.Time
+		Duration    time.Duration
+		Level       alert.Level
+		Recoverable bool
+		Tags        map[string]string
+	}{
+		data.Name,
+		data.TaskName,
+		state.ID,
+		state.Message,
+		state.Details,
+		state.Time,
+		state.Duration,
+		state.Level,
+		data.Recoverable,
+		data.Tags,
+	}
+	render := func(name, template string) (string, error) {
+		if template != "" {
+			buffer.Reset()
+			templateImpl, err := text.New(name).Parse(template)
+			if err != nil {
+				return "", err
+			}
+			templateImpl.Execute(&buffer, &info)
+			if err != nil {
+				return "", err
+			}
+			return buffer.String(), nil
+		}
+		return "", nil
+	}
+	summary, err := render("summary", hc.Summary)
+	if err != nil {
+		return "", nil, err
+	}
+	device, err := render("device", hc.Device)
+	if err != nil {
+		return "", nil, err
+	}
+	component, err := render("component", hc.Component)
+	if err != nil {
+		return "", nil, err
+	}
+	evclasskey, err := render("evclasskey", hc.EventClassKey)
+	if err != nil {
+		return "", nil, err
+	}
+	evclass, err := render("evclass", hc.EventClass)
+	if err != nil {
+		return "", nil, err
+	}
+	message, err := render("message", hc.Message)
+	if err != nil {
+		return "", nil, err
+	}
+	collector, err := render("collector", hc.Collector)
+	if err != nil {
+		return "", nil, err
+	}
+	severity := c.SeverityMap.ValueFor(state.Level)
+
+	eventData := &EventData{
+		Summary:    cutoff(summary, 256),
+		Device:     device,
+		Component:  component,
+		Severity:   severity,
+		EvClassKey: evclasskey,
+		EvClass:    evclass,
+		Message:    cutoff(message, 4096),
+		Collector:  collector,
+	}
+	eventDataMap, err := s.toMap(eventData)
+	if err != nil {
+		return "", nil, err
+	}
+
+	event := &Event{
+		Action: action,
+		Method: method,
+		Data: []map[string]interface{}{
+			eventDataMap,
+		},
+		Type: typ,
+		TID:  tid,
+	}
+
+	if len(hc.CustomFields) > 0 {
+		customDataMap := make(map[string]interface{})
+		for key, value := range hc.CustomFields {
+			switch v := value.(type) {
+			case string:
+				// resolve templates
+				rv, err := render("customData."+key, v)
+				if err != nil {
+					return "", nil, err
+				}
+				customDataMap[key] = rv
+			default:
+				customDataMap[key] = v
+			}
+		}
+		s.addCustomData(eventDataMap, customDataMap)
+	}
+
+	postBytes, err := json.Marshal(event)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "error marshaling event struct")
+	}
+
+	return u.String(), bytes.NewBuffer(postBytes), nil
+}
+
+func (s *Service) addCustomData(basicData, customData map[string]interface{}) {
+	// add custom fields
+	for key, value := range customData {
+		var cValue interface{}
+		switch v := value.(type) {
+		case string:
+			if strings.HasPrefix(v, "{") || strings.HasPrefix(v, "[") { // can be JSON
+				err := json.Unmarshal([]byte(v), &cValue)
+				if err != nil { // guess not, it is just a text
+					cValue = v
+				}
+			} else {
+				cValue = v
+			}
+		default:
+			cValue = v
+		}
+		basicData[key] = cValue
+	}
+}
+
+func (s *Service) toMap(data *EventData) (map[string]interface{}, error) {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]interface{})
+	err = json.Unmarshal(dataBytes, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+type HandlerConfig struct {
+	// web service URL used to post messages.
+	// If empty uses the service URL from the configuration.
+	URL string `mapstructure:"url"`
+
+	// Username for BASIC authentication.
+	// If empty uses username from the configuration.
+	Username string `mapstructure:"username"`
+
+	// Password for BASIC authentication.
+	// If empty uses password from the configuration.
+	Password string `mapstructure:"password"`
+
+	// Action (router name).
+	// If empty uses action from the configuration.
+	Action string `mapstructure:"action"`
+
+	// Router method.
+	// If empty uses method from the configuration.
+	Method string `mapstructure:"method"`
+
+	// Event type.
+	// If empty uses type from the configuration.
+	Type string `mapstructure:"type"`
+
+	// Event TID.
+	// If empty uses TID from the configuration.
+	TID int64 `mapstructure:"tid"`
+
+	// Summary of the event.
+	Summary string `json:"summary"`
+
+	// Device related to the event.
+	Device string `json:"device"`
+
+	// Component related to the event.
+	Component string `json:"component"`
+
+	// Event Class Key of the event.
+	EventClassKey string `json:"evclasskey"`
+
+	// Event Class of the event.
+	EventClass string `json:"evclass"`
+
+	// Collector (typically IP or hostname).
+	Collector string `json:"collector"`
+
+	// Message related to the event.
+	Message string `json:"message"`
+
+	// Custom fields is a map of key value pairs.
+	CustomFields map[string]interface{} `mapstructure:"customField"`
+}
+
+type handler struct {
+	s    *Service
+	c    HandlerConfig
+	diag Diagnostic
+}
+
+func (s *Service) Handler(c HandlerConfig, ctx ...keyvalue.T) alert.Handler {
+	return &handler{
+		s:    s,
+		c:    c,
+		diag: s.diag.WithContext(ctx...),
+	}
+}
+
+func (h *handler) Handle(event alert.Event) {
+	if err := h.s.Alert(
+		h.c.URL,
+		&event.State,
+		&event.Data,
+		&h.c,
+	); err != nil {
+		h.diag.Error("failed to send event to Zenoss", err)
+	}
+}

--- a/services/zenoss/zenosstest/zenosstest.go
+++ b/services/zenoss/zenosstest/zenosstest.go
@@ -1,0 +1,54 @@
+package zenosstest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/influxdata/kapacitor/services/zenoss"
+)
+
+type Server struct {
+	mu       sync.Mutex
+	ts       *httptest.Server
+	URL      string
+	requests []Request
+	closed   bool
+}
+
+func NewServer() *Server {
+	s := new(Server)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := Request{
+			URL: r.URL.String(),
+		}
+		dec := json.NewDecoder(r.Body)
+		dec.Decode(&pr.Event)
+		s.mu.Lock()
+		s.requests = append(s.requests, pr)
+		s.mu.Unlock()
+	}))
+	s.ts = ts
+	s.URL = ts.URL
+	return s
+}
+
+func (s *Server) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requests
+}
+
+func (s *Server) Close() {
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.ts.Close()
+}
+
+type Request struct {
+	URL   string
+	Event zenoss.Event
+}

--- a/task_master.go
+++ b/task_master.go
@@ -43,6 +43,7 @@ import (
 	"github.com/influxdata/kapacitor/services/teams"
 	"github.com/influxdata/kapacitor/services/telegram"
 	"github.com/influxdata/kapacitor/services/victorops"
+	"github.com/influxdata/kapacitor/services/zenoss"
 	"github.com/influxdata/kapacitor/tick"
 	"github.com/influxdata/kapacitor/tick/stateful"
 	"github.com/influxdata/kapacitor/timer"
@@ -221,6 +222,11 @@ type TaskMaster struct {
 		StateChangesOnly() bool
 		Handler(servicenow.HandlerConfig, ...keyvalue.T) alert.Handler
 	}
+	ZenossService interface {
+		Global() bool
+		StateChangesOnly() bool
+		Handler(zenoss.HandlerConfig, ...keyvalue.T) alert.Handler
+	}
 
 	Commander command.Commander
 
@@ -319,6 +325,7 @@ func (tm *TaskMaster) New(id string) *TaskMaster {
 	n.SideloadService = tm.SideloadService
 	n.TeamsService = tm.TeamsService
 	n.ServiceNowService = tm.ServiceNowService
+	n.ZenossService = tm.ZenossService
 	return n
 }
 


### PR DESCRIPTION
This PR adds _Zenoss_ event handler as requested by https://github.com/influxdata/feature-requests/issues/72. Fixes https://github.com/influxdata/kapacitor/issues/2483.

The handler provides options for Zenoss [basic event fields](https://help.zenoss.com/zsd/RM/administering-resource-manager/event-management/event-fields):
| handler option | event field | default value |
| --- |  --- | --- |
| `summary` | Summary |  `'{{ .Message }}'` |
| `device` | Device | "" (empty string) |
| `component` | Component | "" (empty string) |
| `severity` | Severity | severity level (see Severity mapping) |
| `eventClass` | Event Class |  "" (empty string) |
| `eventClassKey` | Event Class Key | "" (empty string) |
| `collector` | Collector (optional) | _none_ |
| `message` | Message (optional) | _none_ |

In addition to the basic fields, custom fields can be set with `customField` option. The value of a custom field can be  simple type or a string representation of JSON object. There are also handler options to override Zenoss event-related values set in the configuration: `action`, `method`, `type`, `tid`. All these options support templates with the following variables available: `Name`, `TaskName`, `ID`, `Message`, `Details`, `Time`, `Duration`, `Level`, `Recoverable` and `Tags`.

**Severity mapping**
Alert level is mapped to Zenoss event severity according to mapping specified in the configuration file. Severity can be specified either as a number or a string (see [Event severity levels](https://help.zenoss.com/zsd/RM/administering-resource-manager/event-management/event-severity-levels)). The default configuration maps `OK` to `Clear`,  `Info` to `Info`, `Warning` to `Warning` and `Critical` to `Critical`.

**TICKscript examples:**
```
stream
  |from()
    .measurement('cpu')
  |alert()
    .crit(lambda: "usage_user" > 90)
    .message('Hey, check your CPU')
    .zenoss()
        .device('{{ index .Tags "host" }}')
        .component('CPU')
        .eventClass('/App')
```
```
stream
  |from()
    .measurement('cpu')
  |alert()
    .crit(lambda: "usage_user" > 90)
    .message('Hey, check your CPU')
    .zenoss()
        .action('CustomRouter')
        .method('add_event')
        .device('{{ index .Tags "host" }}')
        .component('CPU')
        .eventClass('/App')
        .collector('localhost')
        .customField('ticks', 3300)
```

Default configuration:
```
[zenoss]
  # Configure Zenoss.
  enabled = false
  # The Zenoss URL.
  url = "https://tenant.zenoss.io/zport/dmd/evconsole_router"
  # Username for HTTP BASIC authentication
  # username = ""
  # Password for HTTP BASIC authentication
  # password = ""
  # Action (router name).
  action = "EventsRouter"
  # Router method.
  method = "add_event"
  # Event type.
  type = "rpc"
  # Temporary request transaction ID.
  tid = 1
  # Alert level to event severity mapping.
  severity-map = { OK = "Clear", Info = "Info", Warning = "Warning", Critical = "Critical" }
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
