### PR TITLE
fix: function node name for ServiceNow handler

### DIFF
--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -158,7 +158,7 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 	}
 
 	for _, h := range a.ServiceNowHandlers {
-		n.Dot("servicenow").
+		n.Dot("serviceNow").
 			Dot("source", h.Source).
 			Dot("node", h.Node).
 			Dot("type", h.Type).


### PR DESCRIPTION
Fixes generated function node name for _ServiceNow_ event handler.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
