### PR TITLE
fix(bigPanda): add TICKscript AST processing

### DIFF
--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -177,6 +177,13 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 		}
 	}
 
+	for _, h := range a.BigPandaHandlers {
+		n.Dot("bigPanda").
+			Dot("appKey", h.AppKey).
+			Dot("primaryProperty", h.PrimaryProperty).
+			Dot("secondaryProperty", h.SecondaryProperty)
+	}
+
 	for _, h := range a.SlackHandlers {
 		n.Dot("slack").
 			Dot("workspace", h.Workspace).

--- a/pipeline/tick/alert_test.go
+++ b/pipeline/tick/alert_test.go
@@ -118,6 +118,28 @@ func TestAlertHTTPPost(t *testing.T) {
 	PipelineTickTestHelper(t, pipe, want)
 }
 
+func TestAlertBigPanda(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	handler := from.Alert().BigPanda()
+	handler.AppKey = "A"
+	handler.PrimaryProperty = "B"
+	handler.SecondaryProperty = "C"
+
+	want := `stream
+    |from()
+    |alert()
+        .id('{{ .Name }}:{{ .Group }}')
+        .message('{{ .ID }} is {{ .Level }}')
+        .details('{{ json . }}')
+        .history(21)
+        .bigPanda()
+        .appKey('A')
+        .primaryProperty('B')
+        .secondaryProperty('C')
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
 func TestAlertHTTPPostMultipleHeaders(t *testing.T) {
 	pipe, _, from := StreamFrom()
 	handler := from.Alert().Post("")

--- a/pipeline/tick/alert_test.go
+++ b/pipeline/tick/alert_test.go
@@ -140,6 +140,34 @@ func TestAlertBigPanda(t *testing.T) {
 	PipelineTickTestHelper(t, pipe, want)
 }
 
+func TestAlertServiceNow(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	handler := from.Alert().ServiceNow()
+	handler.Source = "A"
+	handler.Node = "B"
+	handler.Type = "C"
+	handler.Resource = "D"
+	handler.MetricName = "E"
+	handler.MessageKey = "F"
+
+	want := `stream
+    |from()
+    |alert()
+        .id('{{ .Name }}:{{ .Group }}')
+        .message('{{ .ID }} is {{ .Level }}')
+        .details('{{ json . }}')
+        .history(21)
+        .serviceNow()
+        .source('A')
+        .node('B')
+        .type('C')
+        .resource('D')
+        .metricName('E')
+        .messageKey('F')
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
 func TestAlertHTTPPostMultipleHeaders(t *testing.T) {
 	pipe, _, from := StreamFrom()
 	handler := from.Alert().Post("")


### PR DESCRIPTION
This PR Fixes TickScript AST processing so that it includes BigPanda alert handler.

Additionally, it also adds a test for `serviceNow` alert handler AST parsing.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
