### PR TITLE
make deleteGroupMessage align with GroupInfoer interface

### DIFF
--- a/barrier.go
+++ b/barrier.go
@@ -203,7 +203,7 @@ func (n *idleBarrier) emitBarrier() error {
 		return err
 	}
 	if n.del {
-		return n.in.Collect(edge.NewDeleteGroupMessage(&n.group))
+		return n.in.Collect(edge.NewDeleteGroupMessage(n.group))
 	}
 	return nil
 }
@@ -318,7 +318,7 @@ func (n *periodicBarrier) emitBarrier() error {
 	}
 	if n.del {
 		// Send DeleteGroupMessage into self
-		return n.in.Collect(edge.NewDeleteGroupMessage(&n.group))
+		return n.in.Collect(edge.NewDeleteGroupMessage(n.group))
 	}
 	return nil
 }

--- a/edge/messages.go
+++ b/edge/messages.go
@@ -935,10 +935,10 @@ type DeleteGroupMessage interface {
 }
 
 type deleteGroupMessage struct {
-	info *GroupInfo
+	info GroupInfo
 }
 
-func NewDeleteGroupMessage(info *GroupInfo) *deleteGroupMessage {
+func NewDeleteGroupMessage(info GroupInfo) *deleteGroupMessage {
 	return &deleteGroupMessage{
 		info: info,
 	}
@@ -952,6 +952,6 @@ func (d *deleteGroupMessage) GroupID() models.GroupID {
 	return d.info.ID
 }
 
-func (d *deleteGroupMessage) GroupInfo() *GroupInfo {
+func (d *deleteGroupMessage) GroupInfo() GroupInfo {
 	return d.info
 }


### PR DESCRIPTION
Bug : 
```
ts=2021-06-14T07:27:50.277Z lvl=error msg="node failed" service=kapacitor task_master=main task=Infra-Kubernetes-ContainerCPUUsage node=barrier2 err="unexpected message of type *edge.deleteGroupMessage"
ts=2021-06-14T07:27:50.279Z lvl=error msg="node failed" service=kapacitor task_master=main task=Infra-Kubernetes-ContainerCPUUsage node=from1 err="edge aborted"
ts=2021-06-14T07:27:50.387Z lvl=error msg="node failed" service=kapacitor task_master=main task=Infra-Kubernetes-ContainerCPUUsage node=stream0 err="edge aborted"
```
RCA : `deleteGroupMessage` was not compliant with `GroupInfoer` interface
Fix : make `deleteGroupMessage` was compliant with `GroupInfoer` interface

Changelog: Commit

Signed-off-by: Prashanth Joseph Babu

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [TICKscript Spec](https://github.com/influxdata/kapacitor/blob/master/tick/TICKscript.md) updated
