### PR TITLE
fix(ci): use debian image for `aws` commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
       release_type:
         type: string
     docker:
-      - image: ubuntu:latest
+      - image: debian:latest
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -182,7 +182,7 @@ jobs:
       release_type:
         type: string
     docker:
-      - image: ubuntu:latest
+      - image: debian:latest
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
This PR addresses issues in the CI steps that utilize the `aws` command. The `ubuntu:latest` image does not include `awscli` in its default repositories, necessitating a switch to the `debian:latest` image for these operations.

This approach aligns with strategies used in other projects, such as `influxctl`. For reference, see how `influxctl` configures its CI environment: [influxctl CI configuration](https://github.com/influxdata/influxctl/blob/6121cedc1e19508ad2e2a6dfc00a69d3b0d48a2f/.circleci/config.yml#L160).


![image](https://github.com/influxdata/kapacitor/assets/455137/09bf8eca-5641-4da4-b16c-3405a3ce915c)


https://app.circleci.com/pipelines/github/influxdata/kapacitor/2295/workflows/ccd091f8-98b5-4ac1-a23b-73fb54717193/jobs/9093