### PR TITLE
chore: upgrade golang-jwt to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    1. Internal build image reverted to `cross-builder`
    2. Reference GO version upgraded to 1.23.9
    3. Python based UDFs no longer automatically support Python2. This change is part of our effort to follow modern security best practices. Note that as a courtesy to some users legacy Python2 compatible UDF agent code has been moved to the directory `/udf/agent/py2`. Further details can be found in the `README.md` in that directory.
+2. [2855](https://github.com/influxdata/kapacitor/pull/2855): Upgrade go-lang JWT library to v4 v4.5.2
 
 ## v1.7.7 [2025-05-27]
 ----------------------

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/ghodss/yaml v1.0.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/btree v1.0.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -151,7 +151,6 @@ require (
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/influxdb/token_client.go
+++ b/influxdb/token_client.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/kapacitor/keyvalue"
 	"github.com/pkg/errors"

--- a/integrations/metaauth_test.go
+++ b/integrations/metaauth_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/h2non/gock"
 	"golang.org/x/crypto/bcrypt"
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/fluxinit"
 	iclient "github.com/influxdata/influxdb/client/v2"

--- a/services/auth/meta/client.go
+++ b/services/auth/meta/client.go
@@ -17,7 +17,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 const controlClientUA = "InfluxDB Cluster Client"

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/query"


### PR DESCRIPTION
### Required checklist
- [n/a] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ n/a] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Upgrades golang-jwt to use newer version v4.

### Context
Improves security by using a more up-to-date version of the library, in keeping with the `influxdb` project.  

### Affected areas (if applicable):
No user visible changes.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
