### PR TITLE
fix: issue 2849 - add warnings of deprecation of Python 2 support

### DIFF
--- a/udf/agent/py/kapacitor/udf/agent.py
+++ b/udf/agent/py/kapacitor/udf/agent.py
@@ -18,12 +18,6 @@ except ImportError:
 defaultIn = sys.stdin
 defaultOut = sys.stdout
 
-# Check for python3
-# https://stackoverflow.com/a/38939320/703144
-if sys.version_info >= (3, 0):
-    defaultIn = sys.stdin.buffer
-    defaultOut = sys.stdout.buffer
-
 import io
 import traceback
 import socket
@@ -33,6 +27,24 @@ import struct
 import logging
 logger = logging.getLogger()
 
+# Check for python3
+# https://stackoverflow.com/a/38939320/703144
+if sys.version_info >= (3, 0):
+    logger.debug("[DEBUG] Python3 version %d.%d.%d detected.",
+                 sys.version_info.major,
+                 sys.version_info.minor,
+                 sys.version_info.minor)
+    defaultIn = sys.stdin.buffer
+    defaultOut = sys.stdout.buffer
+elif sys.version_info >= (2, 0):
+    logger.warning("[WARNING] DEPRECATED VERSION: Python2 version %d.%d.%d detected. "
+                   "Support for this version in user defined functions (UDF) is now deprecated "
+                   "and will be removed in a future release.",
+                   sys.version_info.major,
+                   sys.version_info.minor,
+                   sys.version_info.minor)
+else:
+    logger.error("[ERROR] Unsupported Python version %s detected", sys.version_info)
 
 # The Agent calls the appropriate methods on the Handler as requests are read off STDIN.
 #

--- a/udf/agent/py/kapacitor/udf/agent.py
+++ b/udf/agent/py/kapacitor/udf/agent.py
@@ -27,6 +27,7 @@ import struct
 import logging
 logger = logging.getLogger()
 
+is_python_2 = None
 # Check for python3
 # https://stackoverflow.com/a/38939320/703144
 if sys.version_info >= (3, 0):
@@ -37,6 +38,7 @@ if sys.version_info >= (3, 0):
     defaultIn = sys.stdin.buffer
     defaultOut = sys.stdout.buffer
 elif sys.version_info >= (2, 0):
+    is_python_2 = True
     logger.warning("[WARNING] DEPRECATED VERSION: Python2 version %d.%d.%d detected. "
                    "Support for this version in user defined functions (UDF) is now deprecated "
                    "and will be removed in a future release.",
@@ -80,6 +82,16 @@ class Handler(object):
 # The Agent requires a Handler object in order to fulfill requests.
 class Agent(object):
     def __init__(self, _in=defaultIn, out=defaultOut,handler=None):
+        if is_python_2:
+            import datetime
+            now_utc = datetime.datetime.utcnow()
+            lgr = logging.getLogger("DEPRECATION")
+            dpr_handler = logging.FileHandler("DEPRECATION_WARNING_PYTHON_2.txt")
+            lgr.addHandler(dpr_handler)
+            lgr.setLevel(logging.WARNING)
+            lgr.warning("[DEPRECATION WARNING] - %s - detected python2.  "
+                        "Python 2 support is now deprecated for UDFs and "
+                        "will be removed entirely in a future release.", now_utc)
         self._in = _in
         self._out = out
 


### PR DESCRIPTION
### Required checklist
- [na] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [na] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description

* In UDF service config
   * Detect whether UDF is using Python 2
   * If UDF is using Python 2 write warning to STDERR using temporary logger
* In UDF `agent.py`
   * Detect python version
   * If python major version is 2 
      * write warning to root logger
      * write additional warning on UDF Init to file `DEPRECATION_WARNING_PYTHON_2.txt`

Note that python UDFs make use of pipes created from STDOUT and STDIN so using these streams will likely pollute data and messages are not likely to be seen.  

### Context
The protobuf library used in generating code for UDFs has not supported Python 2 since the 3.17.3 release (8.6.2021).  Protobuf needs to be updated for reasons of security and stability, so Python 2 support will end.  

Adding deprecation warnings is the first step of this process.  

### Affected areas (if applicable):
APIs should continue to work as before. 

Documentation should be updated to alert users of end of life of Python 2 support.

### Severity (optional)
 i.e., ("recommend to upgrade immediately", "upgrade at your leasure", etc.)

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
