### PR TITLE
fix: make WritePointsPrivileged call WritePoints

### DIFF
--- a/task_master.go
+++ b/task_master.go
@@ -270,7 +270,7 @@ type TaskMaster struct {
 }
 
 func (tm *TaskMaster) WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel imodels.ConsistencyLevel, points []imodels.Point) error {
-	panic("not implemented") // we shouldn't need this.
+	return tm.WritePoints(database, retentionPolicy, consistencyLevel, points)
 }
 
 type forkKey struct {


### PR DESCRIPTION
The TaskMaster type has to implement WritePointsPrivileged instead of WritePoints because of the Influxdb reference update in go.mod from 1.8.4 to 1.9.6

closes https://github.com/influxdata/kapacitor/issues/2735