### PR TITLE
fix(bigpanda): fields of alerting data point should be serialized as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 - [#2585](https://github.com/influxdata/kapacitor/pull/2585):Make DeleteGroupMessage align with GroupInfoer interface, thanks @prashanthjbabu!
-- [#2592](https://github.com/influxdata/kapacitor/pull/2592): Fix: payload serialization for BigPanda
+- [#2596](https://github.com/influxdata/kapacitor/pull/2596): Fix: payload serialization for BigPanda
 
 ## v1.6.0 [2021-06-28]
 

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -238,7 +238,7 @@ func (s *Service) preparePost(id string, message string, details string, level a
 		case string:
 			bpData[k] = value
 		default:
-			b, err := json.Marshal(v)
+			b, err := json.Marshal(value)
 			if err != nil {
 				return nil, err
 			}

--- a/services/bigpanda/service.go
+++ b/services/bigpanda/service.go
@@ -234,7 +234,16 @@ func (s *Service) preparePost(id string, message string, details string, level a
 	}
 
 	for k, v := range data.Fields {
-		bpData[k] = v
+		switch value := v.(type) {
+		case string:
+			bpData[k] = value
+		default:
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			bpData[k] = string(b)
+		}
 	}
 
 	var post bytes.Buffer

--- a/services/bigpanda/service_test.go
+++ b/services/bigpanda/service_test.go
@@ -21,7 +21,19 @@ func TestService_SerializeEventData(t *testing.T) {
 	}{
 		{
 			fields:  map[string]interface{}{"primitive_type": 10},
-			expBody: "{\"app_key\":\"key\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"primitive_type\":10,\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+			expBody: "{\"app_key\":\"key\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"primitive_type\":\"10\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+		},
+		{
+			fields:  map[string]interface{}{"primitive_type": "string"},
+			expBody: "{\"app_key\":\"key\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"primitive_type\":\"string\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+		},
+		{
+			fields:  map[string]interface{}{"primitive_type": true},
+			expBody: "{\"app_key\":\"key\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"primitive_type\":\"true\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+		},
+		{
+			fields:  map[string]interface{}{"primitive_type": 123.45},
+			expBody: "{\"app_key\":\"key\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"primitive_type\":\"123.45\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
 		},
 		{
 			fields:  map[string]interface{}{"escape": "\n"},
@@ -29,7 +41,7 @@ func TestService_SerializeEventData(t *testing.T) {
 		},
 		{
 			fields:  map[string]interface{}{"array": []interface{}{10, true, "string value"}},
-			expBody: "{\"app_key\":\"key\",\"array\":[10,true,\"string value\"],\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
+			expBody: "{\"app_key\":\"key\",\"array\":\"[10,true,\\\"string value\\\"]\",\"check\":\"id\",\"description\":\"message\",\"details\":\"details\",\"status\":\"ok\",\"task\":\":test\",\"timestamp\":31536038}\n",
 		},
 	}
 


### PR DESCRIPTION
Related to https://github.com/influxdata/EAR/issues/2365

The `Additional attributes` of BigPanda alerts should be serialized as a `string`. See docs:

![image](https://user-images.githubusercontent.com/455137/126264831-471c50fa-4b88-4017-aa7d-9cd96e053244.png)

https://docs.bigpanda.io/reference#alerts

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

