### PR TITLE
feat(topics): make topic queue length configurable

### DIFF
--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -13865,7 +13865,7 @@ func createTaskMaster(name string) (*kapacitor.TaskMaster, error) {
 	tm.TaskStore = taskStore{}
 	tm.DeadmanService = deadman{}
 	tm.HTTPPostService, _ = httppost.NewService(nil, diagService.NewHTTPPostHandler())
-	as := alertservice.NewService(diagService.NewAlertServiceHandler(), nil)
+	as := alertservice.NewService(diagService.NewAlertServiceHandler(), nil, 0)
 	as.StorageService = storagetest.New()
 	as.HTTPDService = httpdService
 	if err := as.Open(); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -404,7 +404,7 @@ func (s *Server) appendConfigOverrideService() {
 
 func (s *Server) initAlertService() {
 	d := s.DiagService.NewAlertServiceHandler()
-	srv := alert.NewService(d, s.DisabledHandlers)
+	srv := alert.NewService(d, s.DisabledHandlers, s.config.Alert.TopicBufferLength)
 
 	srv.Commander = s.Commander
 	srv.HTTPDService = s.HTTPDService

--- a/services/alert/config.go
+++ b/services/alert/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/toml"
+	"github.com/influxdata/kapacitor/alert"
 )
 
 const (
@@ -12,12 +13,14 @@ const (
 
 type Config struct {
 	// Whether we persist the alert topics to BoltDB or not
-	PersistTopics bool `toml:"persist-topics"`
+	PersistTopics     bool `toml:"persist-topics"`
+	TopicBufferLength int  `toml:"topic-buffer-length"`
 }
 
 func NewConfig() Config {
 	return Config{
-		PersistTopics: true,
+		PersistTopics:     true,
+		TopicBufferLength: alert.DefaultEventBufferSize,
 	}
 }
 

--- a/services/alert/service.go
+++ b/services/alert/service.go
@@ -154,12 +154,12 @@ type Service struct {
 	}
 }
 
-func NewService(d Diagnostic, disabled map[string]struct{}) *Service {
+func NewService(d Diagnostic, disabled map[string]struct{}, topicBufLen int) *Service {
 	s := &Service{
 		disabled:        disabled,
 		handlers:        make(map[string]map[string]handler),
 		closedTopics:    make(map[string]bool),
-		topics:          alert.NewTopics(),
+		topics:          alert.NewTopics(topicBufLen),
 		diag:            d,
 		inhibitorLookup: alert.NewInhibitorLookup(),
 	}


### PR DESCRIPTION
This is a tuning param to make the topic queue length configurable.  This is useful if very large amounts of alerts must go off due to scheduled maintenance etc such as a windows update.