### PR TITLE
Use more descriptive name for blocked CIDR ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ## v1.6.1 [2021-07-22]
 
 ### Features
-- [#2589](https://github.com/influxdata/kapacitor/pull/2589): Flag for blacklisting CIDR ranges for certain handlers, and nodes
+- [#2589](https://github.com/influxdata/kapacitor/pull/2589): Flag for denylisting CIDR ranges for certain handlers, and nodes
 - [#2591](https://github.com/influxdata/kapacitor/pull/2591): Flag for disabling alert handlers, this is useful for security (such as disabling exec on a shared machine)
 
 ### Bugfixes

--- a/cmd/kapacitord/run/command.go
+++ b/cmd/kapacitord/run/command.go
@@ -107,13 +107,13 @@ func (cmd *Command) Run(args ...string) error {
 		config.Logging.Level = options.LogLevel
 	}
 
-	switch options.BlackListCIDRS {
+	switch options.DenyListCIDRS {
 	case "":
 		khttp.DefaultValidator = furl.PassValidator{}
 	case "private":
 		khttp.DefaultValidator = furl.PrivateIPValidator{}
 	default:
-		if khttp.DefaultValidator, err = khttp.ParseCIDRsString(options.BlackListCIDRS); err != nil {
+		if khttp.DefaultValidator, err = khttp.ParseCIDRsString(options.DenyListCIDRS); err != nil {
 			return fmt.Errorf("flag error: improper CIDRs: %s", err)
 		}
 	}
@@ -211,7 +211,7 @@ func (cmd *Command) ParseFlags(args ...string) (Options, error) {
 	fs.StringVar(&options.MemProfile, "memprofile", "", "")
 	fs.StringVar(&options.LogFile, "log-file", "", "")
 	fs.StringVar(&options.LogLevel, "log-level", "", "")
-	fs.StringVar(&options.BlackListCIDRS, "blacklist-cidrs", "", "")
+	fs.StringVar(&options.DenyListCIDRS, "denylist-cidrs", "", "")
 	fs.StringVar(&options.DisabledAlertHandlers, "disable-handlers", "", "")
 	fs.Usage = func() { fmt.Fprintln(cmd.Stderr, usage) }
 	if err := fs.Parse(args); err != nil {
@@ -263,8 +263,8 @@ func (cmd *Command) ParseConfig(path string) (*server.Config, error) {
 var usage = `usage: run [flags]
 
 run starts the Kapacitor server.
-        -blacklist-cidrs <CIDR1,CIDR2,...>
-                           Comma seperated list of CIDRs to blacklist for
+        -denylist-cidrs <CIDR1,CIDR2,...>
+                           Comma seperated list of CIDRs to denylist for
                            most http get/post operations
 
         -config <path>
@@ -300,5 +300,5 @@ type Options struct {
 	LogFile               string
 	LogLevel              string
 	DisabledAlertHandlers string
-	BlackListCIDRS        string
+	DenyListCIDRS         string
 }

--- a/http/transport.go
+++ b/http/transport.go
@@ -110,7 +110,7 @@ func (v cidrValidator) Validate(u *url.URL) error {
 func (v cidrValidator) ValidateIP(ip net.IP) error {
 	for i := range v.cidrs {
 		if v.cidrs[i].Contains(ip) {
-			return fmt.Errorf("ip '%s' is denylisted", ip)
+			return fmt.Errorf("ip '%s' is on deny list", ip)
 		}
 	}
 	return nil

--- a/http/transport.go
+++ b/http/transport.go
@@ -110,7 +110,7 @@ func (v cidrValidator) Validate(u *url.URL) error {
 func (v cidrValidator) ValidateIP(ip net.IP) error {
 	for i := range v.cidrs {
 		if v.cidrs[i].Contains(ip) {
-			return fmt.Errorf("ip '%s' is blacklisted", ip)
+			return fmt.Errorf("ip '%s' is denylisted", ip)
 		}
 	}
 	return nil

--- a/services/scraper/config.go
+++ b/services/scraper/config.go
@@ -57,8 +57,8 @@ type Config struct {
 	// DiscoverService is the type of the discoverer that generates hosts for the scraper
 	DiscoverService string `toml:"discoverer-service" override:"discoverer-service"`
 
-	// Blacklist is a list of hosts to ignore and not scrape
-	Blacklist []string `toml:"blacklist" override:"blacklist"`
+	// Denylist is a list of hosts to ignore and not scrape
+	Denylist []string `toml:"denylist" override:"denylist"`
 }
 
 // Init adds default values to Config scraper

--- a/services/scraper/service.go
+++ b/services/scraper/service.go
@@ -208,11 +208,11 @@ func (s *Service) Append(_ uint64, labels labels.Labels, timestamp int64, value 
 		tags[string(kv.Name)] = string(kv.Value)
 	}
 
-	// If instance is blacklisted then do not send to PointsWriter
+	// If instance is denylisted then do not send to PointsWriter
 	if instance, ok := tags["instance"]; ok {
 		for _, c := range s.loadConfigs() {
 			if c.Name == job {
-				for _, listed := range c.Blacklist {
+				for _, listed := range c.Denylist {
 					if instance == listed {
 						return 0, nil
 					}


### PR DESCRIPTION
Rename blocked CIDR ranges with more accurate descriptor.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass