### PR TITLE
test: fix flaky test in TestWallClock

### DIFF
--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -159,7 +159,7 @@ func TestWallClock(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		t.Fatal("expected return from c.Until")
 	}
 }


### PR DESCRIPTION
This is to fix the flaky test for TestWallClock.
Since switching to go 1.17 we have seen this flaky test crop up way too often.