### PR TITLE
chore: build testing tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,7 @@ release_filter: &release_filter
   filters:
     tags:
       only:
+        - /.*test/
         - /^v[0-9]+(\.[0-9]+){2}(-(rc|beta)[0-9]+)?/
     branches:
       ignore:  /.*/


### PR DESCRIPTION
This executes the "release" workflow when a tag ending in "test" is pushed. I pushed "BNP_taskstore-1-test" and it generated these: https://app.circleci.com/pipelines/github/influxdata/kapacitor/1622/workflows/c1ba3aef-b77d-48c6-85e2-d7e4910f212b/jobs/6981/artifacts