### PR TITLE
chore(CI): add "influxdata-archive-keyring" package

### DIFF
--- a/build.py
+++ b/build.py
@@ -705,7 +705,9 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                             package_build_root,
                             current_location)
                         if package_type == "rpm":
-                            fpm_command += "--depends coreutils --depends shadow-utils --rpm-posttrans {}".format(POSTINST_SCRIPT)
+                            fpm_command += "--depends coreutils --depends shadow-utils --rpm-posttrans {} --rpm-tag 'Recommends: influxdata-archive-keyring'".format(POSTINST_SCRIPT)
+                        if package_type == "deb":
+                            fpm_command += "--deb-recommends influxdata-archive-keyring"
                         out = run(fpm_command, shell=True)
                         matches = re.search(':path=>"(.*)"', out)
                         outfile = None


### PR DESCRIPTION
```sh
$ dpkg -I build/kapacitor_1.8.2~1e89774b-0_amd64.deb
 new Debian package, version 2.0.
 size 85263518 bytes: control archive=1836 bytes.
      57 bytes,     2 lines      conffiles
     318 bytes,    12 lines      control
     577 bytes,     9 lines      md5sums
    2136 bytes,    80 lines   *  postinst             #!/bin/bash
    2294 bytes,    84 lines   *  postrm               #!/bin/bash
     162 bytes,     7 lines   *  preinst              #!/bin/bash
 Package: kapacitor
 Version: 1.8.2~1e89774b-0
 License: MIT
 Vendor: InfluxData
 Architecture: amd64
 Maintainer: support@influxdb.com
 Installed-Size: 224734
 Recommends: influxdata-archive-keyring
 Section: default
 Priority: optional
 Homepage: github.com/influxdata/kapacitor
 Description: Time series data processing engine
```
```sh
$ rpm -q --recommends build/kapacitor-1.8.2~1e89774b-0.x86_64.rpm
influxdata-archive-keyring
```