### PR TITLE
fix: HttpPost AlertTemplateFile and RowTemplateFile work with either …

### DIFF
--- a/services/httppost/config.go
+++ b/services/httppost/config.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -70,7 +70,7 @@ func (c Config) Validate() error {
 		return errors.New("must specify only one of alert-template and alert-template-file")
 	}
 
-	if c.AlertTemplateFile != "" && !path.IsAbs(c.AlertTemplateFile) {
+	if c.AlertTemplateFile != "" && !filepath.IsAbs(c.AlertTemplateFile) {
 		return errors.New("must use an absolute path for alert-template-file")
 	}
 
@@ -78,7 +78,7 @@ func (c Config) Validate() error {
 		return errors.New("must specify only one of row-template and row-template-file")
 	}
 
-	if c.RowTemplateFile != "" && !path.IsAbs(c.RowTemplateFile) {
+	if c.RowTemplateFile != "" && !filepath.IsAbs(c.RowTemplateFile) {
 		return errors.New("must use an absolute path for row-template-file")
 	}
 

--- a/services/httppost/config_test.go
+++ b/services/httppost/config_test.go
@@ -1,0 +1,71 @@
+//go:build !windows
+
+package httppost
+
+import (
+	"testing"
+)
+
+func Test_Validate_ShouldNotReturnError_WhenAlertTemplateFileIsUnixLikePath(t *testing.T) {
+	testCases := []struct {
+		config Config
+		err    error
+	}{
+		{
+			config: Config{
+				Endpoint:          "test",
+				URLTemplate:       "http://localhost:8080/alert",
+				AlertTemplateFile: "/etc/kapacitor/templates/alert_template.json",
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		validationErr := tc.config.Validate()
+
+		if validationErr != nil {
+			if tc.err == nil {
+				t.Errorf("unexpected error: got %v", validationErr)
+			} else if tc.err.Error() != validationErr.Error() {
+				t.Errorf("unexpected error message: got %q exp %q", validationErr.Error(), tc.err.Error())
+			}
+		} else {
+			if tc.err != nil {
+				t.Errorf("expected error: %q got nil", tc.err.Error())
+			}
+		}
+	}
+}
+
+func Test_Validate_ShouldNotReturnError_WhenRowTemplateFileIsUnixLikePath(t *testing.T) {
+	testCases := []struct {
+		config Config
+		err    error
+	}{
+		{
+			config: Config{
+				Endpoint:        "test",
+				URLTemplate:     "http://localhost:8080/alert",
+				RowTemplateFile: "/etc/kapacitor/templates/row_template.json",
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		validationErr := tc.config.Validate()
+
+		if validationErr != nil {
+			if tc.err == nil {
+				t.Errorf("unexpected error: got %v", validationErr)
+			} else if tc.err.Error() != validationErr.Error() {
+				t.Errorf("unexpected error message: got %q exp %q", validationErr.Error(), tc.err.Error())
+			}
+		} else {
+			if tc.err != nil {
+				t.Errorf("expected error: %q got nil", tc.err.Error())
+			}
+		}
+	}
+}

--- a/services/httppost/config_windows_test.go
+++ b/services/httppost/config_windows_test.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package httppost
+
+import (
+	"testing"
+)
+
+func Test_Validate_ShouldNotReturnError_WhenAlertTemplateFileIsWindowsLikePath(t *testing.T) {
+	testCases := []struct {
+		config Config
+		err    error
+	}{
+		{
+			config: Config{
+				Endpoint:          "test",
+				URLTemplate:       "http://localhost:8080/alert",
+				AlertTemplateFile: "C:\\InfluxData\\kapacitor\\templates\\alert_template.json",
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		validationErr := tc.config.Validate()
+
+		if validationErr != nil {
+			if tc.err == nil {
+				t.Errorf("unexpected error: got %v", validationErr)
+			} else if tc.err.Error() != validationErr.Error() {
+				t.Errorf("unexpected error message: got %q exp %q", validationErr.Error(), tc.err.Error())
+			}
+		} else {
+			if tc.err != nil {
+				t.Errorf("expected error: %q got nil", tc.err.Error())
+			}
+		}
+	}
+}
+
+func Test_Validate_ShouldNotReturnError_WhenRowTemplateFileIsWindowsLikePath(t *testing.T) {
+	testCases := []struct {
+		config Config
+		err    error
+	}{
+		{
+			config: Config{
+				Endpoint:        "test",
+				URLTemplate:     "http://localhost:8080/alert",
+				RowTemplateFile: "C:\\InfluxData\\kapacitor\\templates\\row_template.json",
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		validationErr := tc.config.Validate()
+
+		if validationErr != nil {
+			if tc.err == nil {
+				t.Errorf("unexpected error: got %v", validationErr)
+			} else if tc.err.Error() != validationErr.Error() {
+				t.Errorf("unexpected error message: got %q exp %q", validationErr.Error(), tc.err.Error())
+			}
+		} else {
+			if tc.err != nil {
+				t.Errorf("expected error: %q got nil", tc.err.Error())
+			}
+		}
+	}
+}


### PR DESCRIPTION
…unix- or windows-like paths

### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
As stated on the docs of the package path (https://pkg.go.dev/path), at the overview section, path package does not deal with backslashes and drive letters. Instead, one should use the filepath package (https://pkg.go.dev/path/filepath) to handle operating system specific path separators.

### Context
With this change, windows users will be able to run Kapacitor using either the alert template file or the row template file of the httppost service, without getting the error "must use an absolute path for alert-template-file".

### Affected areas (if applicable):
N/A

### Severity (optional)
upgrade at your leasure

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
