### PR TITLE
fix(security): update go to 1.18.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
       # then update the version here to match. Until we finish the migration to using the cross-builder image,
       # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
-      - image: quay.io/influxdb/cross-builder:go1.18.3-c75d304717395a43913dcc3d576d4f3545375253
+      - image: quay.io/influxdb/cross-builder:go1.18.4-906fbe93f953b47185818364a186604209dc8da0
     resource_class: large
   linux-amd64:
     machine:

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,5 +1,5 @@
 ARG GO_VERSION
-FROM quay.io/influxdb/cross-builder:go${GO_VERSION}-19532d83ff625362c07ca99eee6ea2e1d6bdc22e
+FROM quay.io/influxdb/cross-builder:go${GO_VERSION}-906fbe93f953b47185818364a186604209dc8da0
 
 # This dockerfile is capabable of performing all
 # build/test/package/deploy actions needed for Kapacitor.


### PR DESCRIPTION
This fixes the following CVEs in go
CVE-2022-1705: net/http: improper sanitization of Transfer-Encoding header (medium)
CVE-2022-1962: go/parser: stack exhaustion in all Parse* functions (negligible)
CVE-2022-28131: encoding/xml: stack exhaustion in Decoder.Skip (medium)
CVE-2022-30630: io/fs: stack exhaustion in Glob (medium)
CVE-2022-30631: compress/gzip: stack exhaustion in Reader.Read (medium)
CVE-2022-30632: path/filepath: stack exhaustion in Glob (medium)
CVE-2022-30633: encoding/xml: stack exhaustion in Unmarshal (medium)
CVE-2022-30635: encoding/gob: stack exhaustion in Decoder.Decode (medium)
CVE-2022-32148: When httputil.ReverseProxy.ServeHTTP was called with a Request.Header map (low)
