### PR TITLE
chore: update go to 1.19.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
       # then update the version here to match. Until we finish the migration to using the cross-builder image,
       # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
-      - image: quay.io/influxdb/cross-builder:go1.19.1-03d04e1256c3462db5323714d84dcffc0ae899b0
+      - image: quay.io/influxdb/cross-builder:go1.19.2-f2a580ca8029f26f2c8a2002d6851967808bf96d
     resource_class: large
   linux-amd64:
     machine:

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,4 +1,4 @@
-FROM quay.io/influxdb/cross-builder:go1.19.1-03d04e1256c3462db5323714d84dcffc0ae899b0
+FROM quay.io/influxdb/cross-builder:go1.19.2-f2a580ca8029f26f2c8a2002d6851967808bf96d
 
 # This dockerfile is capabable of performing all
 # build/test/package/deploy actions needed for Kapacitor.


### PR DESCRIPTION
Go 1.18.7 and 1.19.2 were released which fixes:
* CVE-2022-2879 - archive/tar: unbounded memory consumption when reading headers
* CVE-2022-2880 - net/http/httputil: ReverseProxy should not forward unparseable query parameters
* CVE-2022-41715 - regexp/syntax: limit memory used by parsing regexps.

None of these seem to actually affect kapacitor and so this PR isn't security relevant, but it would be nice to get it on the latest Go before the next kapacitor release.