### PR TITLE
fix(teams): make ChannelURL naming consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ kapacitor*.zip
 /kapacitord
 /tickfmt
 /tickdoc
+
+# Ignore go vendor directory
+/vendor

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -2248,7 +2248,7 @@ type TeamsHandler struct {
 
 	// Teams channel webhook URL to post messages.
 	// If empty uses the URL from the configuration.
-	ChannelURL string `json:"channel_url"`
+	ChannelURL string `json:"channel-url"`
 }
 
 // Send the alert to ServiceNow.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9400,7 +9400,7 @@ func TestServer_ListServiceTests(t *testing.T) {
 				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/service-tests/teams"},
 				Name: "teams",
 				Options: client.ServiceTestOptions{
-					"channel_url": "",
+					"channel-url": "",
 					"alert_topic": "test kapacitor alert topic",
 					"alert_id":    "foo/bar/bat",
 					"message":     "test teams message",

--- a/services/teams/service.go
+++ b/services/teams/service.go
@@ -70,7 +70,7 @@ func (s *Service) StateChangesOnly() bool {
 }
 
 type testOptions struct {
-	ChannelURL string      `json:"channel_url"`
+	ChannelURL string      `json:"channel-url"`
 	AlertTopic string      `json:"alert_topic"`
 	AlertID    string      `json:"alert_id"`
 	Message    string      `json:"message"`


### PR DESCRIPTION
This PR fixes Teams alert handler to always serialize ChannelURL to `channel-url` JSON property. Before this PR, `channel-url` was used in the global configuration and `channel_url` in a specific handler configuration and for handler testing. Different names are causing problems in influxdata/chronograf#5740, which naturally expects the same property name when overriding the configured default per alert instance.

Additionally, it adds golang's `vendor` directory `.gitignore`

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated

