### PR TITLE
fix: using UTC timezone for alert levels

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -1057,6 +1057,7 @@ func (a *alertState) BufferedBatch(b edge.BufferedBatchMessage) (edge.Message, e
 	if a.n.a.AllFlag || l == alert.OK {
 		t = begin.Time()
 	}
+	t = t.UTC()
 
 	a.addEvent(t, l)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3707,7 +3707,7 @@ func TestServer_BatchTask_Alert(t *testing.T) {
         .id('test-batch-alert')
         .message('{{ .ID }} got: {{ index .Fields "value" }}')
         .crit(lambda: "value" > 40.0)
-		.post('` + as.URL + `')
+        .post('` + as.URL + `')
 `
 
 	task, err := cli.CreateTask(client.CreateTaskOptions{
@@ -3793,6 +3793,9 @@ func TestServer_BatchTask_Alert(t *testing.T) {
 				_, err = cli.UpdateTask(task.Link, client.UpdateTaskOptions{
 					Status: client.Disabled,
 				})
+				if err != nil {
+					t.Fatal(err)
+				}
 				run = false
 			}
 		}

--- a/services/storage/storagetest/storage.go
+++ b/services/storage/storagetest/storage.go
@@ -3,7 +3,7 @@ package storagetest
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/influxdata/kapacitor/services/alert"
 	"github.com/influxdata/kapacitor/services/storage"
@@ -57,7 +57,7 @@ func (b BoltDB) Close() error {
 	if err != nil {
 		return err
 	}
-	return os.RemoveAll(path.Dir(dbPath))
+	return os.RemoveAll(filepath.Dir(dbPath))
 }
 
 func New(t CleanedTest, diagnostic storage.Diagnostic) *TestStore {


### PR DESCRIPTION
### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Forcing batch alert time timezone to UTC. Fixes #938 and  [EAR #5376](https://github.com/influxdata/EAR/issues/5376)
Stream alert also has the time in the UTC zone.

### Context


### Affected areas (if applicable):
The `.Time` variable printed as a string will always be in UTC.

### Severity (optional)


### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
