### PR TITLE
chore: upgrade reference go version to go1.22.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version:  "2.1"
 executors:
   cross-builder:
     docker:
-      - image: quay.io/influxdb/builder:kapacitor-20250204
+      - image: quay.io/influxdb/builder:kapacitor-20250520
     resource_class: large
 
 commands:

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,4 +1,4 @@
-FROM quay.io/influxdb/builder:kapacitor-20250204
+FROM quay.io/influxdb/builder:kapacitor-20250520
 
 # This dockerfile is capabable of performing all
 # build/test/package/deploy actions needed for Kapacitor.

--- a/builder/Dockerfile_build
+++ b/builder/Dockerfile_build
@@ -46,7 +46,7 @@ RUN gem install fpm
 # src: https://github.com/influxdata/chronograf/blob/9c4b1aa1a458ed86716985ed93783c35cc6411a7/etc/Dockerfile_build#L35
 #
 ENV GOPATH=/root/go
-ENV GO_VERSION=1.22.11
+ENV GO_VERSION=1.22.12
 ENV GO_ARCH=amd64
 ENV GO111MODULES=ON
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \


### PR DESCRIPTION
### Required checklist
- [n/a] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [n/a] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Upgrades reference go release to go1.22.12.  

### Context
It is best to keep product up to date with latest releases.  Since we cannot yet upgrade to go1.23 because of old protobuf dependencies in user defined functions (UDF), which might break customer implementations, at least we can upgrade to the latest release of go.12.12

### Affected areas (if applicable):
Affects primarily the build

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
