### PR TITLE
feat: auto-create 1.x DB or 2.x bucket for flux task logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2605](https://github.com/influxdata/kapacitor/pull/2605): Updated jwt dependencies of libraries because of https://nvd.nist.gov/vuln/detail/CVE-2020-26160
 - [#2601](https://github.com/influxdata/kapacitor/pull/2601): Switched to github.com/golang-jwt/jwt for kapacitor's use because of https://nvd.nist.gov/vuln/detail/CVE-2020-26160
 - [#2618](https://github.com/influxdata/kapacitor/pull/2618): Switch task service to use Flux formatter that preserves comments
+- [#2622](https://github.com/influxdata/kapacitor/pull/2622): auto-create 1.x DB or 2.x bucket for flux task logs
 
 ### Features
 

--- a/barrier.go
+++ b/barrier.go
@@ -2,10 +2,9 @@ package kapacitor
 
 import (
 	"errors"
-	"time"
-
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/influxdata/kapacitor/edge"
 	"github.com/influxdata/kapacitor/models"

--- a/http_post.go
+++ b/http_post.go
@@ -1,6 +1,8 @@
 package kapacitor
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -8,9 +10,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-
-	"bytes"
-	"context"
 
 	"github.com/influxdata/kapacitor/edge"
 	"github.com/influxdata/kapacitor/keyvalue"

--- a/influxdb/token_client.go
+++ b/influxdb/token_client.go
@@ -121,6 +121,10 @@ func (tc *tokenClient) QueryFluxResponse(q FluxQuery) (*Response, error) {
 	return tc.client.QueryFluxResponse(q)
 }
 
+func (tc *tokenClient) CreateBucketV2(bucket, org, orgID string) error {
+	return tc.client.CreateBucketV2(bucket, org, orgID)
+}
+
 func (tc *tokenClient) Open() error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()

--- a/services/auth/service.go
+++ b/services/auth/service.go
@@ -22,7 +22,6 @@ import (
 	"github.com/influxdata/kapacitor/services/storage"
 	"github.com/influxdata/kapacitor/tlsconfig"
 	"github.com/pkg/errors"
-
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/services/bigpanda/service_test.go
+++ b/services/bigpanda/service_test.go
@@ -2,10 +2,11 @@ package bigpanda
 
 import (
 	"bytes"
-	"github.com/influxdata/kapacitor/alert"
-	"github.com/influxdata/kapacitor/models"
 	"testing"
 	"time"
+
+	"github.com/influxdata/kapacitor/alert"
+	"github.com/influxdata/kapacitor/models"
 )
 
 func TestService_SerializeEventData(t *testing.T) {

--- a/services/discord/service.go
+++ b/services/discord/service.go
@@ -7,10 +7,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"sync"
 	text "text/template"
 	"time"
-
-	"sync"
 
 	"github.com/influxdata/kapacitor/alert"
 	khttp "github.com/influxdata/kapacitor/http"

--- a/services/httppost/service.go
+++ b/services/httppost/service.go
@@ -2,6 +2,7 @@ package httppost
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -12,10 +13,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
-
 	"time"
-
-	"context"
 
 	"github.com/influxdata/kapacitor/alert"
 	khttp "github.com/influxdata/kapacitor/http"

--- a/services/influxdb/service.go
+++ b/services/influxdb/service.go
@@ -563,6 +563,11 @@ func (c *influxdbCluster) Open() error {
 
 	c.watchSubs()
 
+	// Even if we're not linking subscriptions, validate the client to ensure influxdb is actually up
+	if err := c.validateClientWithBackoff(ctx); err != nil {
+		return errors.Wrap(err, "failed to validate influxdb client on startup")
+	}
+
 	if err := c.linkSubscriptions(ctx, c.subName); err != nil {
 		return errors.Wrap(err, "failed to link subscription on startup")
 	}

--- a/services/influxdb/service_test.go
+++ b/services/influxdb/service_test.go
@@ -1303,6 +1303,10 @@ func (c influxDBClient) Update(config influxcli.Config) error {
 	return nil
 }
 
+func (c influxDBClient) CreateBucketV2(bucket string, org string, orgID string) error {
+	return nil
+}
+
 type logSerivce struct {
 }
 

--- a/services/load/service.go
+++ b/services/load/service.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/ghodss/yaml"
-
 	"github.com/influxdata/kapacitor/client/v1"
 	kexpvar "github.com/influxdata/kapacitor/expvar"
 	"github.com/influxdata/kapacitor/server/vars"

--- a/services/smtp/service.go
+++ b/services/smtp/service.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/influxdata/kapacitor/alert"
 	"github.com/influxdata/kapacitor/keyvalue"
-
 	"gopkg.in/gomail.v2"
 )
 

--- a/services/teams/service.go
+++ b/services/teams/service.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/url"
 	"sync/atomic"
-
-	"math"
 
 	"github.com/influxdata/kapacitor/alert"
 	"github.com/influxdata/kapacitor/keyvalue"

--- a/services/telegram/service.go
+++ b/services/telegram/service.go
@@ -9,9 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"sync/atomic"
-
 	"strings"
+	"sync/atomic"
 
 	"github.com/influxdata/kapacitor/alert"
 	"github.com/influxdata/kapacitor/keyvalue"

--- a/task/config.go
+++ b/task/config.go
@@ -38,9 +38,12 @@ type Config struct {
 	Secrets map[string]string `toml:"secrets"`
 }
 
+const DefaultTaskRunBucket = "kapacitor_fluxtask_logs"
+
 func NewConfig() Config {
 	return Config{
 		TaskRunMeasurement: "runs",
+		TaskRunBucket:      DefaultTaskRunBucket,
 	}
 }
 
@@ -53,9 +56,6 @@ func (c Config) Validate() error {
 	}
 	if len(c.TaskRunOrgID) > 0 && len(c.TaskRunOrg) > 0 {
 		return fmt.Errorf("only one of task-run-org and task-run-orgid should be set")
-	}
-	if len(c.TaskRunBucket) == 0 {
-		return fmt.Errorf("task-run-bucket is required")
 	}
 	return nil
 }

--- a/tick/stack.go
+++ b/tick/stack.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	//"log"
 )
 
 var ErrEmptyStack = errors.New("stack is empty")


### PR DESCRIPTION
Closes #2620

Flux task logs are stored in the "Analytic Store", which is backed
by an influxdb 1.x Database or 2.x Bucket.

Auto-creation gives an infinite retention policy, which can be adjusted later by the user.

Note that for 1.x, "database/rp" bucket names will not be autocreated, only
bare "database" bucket names. This could potentially be added in the future
but the assumption is if a user wants control over the retention policy name
they probably want to control the retention policy creation as well.

Tested manually against 1.x and 2.x.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

