### PR TITLE
chore: update go.mongodb.org/mongo-driver to 1.5.1 for dependabot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -220,7 +220,7 @@ require (
 	github.com/xdg/stringprep v1.0.0 // indirect
 	github.com/xlab/treeprint v1.0.0 // indirect
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 // indirect
-	go.mongodb.org/mongo-driver v1.4.6 // indirect
+	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1312,7 +1312,9 @@ github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPyS
 github.com/willf/bitset v1.1.9 h1:GBtFynGY9ZWZmEC9sWuu41/7VBXPFCOAbCbqTflOg9c=
 github.com/willf/bitset v1.1.9/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
+github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
+github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -1326,6 +1328,7 @@ github.com/xlab/treeprint v1.0.0/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cim
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
+github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
@@ -1350,8 +1353,9 @@ go.mongodb.org/mongo-driver v1.3.0/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.4.3/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.mongodb.org/mongo-driver v1.4.4/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
-go.mongodb.org/mongo-driver v1.4.6 h1:rh7GdYmDrb8AQSkF8yteAus8qYOgOASWDOv1BWqBXkU=
 go.mongodb.org/mongo-driver v1.4.6/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
+go.mongodb.org/mongo-driver v1.5.1 h1:9nOVLGDfOaZ9R0tBumx/BcuqkbFpyTCU2r/Po7A2azI=
+go.mongodb.org/mongo-driver v1.5.1/go.mod h1:gRXCHX4Jo7J0IJ1oDQyUxF7jfy19UfxniMS4xxMmUqw=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -1414,6 +1418,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Performed:

```
$ go mod edit -require go.mongodb.org/mongo-driver@v1.5.1
$ go mod tidy
$ go test ./...
```

Note, `go test ./...` initially failed locally with:
```
--- FAIL: TestServer_UDFStreamAgents (0.66s)
    server_test.go:5509: open service *udf.Service: failed to load process info for "movingAvg": exec: "python": executable file not found in $PATH
2022/11/21 11:08:32 Server listening on /tmp/TestServer_UDFStreamAgentsSocket84497654/001/mirror.go.sock
2022/11/21 11:08:32 Starting agent for connection 0
2022/11/21 11:08:32 Agent for connection 0 finished
2022/11/21 11:08:32 Starting agent for connection 1
2022/11/21 11:08:32 Agent for connection 1 finished
2022/11/21 11:14:45 Server stopped
--- FAIL: TestServer_UDFStreamAgents (0.66s)
    server_test.go:5509: open service *udf.Service: failed to load process info for "movingAvg": exec: "python": executable file not found in $PATH
2022/11/21 11:08:32 Server listening on /tmp/TestServer_UDFStreamAgentsSocket84497654/001/mirror.go.sock
2022/11/21 11:08:32 Starting agent for connection 0
2022/11/21 11:08:32 Agent for connection 0 finished
2022/11/21 11:08:32 Starting agent for connection 1
2022/11/21 11:08:32 Agent for connection 1 finished
2022/11/21 11:14:45 Server stopped
--- FAIL: TestServer_UDFStreamAgentsSocket (373.49s)
    server_test.go:5708: open service *udf.Service: failed to load process info for "mirror": dial unix /tmp/TestServer_UDFStreamAgentsSocket84497654/001/mirror.py.sock: connect: no such file or directory
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x80c059]

goroutine 9127 [running]:
testing.tRunner.func1.2({0x36935a0, 0x6774720})
	/snap/go/9994/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
	/snap/go/9994/src/testing/testing.go:1399 +0x39f
panic({0x36935a0, 0x6774720})
	/snap/go/9994/src/runtime/panic.go:884 +0x212
os.(*Process).signal(0xc00056d5c0?, {0x43485b0?, 0x67a82c0?})
	/snap/go/9994/src/os/exec_unix.go:63 +0x39
os.(*Process).Signal(0x790960?, {0x43485b0?, 0x67a82c0?})
	/snap/go/9994/src/os/exec.go:138 +0x25
runtime.Goexit()
	/snap/go/9994/src/runtime/panic.go:540 +0x1c9
testing.(*common).FailNow(0xc0023304e0)
	/snap/go/9994/src/testing/testing.go:871 +0x4c
testing.(*common).Fatal(0xc0023304e0, {0xc00056d8b0?, 0x3cc8f17?, 0x3?})
	/snap/go/9994/src/testing/testing.go:948 +0x58
github.com/influxdata/kapacitor/server_test.testStreamAgentSocket(0xc0023304e0, 0xc002d3e2a0?)
	/home/ubuntu/code/kapacitor/server/server_test.go:5708 +0xa5
github.com/influxdata/kapacitor/server_test.TestServer_UDFStreamAgentsSocket(0xc0023304e0)
	/home/ubuntu/code/kapacitor/server/server_test.go:5700 +0x554
testing.tRunner(0xc0023304e0, 0x3e6ac60)
	/snap/go/9994/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
	/snap/go/9994/src/testing/testing.go:1493 +0x35f
FAIL	github.com/influxdata/kapacitor/server	388.339s
```

This was in an Ubuntu 20.04 system container. After fiddling with the symlink for `/usr/bin/python` I then found I needed `protobuf` for python. I then tried to use a `virtualenv` and then without `virtualenv` and installing into the user's site-packages, but the way that the go testsuite was invoking python made this not work. There might be a way to make this work still (eg, installing into /usr/local like circleci does, but ultimately, this isn't a huge concern since `.circleci/config.yaml` sets it up so `protobuf` can be imported.