### PR TITLE
test(tick): remove depreciated importer.For

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
-	golang.org/x/tools v0.1.0 // indirect
+	golang.org/x/tools v0.1.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/api v0.42.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
This removes the depreciated importer.For.  This removal allows tests to be module aware.