### PR TITLE
fix: Zenoss property name compatibility

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -584,7 +584,7 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 			Action:        s.Action,
 			Method:        s.Method,
 			Type:          s.Type,
-			TID:           s.TID,
+			TID:           s.Tid,
 			Summary:       s.Summary,
 			Device:        s.Device,
 			Component:     s.Component,

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -2421,7 +2421,7 @@ type ZenossHandler struct {
 
 	// Temporary transaction ID.
 	// If empty uses value from the configuration.
-	TID int64 `json:"tid"`
+	Tid int64 `json:"tid"`
 
 	// Collector name.
 	// If empty uses value from the configuration.

--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -263,7 +263,7 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 			Dot("action", h.Action).
 			Dot("method", h.Method).
 			Dot("type", h.Type).
-			Dot("tid", h.TID).
+			Dot("tid", h.Tid).
 			// standard event data element fields
 			Dot("summary", h.Summary).
 			Dot("device", h.Device).


### PR DESCRIPTION
Changes Zenoss property name to camel case, uppercase seems to break Kapacitor integration.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
