### PR TITLE
Typo:changelog for merge, in wrong place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugfixes
 - [#2585](https://github.com/influxdata/kapacitor/pull/2585):Make DeleteGroupMessage align with GroupInfoer interface, thanks @prashanthjbabu!
+- [#2592](https://github.com/influxdata/kapacitor/pull/2592): Fix: payload serialization for BigPanda
 
 ## v1.6.0 [2021-06-28]
 
@@ -27,7 +28,6 @@
 ### Bugfixes
 - [#2564](https://github.com/influxdata/kapacitor/pull/2564): Fix a panic in the scraper handler when debug mode is enabled
 - [#2579](https://github.com/influxdata/kapacitor/pull/2579): Fix: cli auth and error handling for flux tasks
-- [#2592](https://github.com/influxdata/kapacitor/pull/2592): Fix: payload serialization for BigPanda
 
 ## v1.5.9 [2021-04-01]
 


### PR DESCRIPTION
There was a typo in the position of a changelog item, this puts it in the right place,