### PR TITLE
feat: Kafka SASL OAUTH token refreshing

### DIFF
--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -34,7 +34,7 @@ default-retention-policy = ""
   # Password for basic user authorization when using meta API. meta-username must also be set.
   # meta-password = "kapapass"
 
-  # Shared secret for JWT bearer token authentication when using meta API. 
+  # Shared secret for JWT bearer token authentication when using meta API.
   # If this is set, then the `meta-username` and `meta-password` settings are ignored.
   # This should match the `[meta] internal-shared-secret` setting on the meta nodes.
   # meta-internal-shared-secret = "MyVoiceIsMyPassport"
@@ -573,27 +573,46 @@ default-retention-policy = ""
   # Use SSL but skip chain & host verification
   insecure-skip-verify = false
   ## Optional SASL Config
-  # sasl_username = "kafka"
-  # sasl_password = "secret"
+  # sasl-username = "kafka"
+  # sasl-password = "secret"
+  ## Arbitrary key value string pairs to pass as a TOML table. For example:
+  # {logicalCluster = "cluster-042", poolId = "pool-027"}
+  # sasl-extensions = {}
   ## Optional SASL:
   ## one of: OAUTHBEARER, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, GSSAPI
   ## (defaults to PLAIN)
-  # sasl_mechanism = ""
+  # sasl-mechanism = ""
   ## used if sasl_mechanism is GSSAPI
-  # sasl_gssapi_service_name = ""
+  # sasl-gssapi-service-name = ""
   # ## One of: KRB5_USER_AUTH and KRB5_KEYTAB_AUTH
-  # sasl_gssapi_auth_type = "KRB5_USER_AUTH"
-  # sasl_gssapi_kerberos_config_path = "/"
-  # sasl_gssapi_realm = "realm"
-  # sasl_gssapi_key_tab_path = ""
-  # sasl_gssapi_disable_pafxfast = false
-  ## Access token used if sasl_mechanism is OAUTHBEARER
-  # sasl_access_token = ""
-  ## Arbitrary key value string pairs to pass as a TOML table. For example:
-  # {logicalCluster = "cluster-042", poolId = "pool-027"}
-  # sasl_extensions = {}
+  # sasl-gssapi-auth-type = "KRB5_USER_AUTH"
+  # sasl-gssapi-kerberos-config-path = "/"
+  # sasl-gssapi-realm = "realm"
+  # sasl-gssapi-key-tab-path = ""
+  # sasl-gssapi-disable-pafxfast = false
+  ## Options if sasl-mechanism is OAUTHBEARER
+  ## The service name to use when authenticating with SASL/OAUTH.
+  # ## One of: "" or custom, auth0, azuread
+  # sasl-oauth-service = ""
+  ## The client ID to use when authenticating with SASL/OAUTH.
+  # sasl-oauth-client-id = ""
+  ## The client secret to use when authenticating with SASL/OAUTH.
+  # sasl-oauth-client-secret = ""
+  ## The token URL to use when authenticating with SASL/OAUTH.
+  # sasl-oauth-token-url = ""
+  ## The expiry margin for the token.
+  # sasl-oauth-token-expiry-margin = "10s"
+  ## Optional scopes to use when authenticating with SASL/OAUTH.
+  # sasl-oauth-scopes = ""
+  ## Tenant ID for the AzureAD service.
+  # sasl-oauth-tenant-id = ""
+  ## The optional params for SASL/OAUTH. e.g. audience for AUTH0
+  # [kafka.sasl-oauth-parameters]
+  #   audience = ""
+  ## Static OAUTH token. Use this instead of other OAUTH params.
+  # sasl-access-token = ""
   ## SASL protocol version.  When connecting to Azure EventHub set to 0.
-  # sasl_version = 1
+  # sasl-version = 1
 
 [alerta]
   # Configure Alerta.

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -598,7 +598,7 @@ default-retention-policy = ""
   # sasl-oauth-client-id = ""
   ## The client secret to use when authenticating with SASL/OAUTH.
   # sasl-oauth-client-secret = ""
-  ## The token URL to use when authenticating with SASL/OAUTH.
+  ## The token URL to use when sasl-oauth-service is custom or auth0. Leave empty otherwise.
   # sasl-oauth-token-url = ""
   ## The expiry margin for the token.
   # sasl-oauth-token-expiry-margin = "10s"

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -600,14 +600,14 @@ default-retention-policy = ""
   # sasl-oauth-client-secret = ""
   ## The token URL to use when sasl-oauth-service is custom or auth0. Leave empty otherwise.
   # sasl-oauth-token-url = ""
-  ## The expiry margin for the token.
+  ## The margin for the token's expiration time.
   # sasl-oauth-token-expiry-margin = "10s"
   ## Optional scopes to use when authenticating with SASL/OAUTH.
   # sasl-oauth-scopes = ""
   ## Tenant ID for the AzureAD service.
   # sasl-oauth-tenant-id = ""
   ## The optional params for SASL/OAUTH. e.g. audience for AUTH0
-  # [kafka.sasl-oauth-parameters]
+  [kafka.sasl-oauth-parameters]
   #   audience = ""
   ## Static OAUTH token. Use this instead of other OAUTH params.
   # sasl-access-token = ""

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	cloud.google.com/go/bigquery v1.50.0 // indirect
 	cloud.google.com/go/bigtable v1.10.1 // indirect
 	cloud.google.com/go/compute v1.19.1 // indirect
-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	cloud.google.com/go/iam v0.13.0 // indirect
 	cloud.google.com/go/longrunning v0.4.1 // indirect
 	collectd.org v0.3.0 // indirect
@@ -242,7 +242,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/oauth2 v0.7.0 // indirect
+	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/term v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ cloud.google.com/go/compute v1.19.1 h1:am86mquDUgjGNWxiGn+5PGLbmgiWXlE/yNWpIpNvu
 cloud.google.com/go/compute v1.19.1/go.mod h1:6ylj3a05WF8leseCdIf77NK0g1ey+nj5IKd5/kvShxE=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 cloud.google.com/go/datacatalog v1.13.0 h1:4H5IJiyUE0X6ShQBqgFFZvGGcrwGVndTwUSLP4c52gw=
 cloud.google.com/go/datacatalog v1.13.0/go.mod h1:E4Rj9a5ZtAxcQJlEBTLgMTphfP11/lNaAshpoBgemX8=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
@@ -1623,6 +1625,8 @@ golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.7.0 h1:qe6s0zUXlPX80/dITx3440hWZ7GwMwgDDyrSGTPJG/g=
 golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4=
+golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/services/kafka/config.go
+++ b/services/kafka/config.go
@@ -83,8 +83,9 @@ type Closer interface {
 }
 
 type WriterConfig struct {
-	Closers []Closer
-	Config  *kafka.Config
+	// additional resource to close
+	Closer Closer
+	Config *kafka.Config
 }
 
 type WriteTarget struct {
@@ -147,7 +148,7 @@ func (c Config) writerConfig(target WriteTarget) (*WriterConfig, error) {
 	if o, err := c.SASLAuth.SetSASLConfig(cfg); err != nil {
 		return nil, err
 	} else {
-		return &WriterConfig{[]Closer{o}, cfg}, cfg.Validate()
+		return &WriterConfig{o, cfg}, cfg.Validate()
 	}
 }
 

--- a/services/kafka/config.go
+++ b/services/kafka/config.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	DefaultTimeout      = 10 * time.Second
-	DefaultBatchSize    = 100
-	DefaultBatchTimeout = 1 * time.Second
-	DefaultID           = "default"
+	DefaultTimeout               = 10 * time.Second
+	DefaultBatchSize             = 100
+	DefaultBatchTimeout          = 1 * time.Second
+	DefaultID                    = "default"
+	DefaultSASLOAUTHExpiryMargin = 10 * time.Second
 )
 
 type Config struct {
@@ -49,7 +50,7 @@ type Config struct {
 }
 
 func NewConfig() Config {
-	return Config{ID: DefaultID, SASLAuth: SASLAuth{SASLOAUTHExpiryMargin: 10 * time.Second}}
+	return Config{ID: DefaultID, SASLAuth: SASLAuth{SASLOAUTHExpiryMargin: DefaultSASLOAUTHExpiryMargin}}
 }
 
 func (c Config) Validate() error {

--- a/services/kafka/config.go
+++ b/services/kafka/config.go
@@ -49,7 +49,7 @@ type Config struct {
 }
 
 func NewConfig() Config {
-	return Config{ID: DefaultID}
+	return Config{ID: DefaultID, SASLAuth: SASLAuth{SASLOAUTHExpiryMargin: 1 * time.Second}}
 }
 
 func (c Config) Validate() error {

--- a/services/kafka/config.go
+++ b/services/kafka/config.go
@@ -49,7 +49,7 @@ type Config struct {
 }
 
 func NewConfig() Config {
-	return Config{ID: DefaultID, SASLAuth: SASLAuth{SASLOAUTHExpiryMargin: 1 * time.Second}}
+	return Config{ID: DefaultID, SASLAuth: SASLAuth{SASLOAUTHExpiryMargin: 10 * time.Second}}
 }
 
 func (c Config) Validate() error {
@@ -63,7 +63,7 @@ func (c Config) Validate() error {
 	if len(c.Brokers) == 0 {
 		return errors.New("no brokers specified, must provide at least one broker URL")
 	}
-	return nil
+	return c.SASLAuth.Validate()
 }
 
 func (c *Config) ApplyConditionalDefaults() {
@@ -84,7 +84,7 @@ type WriteTarget struct {
 	PartitionAlgorithm string
 }
 
-func (c Config) writerConfig(diagnostic Diagnostic, target WriteTarget) (*kafka.Config, error) {
+func (c Config) writerConfig(target WriteTarget) (*kafka.Config, error) {
 	cfg := kafka.NewConfig()
 
 	if target.Topic == "" {

--- a/services/kafka/sasl.go
+++ b/services/kafka/sasl.go
@@ -140,10 +140,10 @@ func (k *SASLAuth) SetSASLConfig(config *kafka.Config) error {
 			for k, v := range k.SASLOAUTHParams {
 				cfg.EndpointParams.Add(k, v)
 			}
-			ctx, _ := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(context.Background())
 			src := cfg.TokenSource(ctx)
 			source := oauth2.ReuseTokenSourceWithExpiry(nil, src, k.SASLOAUTHExpiryMargin)
-			config.Net.SASL.TokenProvider = NewRefreshingToken(source, k.SASLExtensions)
+			config.Net.SASL.TokenProvider = NewRefreshingToken(source, cancel, k.SASLExtensions)
 
 		case kafka.SASLTypeGSSAPI:
 			config.Net.SASL.GSSAPI.ServiceName = k.SASLGSSAPIServiceName

--- a/services/kafka/sasl.go
+++ b/services/kafka/sasl.go
@@ -188,10 +188,7 @@ func (k *SASLAuth) Equals(other *SASLAuth) bool {
 			return false
 		}
 	}
-	if k.SASLOAUTHExpiryMargin != other.SASLOAUTHExpiryMargin {
-		return false
-	}
-	return true
+	return k.SASLOAUTHExpiryMargin == other.SASLOAUTHExpiryMargin
 }
 
 func SASLVersion(kafkaVersion sarama.KafkaVersion, saslVersion *int) (int16, error) {

--- a/services/kafka/sasl.go
+++ b/services/kafka/sasl.go
@@ -3,10 +3,11 @@ package kafka
 import (
 	"context"
 	"errors"
-	"golang.org/x/oauth2/endpoints"
 	"net/url"
 	"strings"
 	"time"
+
+	"golang.org/x/oauth2/endpoints"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"

--- a/services/kafka/sasl.go
+++ b/services/kafka/sasl.go
@@ -1,9 +1,15 @@
 package kafka
 
 import (
+	"context"
 	"errors"
+	"net/url"
+	"time"
 
-	sarama "github.com/IBM/sarama"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+
+	"github.com/IBM/sarama"
 )
 
 type SASLAuth struct {
@@ -21,14 +27,28 @@ type SASLAuth struct {
 	SASLGSSAPIKeyTabPath         string `toml:"sasl-gssapi-key-tab-path" override:"sasl-gssapi-key-tab-path"`
 	SASLGSSAPIRealm              string `toml:"sasl-gssapi-realm" override:"sasl-gssapi-realm"`
 
-	// OAUTHBEARER config. experimental. undoubtedly this is not good enough.
+	// OAUTHBEARER config
+	SASLOAUTHService      string            `toml:"sasl-oauth-service" override:"sasl-oauth-service"`
+	SASLOAUTHClientID     string            `toml:"sasl-oauth-client-id" override:"sasl-oauth-client-id"`
+	SASLOAUTHClientSecret string            `toml:"sasl-oauth-client-secret" override:"sasl-oauth-client-secret"`
+	SASLOAUTHTokenURL     string            `toml:"sasl-oauth-token-url" override:"sasl-oauth-token-url"`
+	SASLOAUTHScopes       []string          `toml:"sasl-oauth-scopes" override:"sasl-oauth-scopes"`
+	SASLOAUTHParams       map[string]string `toml:"sasl-oauth-parameters" override:"sasl-oauth-parameters"`
+	SASLOAUTHExpiryMargin time.Duration     `toml:"sasl-oauth-token-expiry-margin" override:"sasl-oauth-token-expiry-margin"`
+	//Deprecated, not used
 	SASLAccessToken string `toml:"sasl-access-token" override:"sasl-access-token"`
+
+	source oauth2.TokenSource
+	cancel context.CancelFunc
 }
 
 // SetSASLConfig configures SASL for kafka (sarama)
 // We mutate instead of returning the appropriate struct, because sarama.NewConfig() already populates certain defaults
 // that we do not want to disrupt.
 func (k *SASLAuth) SetSASLConfig(config *sarama.Config) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	k.cancel = cancel
+
 	config.Net.SASL.User = k.SASLUsername
 	config.Net.SASL.Password = k.SASLPassword
 
@@ -45,6 +65,30 @@ func (k *SASLAuth) SetSASLConfig(config *sarama.Config) error {
 			}
 		case sarama.SASLTypeOAuth:
 			config.Net.SASL.TokenProvider = k // use self as token provider.
+			var endpoint oauth2.Endpoint
+			if k.SASLOAUTHService == "auth0" {
+				endpoint = oauth2.Endpoint{
+					TokenURL:  k.SASLOAUTHTokenURL,
+					AuthStyle: oauth2.AuthStyleInParams,
+				}
+			}
+			if k.SASLOAUTHExpiryMargin == 0 {
+				k.SASLOAUTHExpiryMargin = 1 * time.Second
+			}
+			cfg := &clientcredentials.Config{
+				ClientID:       k.SASLOAUTHClientID,
+				ClientSecret:   k.SASLOAUTHClientSecret,
+				TokenURL:       endpoint.TokenURL,
+				Scopes:         k.SASLOAUTHScopes,
+				AuthStyle:      endpoint.AuthStyle,
+				EndpointParams: url.Values{},
+			}
+			for k, v := range k.SASLOAUTHParams {
+				cfg.EndpointParams.Add(k, v)
+			}
+			src := cfg.TokenSource(ctx)
+			k.source = oauth2.ReuseTokenSourceWithExpiry(nil, src, time.Duration(k.SASLOAUTHExpiryMargin))
+
 		case sarama.SASLTypeGSSAPI:
 			config.Net.SASL.GSSAPI.ServiceName = k.SASLGSSAPIServiceName
 			config.Net.SASL.GSSAPI.AuthType = gssapiAuthType(k.SASLGSSAPIAuthType)
@@ -75,10 +119,79 @@ func (k *SASLAuth) SetSASLConfig(config *sarama.Config) error {
 
 // Token does nothing smart, it just grabs a hard-coded token from config.
 func (k *SASLAuth) Token() (*sarama.AccessToken, error) {
+	token, err := k.source.Token()
+	if err != nil {
+		return nil, err
+	}
 	return &sarama.AccessToken{
-		Token:      k.SASLAccessToken,
+		Token:      token.AccessToken,
 		Extensions: k.SASLExtensions,
 	}, nil
+}
+
+func (k *SASLAuth) Equals(other *SASLAuth) bool {
+	if k.SASLUsername != other.SASLUsername {
+		return false
+	}
+	if k.SASLPassword != other.SASLPassword {
+		return false
+	}
+	if k.SASLMechanism != other.SASLMechanism {
+		return false
+	}
+	if k.SASLVersion != other.SASLVersion {
+		return false
+	}
+	if k.SASLGSSAPIServiceName != other.SASLGSSAPIServiceName {
+		return false
+	}
+	if k.SASLGSSAPIAuthType != other.SASLGSSAPIAuthType {
+		return false
+	}
+	if k.SASLGSSAPIDisablePAFXFAST != other.SASLGSSAPIDisablePAFXFAST {
+		return false
+	}
+	if k.SASLGSSAPIKerberosConfigPath != other.SASLGSSAPIKerberosConfigPath {
+		return false
+	}
+	if k.SASLGSSAPIKeyTabPath != other.SASLGSSAPIKeyTabPath {
+		return false
+	}
+	if k.SASLGSSAPIRealm != other.SASLGSSAPIRealm {
+		return false
+	}
+	if k.SASLOAUTHService != other.SASLOAUTHService {
+		return false
+	}
+	if k.SASLOAUTHClientID != other.SASLOAUTHClientID {
+		return false
+	}
+	if k.SASLOAUTHClientSecret != other.SASLOAUTHClientSecret {
+		return false
+	}
+	if k.SASLOAUTHTokenURL != other.SASLOAUTHTokenURL {
+		return false
+	}
+	if len(k.SASLOAUTHScopes) != len(other.SASLOAUTHScopes) {
+		return false
+	}
+	for i, v := range k.SASLOAUTHScopes {
+		if v != other.SASLOAUTHScopes[i] {
+			return false
+		}
+	}
+	if len(k.SASLOAUTHParams) != len(other.SASLOAUTHParams) {
+		return false
+	}
+	for k, v := range k.SASLOAUTHParams {
+		if v != other.SASLOAUTHParams[k] {
+			return false
+		}
+	}
+	if k.SASLOAUTHExpiryMargin != other.SASLOAUTHExpiryMargin {
+		return false
+	}
+	return true
 }
 
 func SASLVersion(kafkaVersion sarama.KafkaVersion, saslVersion *int) (int16, error) {

--- a/services/kafka/sasl_test.go
+++ b/services/kafka/sasl_test.go
@@ -1,0 +1,94 @@
+package kafka
+
+import "testing"
+
+func TestSASLAuth_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		auth    SASLAuth
+		wantErr bool
+	}{
+		{
+			name:    "Ignore empty SASL mechanism",
+			auth:    SASLAuth{SASLMechanism: ""},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid SASL mechanism",
+			auth:    SASLAuth{SASLMechanism: "mech"},
+			wantErr: true,
+		},
+		{
+			name:    "Missing client ID",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "", SASLOAUTHClientSecret: "secret"},
+			wantErr: true,
+		},
+		{
+			name:    "Missing client secret",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: ""},
+			wantErr: true,
+		},
+		{
+			name:    "Invalid service",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "auth"},
+			wantErr: true,
+		},
+		{
+			name:    "Missing token url custom",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "custom", SASLOAUTHTokenURL: ""},
+			wantErr: true,
+		},
+		{
+			name:    "Missing token url empty (custom)",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "", SASLOAUTHTokenURL: ""},
+			wantErr: true,
+		},
+		{
+			name:    "Ok custom",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "custom", SASLOAUTHTokenURL: "url"},
+			wantErr: false,
+		},
+		{
+			name:    "Ok custom (empty)",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "", SASLOAUTHTokenURL: "url"},
+			wantErr: false,
+		},
+		{
+			name:    "Missing token url",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "auth0", SASLOAUTHTokenURL: ""},
+			wantErr: true,
+		},
+		{
+			name:    "Missing auth0 audience",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "auth0", SASLOAUTHTokenURL: "url"},
+			wantErr: true,
+		},
+		{
+			name:    "Ok auth0 ",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "auth0", SASLOAUTHTokenURL: "url", SASLOAUTHParams: map[string]string{"audience": "aud"}},
+			wantErr: false,
+		},
+		{
+			name:    "Azure OK",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "azuread", SASLOAUTHTenant: "tenant"},
+			wantErr: false,
+		},
+		{
+			name:    "Azure missing tenant",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "azuread"},
+			wantErr: true,
+		},
+		{
+			name:    "Azure Redundant token url",
+			auth:    SASLAuth{SASLMechanism: "OAUTHBEARER", SASLOAUTHClientID: "id", SASLOAUTHClientSecret: "secret", SASLOAUTHService: "azuread", SASLOAUTHTokenURL: "url"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.auth.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("SASLAuth.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/services/kafka/service.go
+++ b/services/kafka/service.go
@@ -86,7 +86,9 @@ func (w *writer) Close() {
 	close(w.done)
 	vars.DeleteStatistic(w.statsKey)
 	for _, c := range w.closers {
-		c.Close()
+		if c != nil {
+			c.Close()
+		}
 	}
 	err := w.kafka.Close()
 

--- a/services/kafka/service.go
+++ b/services/kafka/service.go
@@ -55,7 +55,7 @@ type writer struct {
 
 	done chan struct{}
 
-	closers []Closer
+	closer Closer
 }
 
 func (w *writer) Open() {
@@ -85,10 +85,8 @@ func (w *writer) Close() {
 
 	close(w.done)
 	vars.DeleteStatistic(w.statsKey)
-	for _, c := range w.closers {
-		if c != nil {
-			c.Close()
-		}
+	if w.closer != nil {
+		w.closer.Close()
 	}
 	err := w.kafka.Close()
 
@@ -186,7 +184,7 @@ func (c *Cluster) writer(target WriteTarget, diagnostic Diagnostic) (*writer, er
 				cluster:                c.cfg.ID,
 				topic:                  topic,
 				diagnostic:             diagnostic,
-				closers:                wc.Closers,
+				closer:                 wc.Closer,
 			}
 			w.Open()
 			c.writers[topic] = w

--- a/services/kafka/service.go
+++ b/services/kafka/service.go
@@ -220,7 +220,7 @@ func configChanged(old, new Config) bool {
 		old.SSLCA != new.SSLCA ||
 		old.SSLCert != new.SSLCert ||
 		old.SSLKey != new.SSLKey ||
-		!cmp.Equal(old.SASLAuth, new.SASLAuth)
+		!old.SASLAuth.Equals(&new.SASLAuth)
 }
 
 func (c *Cluster) clearWriters() {

--- a/services/kafka/service.go
+++ b/services/kafka/service.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"text/template"
+
+	"github.com/google/go-cmp/cmp"
 
 	kafka "github.com/IBM/sarama"
 	"github.com/influxdata/kapacitor/alert"

--- a/services/kafka/service.go
+++ b/services/kafka/service.go
@@ -4,20 +4,19 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"text/template"
 
-	"github.com/google/go-cmp/cmp"
-
 	kafka "github.com/IBM/sarama"
 	"github.com/influxdata/kapacitor/alert"
 	"github.com/influxdata/kapacitor/keyvalue"
 	"github.com/influxdata/kapacitor/server/vars"
 	"github.com/pkg/errors"
-	metrics "github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics"
 )
 
 const (
@@ -162,7 +161,7 @@ func (c *Cluster) writer(target WriteTarget, diagnostic Diagnostic) (*writer, er
 		defer c.mu.Unlock()
 		w, ok = c.writers[topic]
 		if !ok {
-			wc, err := c.cfg.writerConfig(diagnostic, target)
+			wc, err := c.cfg.writerConfig(target)
 			if err != nil {
 				return nil, err
 			}
@@ -220,7 +219,7 @@ func configChanged(old, new Config) bool {
 		old.SSLCA != new.SSLCA ||
 		old.SSLCert != new.SSLCert ||
 		old.SSLKey != new.SSLKey ||
-		!old.SASLAuth.Equals(&new.SASLAuth)
+		!cmp.Equal(old.SASLAuth, new.SASLAuth)
 }
 
 func (c *Cluster) clearWriters() {

--- a/services/kafka/token.go
+++ b/services/kafka/token.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+
 	"github.com/IBM/sarama"
 	"golang.org/x/oauth2"
 )

--- a/services/kafka/token.go
+++ b/services/kafka/token.go
@@ -3,7 +3,7 @@ package kafka
 import (
 	"context"
 
-	"github.com/IBM/sarama"
+	kafka "github.com/IBM/sarama"
 	"golang.org/x/oauth2"
 )
 
@@ -18,19 +18,20 @@ type StaticToken struct {
 	extensions map[string]string
 }
 
-func NewRefreshingToken(source oauth2.TokenSource, extensions map[string]string) *RefreshingToken {
+func NewRefreshingToken(source oauth2.TokenSource, cancel context.CancelFunc, extensions map[string]string) *RefreshingToken {
 	return &RefreshingToken{
 		source:     source,
+		cancel:     cancel,
 		extensions: extensions,
 	}
 }
 
-func (k *RefreshingToken) Token() (*sarama.AccessToken, error) {
+func (k *RefreshingToken) Token() (*kafka.AccessToken, error) {
 	token, err := k.source.Token()
 	if err != nil {
 		return nil, err
 	}
-	return &sarama.AccessToken{
+	return &kafka.AccessToken{
 		Token:      token.AccessToken,
 		Extensions: k.extensions,
 	}, nil
@@ -43,8 +44,8 @@ func NewStaticToken(token string, extensions map[string]string) *StaticToken {
 	}
 }
 
-func (k *StaticToken) Token() (*sarama.AccessToken, error) {
-	return &sarama.AccessToken{
+func (k *StaticToken) Token() (*kafka.AccessToken, error) {
+	return &kafka.AccessToken{
 		Token:      k.token,
 		Extensions: k.extensions,
 	}, nil

--- a/services/kafka/token.go
+++ b/services/kafka/token.go
@@ -1,0 +1,50 @@
+package kafka
+
+import (
+	"context"
+	"github.com/IBM/sarama"
+	"golang.org/x/oauth2"
+)
+
+type RefreshingToken struct {
+	source     oauth2.TokenSource
+	cancel     context.CancelFunc
+	extensions map[string]string
+}
+
+type StaticToken struct {
+	token      string
+	extensions map[string]string
+}
+
+func NewRefreshingToken(source oauth2.TokenSource, extensions map[string]string) *RefreshingToken {
+	return &RefreshingToken{
+		source:     source,
+		extensions: extensions,
+	}
+}
+
+func (k *RefreshingToken) Token() (*sarama.AccessToken, error) {
+	token, err := k.source.Token()
+	if err != nil {
+		return nil, err
+	}
+	return &sarama.AccessToken{
+		Token:      token.AccessToken,
+		Extensions: k.extensions,
+	}, nil
+}
+
+func NewStaticToken(token string, extensions map[string]string) *StaticToken {
+	return &StaticToken{
+		token:      token,
+		extensions: extensions,
+	}
+}
+
+func (k *StaticToken) Token() (*sarama.AccessToken, error) {
+	return &sarama.AccessToken{
+		Token:      k.token,
+		Extensions: k.extensions,
+	}, nil
+}

--- a/services/kafka/token.go
+++ b/services/kafka/token.go
@@ -37,6 +37,11 @@ func (k *RefreshingToken) Token() (*kafka.AccessToken, error) {
 	}, nil
 }
 
+func (k *RefreshingToken) Close() {
+	// canceling the token refresh
+	k.cancel()
+}
+
 func NewStaticToken(token string, extensions map[string]string) *StaticToken {
 	return &StaticToken{
 		token:      token,


### PR DESCRIPTION
### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Adding SASL OAUTH token refreshing for Kafka plugin. The same support as Telegraf has - custom, Auth0, AzureAD.

Kapacitor docs update PR: [#5617](https://github.com/influxdata/docs-v2/pull/5617)

New Kafka config params:
- sasl-oauth-service
- sasl-oauth-client-id
- sasl-oauth-client-secret
- sasl-oauth-token-url
- sasl-oauth-token-expiry-margin
- [kafka.sasl-oauth-parameters]
- sasl-oauth-tenant-id
- sasl-oauth-scopes

