### PR TITLE
fix(bigpanda): fields of alerting data point are serialized to proper types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bugfixes
 - [#2564](https://github.com/influxdata/kapacitor/pull/2564): Fix a panic in the scraper handler when debug mode is enabled
 - [#2579](https://github.com/influxdata/kapacitor/pull/2579): Fix: cli auth and error handling for flux tasks
+- [#2592](https://github.com/influxdata/kapacitor/pull/2592): Fix: payload serialization for BigPanda
 
 ## v1.5.9 [2021-04-01]
 

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -234,7 +234,7 @@ func (s *Service) preparePost(id string, message string, details string, level a
 	}
 
 	for k, v := range data.Fields {
-		bpData[k] = fmt.Sprintf("%v", v)
+		bpData[k] = v
 	}
 
 	var post bytes.Buffer

--- a/services/bigpanda/service_test.go
+++ b/services/bigpanda/service_test.go
@@ -1,0 +1,66 @@
+package bigpanda
+
+import (
+	"bytes"
+	"github.com/influxdata/kapacitor/alert"
+	"github.com/influxdata/kapacitor/models"
+	"testing"
+	"time"
+)
+
+func TestService_SerializeEventData(t *testing.T) {
+	config := Config{Enabled: true, AppKey: "key"}
+	s, err := NewService(config, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		fields  map[string]interface{}
+		expBody string
+	}{
+		{
+			fields:  map[string]interface{}{"primitive_type": 10},
+			expBody: "{\"app_key\":\"key\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"primitive_type\":10,\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+		},
+		{
+			fields:  map[string]interface{}{"escape": "\n"},
+			expBody: "{\"app_key\":\"key\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"escape\":\"\\n\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+		},
+		{
+			fields:  map[string]interface{}{"array": []interface{}{10, true, "string value"}},
+			expBody: "{\"app_key\":\"key\",\"array\":[10,true,\"string value\"],\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		r, err := s.preparePost(
+			"id",
+			"message",
+			"details",
+			alert.OK,
+			time.Date(1971, 1, 1, 0, 0, 38, 0, time.UTC),
+			alert.EventData{
+				Name:   "test",
+				Tags:   make(map[string]string),
+				Fields: tc.fields,
+				Result: models.Result{},
+			},
+			&HandlerConfig{})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		buf := new(bytes.Buffer)
+		_, err = buf.ReadFrom(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newStr := buf.String()
+
+		if tc.expBody != newStr {
+			t.Fatalf("unexpected content: got '%s' exp '%s'", newStr, tc.expBody)
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/influxdata/EAR/issues/2365

This PR changes how are serialized `fields of alerting` data into BigPanda payload - use original type of field instead mapping a field value to `string`.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

