### PR TITLE
fix(teams): add TICKscript AST processing

### DIFF
--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -283,6 +283,10 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 			n.Dot("customField", k, h.CustomFieldsMap[k])
 		}
 	}
+	for _, h := range a.TeamsHandlers {
+		n.Dot("teams").
+			Dot("channelURL", h.ChannelURL)
+	}
 
 	return n.prev, n.err
 }

--- a/pipeline/tick/alert_test.go
+++ b/pipeline/tick/alert_test.go
@@ -168,6 +168,24 @@ func TestAlertServiceNow(t *testing.T) {
 	PipelineTickTestHelper(t, pipe, want)
 }
 
+func TestAlertTeams(t *testing.T) {
+	pipe, _, from := StreamFrom()
+	handler := from.Alert().Teams()
+	handler.ChannelURL = "https://..."
+
+	want := `stream
+    |from()
+    |alert()
+        .id('{{ .Name }}:{{ .Group }}')
+        .message('{{ .ID }} is {{ .Level }}')
+        .details('{{ json . }}')
+        .history(21)
+        .teams()
+        .channelURL('https://...')
+`
+	PipelineTickTestHelper(t, pipe, want)
+}
+
 func TestAlertHTTPPostMultipleHeaders(t *testing.T) {
 	pipe, _, from := StreamFrom()
 	handler := from.Alert().Post("")


### PR DESCRIPTION
This PR Fixes TickScript AST processing so that it includes Teams alert handler. This is required in order to fully support Teams alert configuration in Chronograf ( influxdata/chronograf#5732 )

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated