### PR TITLE
Fix Stop Index Check in strSubstring Function for Accurate Substring Extraction! ( Update functions.go )

### DIFF
--- a/tick/stateful/functions.go
+++ b/tick/stateful/functions.go
@@ -726,7 +726,7 @@ func (m strSubstring) Call(args ...interface{}) (v interface{}, err error) {
 		return nil, fmt.Errorf("stop index too large for string in strSubstring: %d", stop)
 	}
 
-	v = str[start:stop]
+	v = str[start:stop + 1]
 	return
 }
 


### PR DESCRIPTION
**Issue Description:**
The current `strSubstring` function has a potential issue with the stop index check. The condition `if stop >= len(str)` may result in undesired behavior, especially when attempting to include the last character in the substring. Since the slicing operation `v = str[start : stop+1]` is left-closed and right-open, the character at the `stop` index is excluded.

**Proposed Solution:**
To address this, it is suggested to modify the condition to `if stop > len(str) || stop < 0` for a more accurate check on invalid stop indices. Additionally, the error message should be updated to reflect this change:

```go
if stop > len(str) || stop < 0 {
    return nil, fmt.Errorf("invalid stop index for string in strSubstring: %d", stop)
}
v = str[start : stop+1]
```

This modification ensures correct substring extraction, even when attempting to include the character at the stop index.

### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
1-3 sentences describing the PR (or link to well written issue)

### Context
Why was this added? What value does it add? What are risks/best practices?

### Affected areas (if applicable):
List of user-visible changes. As a user, what would I need to see in docs?
Examples:
CLI commands, subcommands, and flags
API changes
Configuration (sample config blocks)

### Severity (optional)
 i.e., ("recommend to upgrade immediately", "upgrade at your leasure", etc.)

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
