### PR TITLE
fix(bigpanda): setup test options from configuration

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9100,7 +9100,7 @@ func TestServer_ListServiceTests(t *testing.T) {
 				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/service-tests/bigpanda"},
 				Name: "bigpanda",
 				Options: client.ServiceTestOptions{
-					"app_key":            "my-app-key-123456",
+					"app_key":            "",
 					"level":              "CRITICAL",
 					"message":            "test bigpanda message",
 					"timestamp":          "1970-01-01T00:00:01Z",
@@ -9483,6 +9483,13 @@ func TestServer_ListServiceTests(t *testing.T) {
 	for i := range expServiceTests.Services {
 		exp := expServiceTests.Services[i]
 		got := serviceTests.Services[i]
+		if _, expHasTimestamp := exp.Options["timestamp"]; expHasTimestamp {
+			if _, gotHasTimestamp := got.Options["timestamp"]; !gotHasTimestamp {
+				t.Errorf("timestamp not found in server test %s:\n%s", exp.Name, cmp.Diff(exp, got))
+			}
+			exp.Options["timestamp"] = ""
+			got.Options["timestamp"] = ""
+		}
 		if !reflect.DeepEqual(got, exp) {
 			t.Errorf("unexpected server test %s:\n%s", exp.Name, cmp.Diff(exp, got))
 		}

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -94,9 +94,10 @@ type testOptions struct {
 
 func (s *Service) TestOptions() interface{} {
 	t := time.Now()
+	c := s.config()
 
 	return &testOptions{
-		AppKey:  "my-app-key-123456",
+		AppKey:  c.AppKey,
 		Message: "test bigpanda message",
 		Level:   alert.Critical,
 		Data: alert.EventData{

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -93,11 +93,8 @@ type testOptions struct {
 }
 
 func (s *Service) TestOptions() interface{} {
-	t := time.Now()
-	c := s.config()
-
 	return &testOptions{
-		AppKey:  c.AppKey,
+		AppKey:  s.config().AppKey,
 		Message: "test bigpanda message",
 		Level:   alert.Critical,
 		Data: alert.EventData{
@@ -106,9 +103,8 @@ func (s *Service) TestOptions() interface{} {
 			Fields: make(map[string]interface{}),
 			Result: models.Result{},
 		},
-		Timestamp: t,
+		Timestamp: time.Now(),
 	}
-
 }
 
 func (s *Service) Test(options interface{}) error {

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -93,7 +93,7 @@ type testOptions struct {
 }
 
 func (s *Service) TestOptions() interface{} {
-	t, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:01Z")
+	t := time.Now()
 
 	return &testOptions{
 		AppKey:  "my-app-key-123456",


### PR DESCRIPTION
Closes influxdata/chronograf#5753

This PR fixes BigPanda service so that its testing functionality
- uses the configured AppKey (it was fake before this PR)
- uses current time timestamp (it was 0 since epoch before this PR)

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

