### PR TITLE
feat(alerta-service): Support the "attributes" attribute in Alerta node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [#2559](https://github.com/influxdata/kapacitor/pull/2559): kapacitor cli supports flux tasks
 - [#2560](https://github.com/influxdata/kapacitor/pull/2560): enable new-style slack apps
 - [#2562](https://github.com/influxdata/kapacitor/pull/2560): handle Delete messages in the joinNode
+- [#2575](https://github.com/influxdata/kapacitor/pull/2575): Support the "attributes" attribute in Alerta node
 - [#2576](https://github.com/influxdata/kapacitor/pull/2576): shared secret auth to influxdb in OSS
 
 ### Bugfixes

--- a/alert.go
+++ b/alert.go
@@ -381,6 +381,9 @@ func newAlertNode(et *ExecutingTask, n *pipeline.AlertNode, d NodeDiagnostic) (a
 		if len(a.Correlate) != 0 {
 			c.Correlate = a.Correlate
 		}
+		if len(a.Attributes) != 0 {
+			c.Attributes = a.Attributes
+		}
 		if a.Timeout != 0 {
 			c.Timeout = a.Timeout
 		}

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -9207,6 +9207,10 @@ stream
 			.value('{{ index .Fields "count" }}')
 			.services('serviceA', 'serviceB', '{{ .Name }}')
 			.correlated('{{ .Name }}')
+			.attribute('attributeA', '{{ .Name }}')
+			.attribute('attributeB', TRUE)
+			.attribute('attributeC', 9001.0)
+
 `
 	tmInit := func(tm *kapacitor.TaskMaster) {
 		c := alerta.NewConfig()
@@ -9231,6 +9235,7 @@ stream
 				Origin:      "Kapacitor",
 				Service:     []string{"cpu"},
 				Correlate:   []string{"cpu"},
+				Attributes:  nil,
 				Timeout:     3600,
 			},
 		},
@@ -9247,6 +9252,7 @@ stream
 				Service:     []string{"serviceA", "serviceB", "cpu"},
 				Correlate:   []string{"cpu"},
 				Value:       "10",
+				Attributes:  map[string]interface{}{"attributeA": "cpu", "attributeB": true, "attributeC": 9001.0},
 				Timeout:     86400,
 			},
 		},

--- a/pipeline/alert.go
+++ b/pipeline/alert.go
@@ -1263,6 +1263,9 @@ type AlertaHandler struct {
 	// List of Correlated
 	Correlate []string `tick:"Correlated" json:"correlate"`
 
+	// Map of alert Attributes
+	Attributes map[string]interface{} `tick:"Attribute" json:"attributes"`
+
 	// Alerta timeout.
 	// Default: 24h
 	Timeout time.Duration `json:"timeout"`
@@ -1278,6 +1281,14 @@ func (a *AlertaHandler) Services(service ...string) *AlertaHandler {
 
 func (a *AlertaHandler) Correlated(correlate ...string) *AlertaHandler {
 	a.Correlate = correlate
+	return a
+}
+
+func (a *AlertaHandler) Attribute(k string, v interface{}) *AlertaHandler {
+	if a.Attributes == nil {
+		a.Attributes = make(map[string]interface{})
+	}
+	a.Attributes[k] = v
 	return a
 }
 

--- a/pipeline/tick/alert.go
+++ b/pipeline/tick/alert.go
@@ -227,6 +227,15 @@ func (n *AlertNode) Build(a *pipeline.AlertNode) (ast.Node, error) {
 			Dot("services", args(h.Service)...).
 			Dot("correlated", args(h.Correlate)...).
 			Dot("timeout", h.Timeout)
+
+		var attributes []string
+		for k := range h.Attributes {
+			attributes = append(attributes, k)
+		}
+		sort.Strings(attributes)
+		for _, k := range attributes {
+			n.Dot("attribute", k, h.Attributes[k])
+		}
 	}
 
 	for _, h := range a.OpsGenieHandlers {

--- a/pipeline/tick/alert_test.go
+++ b/pipeline/tick/alert_test.go
@@ -667,6 +667,9 @@ func TestAlertAlerta(t *testing.T) {
 	handler.Services("legion", "vent", "garrus", "distraction team", "grunt", "crew", "samara", "barrier")
 	handler.Correlated("Harbinger")
 	handler.Timeout = 10 * time.Second
+	handler.Attribute("source", "Dragon Ball Z")
+	handler.Attribute("power", float64(9001))
+	handler.Attribute("o rly?", true)
 
 	want := `stream
     |from()
@@ -686,6 +689,9 @@ func TestAlertAlerta(t *testing.T) {
         .services('legion', 'vent', 'garrus', 'distraction team', 'grunt', 'crew', 'samara', 'barrier')
         .correlated('Harbinger')
         .timeout(10s)
+        .attribute('o rly?', TRUE)
+        .attribute('power', 9001.0)
+        .attribute('source', 'Dragon Ball Z')
 `
 	PipelineTickTestHelper(t, pipe, want)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9127,6 +9127,11 @@ func TestServer_ListServiceTests(t *testing.T) {
 						"testServiceX",
 						"testServiceY",
 					},
+					"attributes": map[string]interface{}{
+						"testAttributeA": "A",
+						"testAttributeB": true,
+						"testAttributeC": float64(9001.0),
+					},
 					"timeout": "24h0m0s",
 				},
 			},

--- a/services/alerta/alertatest/alertatest.go
+++ b/services/alerta/alertatest/alertatest.go
@@ -53,14 +53,15 @@ type Request struct {
 }
 
 type PostData struct {
-	Resource    string   `json:"resource"`
-	Event       string   `json:"event"`
-	Group       string   `json:"group"`
-	Environment string   `json:"environment"`
-	Text        string   `json:"text"`
-	Origin      string   `json:"origin"`
-	Service     []string `json:"service"`
-	Correlate   []string `json:"correlate"`
-	Value       string   `json:"value"`
-	Timeout     int64    `json:"timeout"`
+	Resource    string                 `json:"resource"`
+	Event       string                 `json:"event"`
+	Group       string                 `json:"group"`
+	Environment string                 `json:"environment"`
+	Text        string                 `json:"text"`
+	Origin      string                 `json:"origin"`
+	Service     []string               `json:"service"`
+	Correlate   []string               `json:"correlate"`
+	Attributes  map[string]interface{} `json:"attributes"`
+	Value       string                 `json:"value"`
+	Timeout     int64                  `json:"timeout"`
 }


### PR DESCRIPTION
Fix influxdata#2349

This commit adds support for custom Alerta alert attributes (see Alerta Alert Format for details).

Attributes are specified with "attribute" keyword in tick script, e.g.:

    |alert()
        // ...
        .alerta()
            // ...
            .attribute('customUrl', 'https://example.com/')
            .attribute('booleanAttribute', TRUE)
            .attribute('numericAttribute', 9001)
            .attribute('templatedAttribute', 'Templates are supported: {{ .Name }}')

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
