### PR TITLE
chore: tweak wording and don't reference gpg key in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Reporting a Vulnerability
 
-InfluxData takes security and our users' trust very seriously. If you believe
-you have found a security issue in any of our open source projects, please
+InfluxData takes security and our users' trust seriously. If you believe you
+have found a security issue in any of our open source projects, please
 responsibly disclose it by contacting `security@influxdata.com`. More details
-about security vulnerability reporting, including our GPG key, can be found
-on the [InfluxData How to Report Vulnerabilities page][InfluxData Security].
+about security vulnerability reporting can be found on the
+[InfluxData How to Report Vulnerabilities page][InfluxData Security].
 
 [InfluxData Security]: https://www.influxdata.com/how-to-report-security-vulnerabilities/


### PR DESCRIPTION
We don't require nor publish the GPG key for reporting security issues any more.