### PR TITLE
fix(teams): revert ChannelURL mapping to preserve BC with saved TICKscripts

### DIFF
--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -2248,7 +2248,7 @@ type TeamsHandler struct {
 
 	// Teams channel webhook URL to post messages.
 	// If empty uses the URL from the configuration.
-	ChannelURL string `json:"channel-url"`
+	ChannelURL string `json:"channel_url"`
 }
 
 // Send the alert to ServiceNow.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9457,7 +9457,7 @@ func TestServer_ListServiceTests(t *testing.T) {
 				Link: client.Link{Relation: client.Self, Href: "/kapacitor/v1/service-tests/teams"},
 				Name: "teams",
 				Options: client.ServiceTestOptions{
-					"channel-url": "",
+					"channel_url": "",
 					"alert_topic": "test kapacitor alert topic",
 					"alert_id":    "foo/bar/bat",
 					"message":     "test teams message",

--- a/services/teams/service.go
+++ b/services/teams/service.go
@@ -70,7 +70,7 @@ func (s *Service) StateChangesOnly() bool {
 }
 
 type testOptions struct {
-	ChannelURL string      `json:"channel-url"`
+	ChannelURL string      `json:"channel_url"`
 	AlertTopic string      `json:"alert_topic"`
 	AlertID    string      `json:"alert_id"`
 	Message    string      `json:"message"`


### PR DESCRIPTION
This PR reverts consistent ChannelURL JSON mapping introduced in #2545, it would cause anyone who has Teams Pipeline saved to lose that field from their pipeline. 

In order to preserve backward compatibility, MS Teams ChannelURL has to remain `channel_url` in TICKscript and `channel-url` in the config. This discrepancy requires an extra care in chronograf 1.9 that added Teams alert/configuration UI.

- [ ] Rebased/mergable
- [ ] Tests pass
