### PR TITLE
fix: cli auth and error handling for flux tasks

### DIFF
--- a/cmd/kapacitor/fluxtask.go
+++ b/cmd/kapacitor/fluxtask.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"net"
 	"net/http"
 	"net/url"
@@ -80,6 +81,11 @@ func withApi(u string, skipSsl bool) cli.BeforeFunc {
 		conf.Host = parsedUrl.Host
 		conf.Scheme = parsedUrl.Scheme
 		conf.UserAgent = kclient.DefaultUserAgent
+		if parsedUrl.User != nil {
+			conf.AddDefaultHeader("Authorization",
+				"Basic "+base64.StdEncoding.EncodeToString([]byte(parsedUrl.User.String())),
+			)
+		}
 		// All the client code we share with influxdb assumes the /api/v2/tasks endpoint. Translate to
 		// the /kapacitor/v1/api/v2/tasks endpoint
 		conf.HTTPClient = &http.Client{Transport: urlPrefixer{

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -223,7 +223,7 @@ func main() {
 
 	err = commandF(commandArgs)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("Error: %s", err.Error()))
 		os.Exit(3)
 	}
 }

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -555,13 +555,17 @@ func serveExpvar(w http.ResponseWriter, r *http.Request) {
 
 // HttpError writes an error to the client in a standard format.
 func HttpError(w http.ResponseWriter, err string, pretty bool, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 
 	type errResponse struct {
+		// Kapacitor 1.5 used only 'error'
 		Error string `json:"error"`
+		// Kapacitor 1.6 also uses 'message' to match InfluxDB 2.x
+		Message string `json:"message"`
 	}
 
-	response := errResponse{Error: err}
+	response := errResponse{Error: err, Message: err}
 	var b []byte
 	if pretty {
 		b, _ = json.MarshalIndent(response, "", "    ")


### PR DESCRIPTION
Closes #2578 

Before:

➜  ./kapacitor -url http://steve:pas@localhost:9092 flux task list
undefined response type
➜  ./kapacitor -url http://steve:pass@localhost:9092 flux task list
undefined response type 

After:

➜  ./kapacitor -url http://steve:pas@localhost:9092 flux task list
Error: authorization failed
➜  ./kapacitor -url http://steve:pass@localhost:9092 flux task list
ID                      Name    Organization ID Organization    Status  Every   Cron
079625bc3aeb8000        poster                                  active  3s

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
