### PR TITLE
build(ci): use compatible dependencies with Ruby v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ executors:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
       # then update the version here to match. Until we finish the migration to using the cross-builder image,
       # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
+      #
+      # NOTE 2: Remove `gem install dotenv -v 2.8.1` from the `install_dependencies` step once
+      # the cross-builder supports Ruby v3.
       - image: quay.io/influxdb/cross-builder:go1.20.13-latest
     resource_class: large
   linux-amd64:
@@ -44,6 +47,7 @@ commands:
                 libtool
 
             # Ruby dependencies
+            gem install dotenv -v 2.8.1
             gem install fpm
 
             # Protobuf


### PR DESCRIPTION
### Required checklist
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Install `dotenv` gem dependency with locked at version `2.8.1` .

### Context
To fix CI build:

https://app.circleci.com/pipelines/github/influxdata/kapacitor/2132/workflows/2422dbee-a1cb-48e7-8605-abf3969d5bb2/jobs/8577

![image](https://github.com/influxdata/kapacitor/assets/455137/b989d961-ac33-42f9-ae3b-f2d2fae3a785)

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
