### PR TITLE
expvar string json encoding to handle special chars

### DIFF
--- a/expvar/expvar.go
+++ b/expvar/expvar.go
@@ -4,6 +4,7 @@ package expvar
 
 import (
 	"bytes"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"math"
@@ -281,7 +282,8 @@ type String struct {
 func (v *String) String() string {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
-	return strconv.Quote(v.s)
+	b, _ := json.Marshal(v.s)
+	return string(b)
 }
 
 func (v *String) Set(value string) {


### PR DESCRIPTION
Fixes #2583 

RCA: The `String()` function of type `String` should perform a json.Marshal to ensure it generates a valid json even for special chars . 

Ref :  https://golang.org/src/expvar/expvar.go?s=5421:5453#L233

Changelog: Commit
Signed-off-by: Prashanth Joseph Babu <prashanthjbabu@gmail.com>

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
