### PR TITLE
fix(security): update go to 1.18.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
       # then update the version here to match. Until we finish the migration to using the cross-builder image,
       # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
-      - image: quay.io/influxdb/cross-builder:go1.18.4-906fbe93f953b47185818364a186604209dc8da0
+      - image: quay.io/influxdb/cross-builder:go1.18.6-9c97f2f2903566a00bd4b00184aeca0c813adda0
     resource_class: large
   linux-amd64:
     machine:

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,5 +1,5 @@
 ARG GO_VERSION
-FROM quay.io/influxdb/cross-builder:go${GO_VERSION}-906fbe93f953b47185818364a186604209dc8da0
+FROM quay.io/influxdb/cross-builder:go${GO_VERSION}-9c97f2f2903566a00bd4b00184aeca0c813adda0
 
 # This dockerfile is capabable of performing all
 # build/test/package/deploy actions needed for Kapacitor.


### PR DESCRIPTION
This fixes the following CVEs in go:
* CVE-2022-32189 - encoding/gob & math/big: decoding big.Float and big.Rat can panic
* CVE-2022-27664 - net/http: handle server errors after sending GOAWAY
* CVE-2022-32190 - net/url: JoinPath does not strip relative path components in all circumstances