### PR TITLE
fix: better error message for flux data without the appropriate columns

### DIFF
--- a/influxdb/event_parser.go
+++ b/influxdb/event_parser.go
@@ -104,7 +104,7 @@ readRow:
 	switch q.row[0] {
 	case "":
 		if len(q.row) <= 5 {
-			return errors.New("Unexpectedly few columns")
+			return errors.New("Unexpectedly few columns -- Kapacitor cannot understand this data. We need at minimum a _time column, table number, and at least one column with data in")
 		}
 		if state == stateNameRow {
 			newNames := q.row[skipNonDataFluxCols:]


### PR DESCRIPTION
Flux is much more general purpose than tick script, and can handle data that isn't a time series.  However, Tick cannot understand this data.  When people output one of these scripts into a tick script, we error.  The error wasn't descriptive enough and was causing confusion.